### PR TITLE
Compress released binary with UPX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 
-sudo: false
+sudo: required
 
 os: linux
 go:

--- a/script/buildall
+++ b/script/buildall
@@ -12,5 +12,9 @@ for GOOS in linux darwin; do
 
 	echo "Building $NAME"
 	GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "$LDFLAGS" -o dist/${NAME}
+
+	echo "Compressing $NAME"
+	upx --no-progress dist/${NAME}
+
 	shasum -a 256 dist/${NAME} > dist/${NAME}.sha256
 done

--- a/script/setup-ci
+++ b/script/setup-ci
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -xe
 
 go get -u github.com/golang/dep/cmd/dep
 dep ensure
@@ -8,3 +8,5 @@ if [ "$1" == "test" ]; then
     go get -u gopkg.in/alecthomas/gometalinter.v2
     gometalinter.v2 --install --update
 fi
+
+sudo apt-get install upx


### PR DESCRIPTION
UPX is a tool to build auto-inflating executable. It usually divides Go binaries weight by 3.
The cost is the time it takes to inflate at each execution.

```
-rwxr-xr-x  1 pior  staff   6.3M 10 May 21:46 dad-darwin-amd64
-rwxr-xr-x  1 pior  staff   2.2M 10 May 21:46 dad-darwin-amd64.upx
```

```
$ time ./dad-darwin-amd64.upx --shell-hook
real	0m0.063s
user	0m0.053s
sys	0m0.008s
```
```
$ time ./dad-darwin-amd64 --shell-hook
real	0m0.011s
user	0m0.004s
sys	0m0.005s
```