### PR TITLE
Make use of stderr for debug and to print out stuff about hook system

### DIFF
--- a/pkg/termui/base.go
+++ b/pkg/termui/base.go
@@ -9,12 +9,13 @@ import (
 
 type baseUI struct {
 	out          *os.File
+	err          *os.File
 	debugEnabled bool
 }
 
 func (u *baseUI) Debug(format string, params ...interface{}) {
 	if u.debugEnabled {
 		msg := fmt.Sprintf(format, params...)
-		fmt.Fprintf(u.out, "BUD_DEBUG: %s\n", color.Gray(msg))
+		fmt.Fprintf(u.err, "BUD_DEBUG: %s\n", color.Gray(msg))
 	}
 }

--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -16,7 +16,8 @@ type HookUI struct {
 func NewHookUI(cfg *config.Config) *HookUI {
 	return &HookUI{
 		baseUI{
-			out:          os.Stderr,
+			out:          os.Stdout,
+			err:          os.Stderr,
 			debugEnabled: cfg.DebugEnabled,
 		},
 	}
@@ -25,11 +26,11 @@ func NewHookUI(cfg *config.Config) *HookUI {
 func (u *HookUI) HookFeatureActivated(name string, version string) {
 	msg := color.Sprintf("%s activated.", name)
 	ver := color.Sprintf("(version: %s)", version)
-	fmt.Fprintf(u.out, "🐼  %s %s\n", color.Cyan(msg), color.Blue(ver))
+	fmt.Fprintf(u.err, "🐼  %s %s\n", color.Cyan(msg), color.Blue(ver))
 }
 
 func (u *HookUI) HookFeatureFailure(name string, version string) {
 	msg := color.Sprintf("failed to activate %s. Try running 'bud up' first!", name)
 	ver := color.Sprintf("(version: %s)", version)
-	fmt.Fprintf(u.out, "🐼  %s %s\n", color.Red(msg), color.Brown(ver))
+	fmt.Fprintf(u.err, "🐼  %s %s\n", color.Red(msg), color.Brown(ver))
 }

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -18,13 +18,14 @@ func NewUI(cfg *config.Config) *UI {
 	return &UI{
 		baseUI{
 			out:          os.Stdout,
+			err:          os.Stderr,
 			debugEnabled: cfg.DebugEnabled,
 		},
 	}
 }
 
 func (u *UI) CommandHeader(cmdline string) {
-	fmt.Fprintf(os.Stderr, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
+	fmt.Fprintf(u.err, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
 }
 
 func (u *UI) CommandRun(cmdline string, args ...string) {


### PR DESCRIPTION
## Why

Limit the number of times we printing stuff to stdout


## How

1. Adds a new err file descriptor in `baseUI` 
2. Migrates some calls to Fprintf to use this new `err`fd


