### PR TITLE
Add --list flag to open command

### DIFF
--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/devbuddy/devbuddy/pkg/helpers/open"
@@ -14,6 +16,10 @@ var openCmd = &cobra.Command{
 	Args:  zeroOrOneArg,
 }
 
+func init() {
+	openCmd.Flags().Bool("list", false, "List available project's URLs")
+}
+
 func openRun(cmd *cobra.Command, args []string) {
 	linkName := ""
 	if len(args) == 1 {
@@ -22,6 +28,12 @@ func openRun(cmd *cobra.Command, args []string) {
 
 	proj, err := project.FindCurrent()
 	checkError(err)
+
+	if GetFlagBool(cmd, "list") {
+		err = open.PrintLinks(proj)
+		checkError(err)
+		os.Exit(0)
+	}
 
 	url, err := open.FindLink(proj, linkName)
 	checkError(err)

--- a/pkg/helpers/open/open.go
+++ b/pkg/helpers/open/open.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/devbuddy/devbuddy/pkg/helpers"
 	"github.com/devbuddy/devbuddy/pkg/project"
+
+	color "github.com/logrusorgru/aurora"
 )
 
 // Open a file or URL with the default application, return immediately.
@@ -50,4 +52,15 @@ func FindLink(proj *project.Project, linkName string) (url string, err error) {
 	}
 
 	return
+}
+
+func PrintLinks(proj *project.Project) (err error) {
+	if len(proj.Manifest.Open) == 0 {
+		return fmt.Errorf("no links found in the project")
+	}
+	for title, url := range proj.Manifest.Open {
+		fmt.Println(color.Green(title), "\t", url)
+	}
+
+	return nil
 }

--- a/pkg/helpers/open/open_test.go
+++ b/pkg/helpers/open/open_test.go
@@ -54,3 +54,17 @@ func TestFindLinkGithub(t *testing.T) {
 		require.Equal(t, expectedURL, url)
 	}
 }
+
+func TestPrintLinks(t *testing.T) {
+	open := map[string]string{}
+	proj := &project.Project{Manifest: &manifest.Manifest{Open: open}}
+
+	err := PrintLinks(proj)
+	require.Error(t, err)
+
+	open = map[string]string{"doc": "http://doc.com"}
+	proj = &project.Project{Manifest: &manifest.Manifest{Open: open}}
+
+	err = PrintLinks(proj)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Why

Add the `--list` flag support for the open command.

The `--list` command modifier lists in the standard output the entries found in the `open` section of `dev.yml` configuration file.

Resolves #111 

## How

Using Cobra local Flags primitive.

