### PR TITLE
Fix zsh shell integration

### DIFF
--- a/pkg/integration/zsh.go
+++ b/pkg/integration/zsh.go
@@ -1,7 +1,7 @@
 package integration
 
 var zshSource = `
-promptcmd() { $("__bud_prompt_command") }
+promptcmd() { $(__bud_prompt_command) }
 if [[ ! "${precmd_functions[@]}" == *__bud_prompt_command* ]]; then
   precmd_functions+=(promptcmd)
 fi


### PR DESCRIPTION
## Why

Turns out the shell hook didn't work as it was supposed



## How

In the subshell don't escape de string anymore


