### PR TITLE
Adds dev command for building

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -54,5 +54,9 @@ commands:
       [ -e "$GOPATH/bin/bud" ] && sudo rm -v $GOPATH/bin/bud
       bash -c "$(curl -sL https://raw.githubusercontent.com/devbuddy/devbuddy/master/install.sh)"
 
+  build:
+    desc: Build all bud binaries
+    run: script/buildall
+
 open:
   milestone: https://github.com/devbuddy/devbuddy/milestone/1


### PR DESCRIPTION
## Why

It's so much more convenient to have a command that build devbuddy directly from dev.yml

## How

Just adding it

