### PR TITLE
Enable ZSH integration tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: pyenv install 3.6.5 && pyenv global 3.6.5
       - run: pip install -U pip setuptools && pip install -r tests/requirements.txt
       - run: pytest --durations=1 -v tests
-      # - run: pytest --durations=1 --shell zsh -v tests
+      - run: pytest --durations=1 --shell zsh -v tests
 
   lint:
     docker:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def build_pexpect_zsh(workdir):
         'zsh', ['--no-globalrcs', '--no-rcs', '--no-zle', '--no-promptcr'],
         echo=False,
         encoding='utf-8',
-        env={'PROMPT': 'ps1'},
+        env={'PROMPT': 'ps1', 'PATH': os.getenv('PATH')},
         cwd=str(workdir),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,9 @@ class CommandTestHelper:
         return output
 
     def get_exit_code(self):
-        return int(self.run("echo $?"))
+        output = self.run("echo $?")
+        first_line = output.split('\n')[0]  # Ignore lines produced by prompt hook
+        return int(first_line)
 
     def assert_succeed(self):
         exit_code = self.get_exit_code()

--- a/tests/test_task_go.py
+++ b/tests/test_task_go.py
@@ -15,6 +15,7 @@ def test_env(cmd, project, gopath):
     """)
 
     cmd.run("bud up")
+    cmd.assert_succeed()
 
     output = cmd.run("go version")
     assert "go version go1.5" in output
@@ -29,4 +30,6 @@ def test_warn_gopath_missing(cmd, project, gopath):
     """)
 
     output = cmd.run("bud up")
+    cmd.assert_failed()
+
     assert "The GOPATH environment variable should be set" in output

--- a/tests/test_task_python.py
+++ b/tests/test_task_python.py
@@ -5,7 +5,8 @@ def test_task(cmd, project):
         - python: 3.6.5
     """)
 
-    cmd.run("bud up")
+    output = cmd.run("bud up")
+    cmd.assert_succeed()
 
     output = cmd.run("python --version")
     assert output == "Python 3.6.5"

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -21,12 +21,16 @@ def test_with_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=42))
 
     cmd.run("bud up")
+    cmd.assert_succeed()
+
     output = cmd.run("pip show devbuddy-test-pkg")
     assert "Version: 42" in output
 
     project.write_file("setup.py", make_setuppy(version=84))
 
     cmd.run("bud up")
+    cmd.assert_succeed()
+
     output = cmd.run("pip show devbuddy-test-pkg")
     assert "Version: 84" in output
 
@@ -43,9 +47,13 @@ def test_without_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=42))
 
     cmd.run("bud up")
+    cmd.assert_succeed()
+
     assert os.path.exists(sentinel_path)
 
     os.unlink(sentinel_path)
 
+    cmd.assert_succeed()
     cmd.run("bud up")
+
     assert not os.path.exists(sentinel_path)


### PR DESCRIPTION
## Why

We should run the integration tests on ZSH in CI.

## How

Maybe fixed by #131
