### PR TITLE
[FEATURE] Add a task to install a python project in develop mode

### DIFF
--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -1,0 +1,91 @@
+package store
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/devbuddy/devbuddy/pkg/utils"
+)
+
+var dirName = ".devbuddy"
+
+// Store is the place to record information or keep files about a project
+type Store struct {
+	projectPath string
+}
+
+// New returns an instance of Store
+func New(projectPath string) *Store {
+	return &Store{projectPath: projectPath}
+}
+
+func (s *Store) path() string {
+	return filepath.Join(s.projectPath, dirName)
+}
+
+func (s *Store) ensureInit() (err error) {
+	if !utils.PathExists(s.path()) {
+		err = os.MkdirAll(s.path(), 0755)
+		if err != nil {
+			return
+		}
+	}
+
+	gitignore := filepath.Join(s.path(), ".gitignore")
+	if !utils.PathExists(gitignore) {
+		err = ioutil.WriteFile(gitignore, []byte("*"), 0644)
+		if err != nil {
+			return
+		}
+	}
+	return nil
+}
+
+func (s *Store) stateFilePath(kind, key string) string {
+	return filepath.Join(s.path(), fmt.Sprintf("%s-%s", kind, key))
+}
+
+func makeKeyFromPath(path string) string {
+	return strings.Replace(path, string(filepath.Separator), "--", -1)
+}
+
+// RecordFileChange stores the modification time of a file.
+func (s *Store) RecordFileChange(path string) error {
+	err := s.ensureInit()
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Stat(filepath.Join(s.projectPath, path))
+	if err != nil {
+		return err
+	}
+	mtime := info.ModTime()
+
+	stateFilePath := s.stateFilePath("mtime", makeKeyFromPath(path))
+	err = ioutil.WriteFile(stateFilePath, []byte{}, 0644)
+	if err != nil {
+		return err
+	}
+
+	return os.Chtimes(stateFilePath, mtime, mtime)
+}
+
+// HasFileChanged detects whether a path has changed since the last call to RecordFileChange().
+// Defaults to true if path doesn't exists or RecordFileChange() was never called.
+func (s *Store) HasFileChanged(path string) bool {
+	info, err := os.Stat(filepath.Join(s.projectPath, path))
+	if err != nil {
+		return true
+	}
+
+	stateInfo, err := os.Stat(s.stateFilePath("mtime", makeKeyFromPath(path)))
+	if err != nil {
+		return true
+	}
+
+	return info.ModTime().After(stateInfo.ModTime())
+}

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/devbuddy/devbuddy/pkg/utils"
 )
@@ -53,19 +52,6 @@ func makeKeyFromPath(path string) string {
 	return strings.Replace(path, string(filepath.Separator), "--", -1)
 }
 
-func touch(path string, atime, mtime time.Time) error {
-	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
-	if err != nil {
-		return err
-	}
-	err = f.Close()
-	if err != nil {
-		return err
-	}
-
-	return os.Chtimes(path, atime, mtime)
-}
-
 // RecordFileChange stores the modification time of a file.
 func (s *Store) RecordFileChange(path string) error {
 	err := s.ensureInit()
@@ -79,7 +65,7 @@ func (s *Store) RecordFileChange(path string) error {
 	}
 
 	stateFilePath := s.stateFilePath("mtime", makeKeyFromPath(path))
-	return touch(stateFilePath, info.ModTime(), info.ModTime())
+	return utils.Touch(stateFilePath, info.ModTime(), info.ModTime())
 }
 
 // HasFileChanged detects whether a path has changed since the last call to RecordFileChange().

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/Flaque/filet"
+)
+
+func touch(t *testing.T, path string) {
+	err := ioutil.WriteFile(path, []byte(""), 0644)
+	require.NoError(t, err)
+}
+
+func TestWithoutFile(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	require.True(t, s.HasFileChanged("testfile"))
+}
+
+func TestFirstTime(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	path := filepath.Join(tmpdir, "testfile")
+	touch(t, path)
+
+	require.True(t, s.HasFileChanged("testfile"))
+}
+
+func TestRecordWithoutFile(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	err := s.RecordFileChange("testfile")
+	require.Error(t, err)
+}
+
+func TestRecord(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	path := filepath.Join(tmpdir, "testfile")
+	touch(t, path)
+
+	err := s.RecordFileChange("testfile")
+	require.NoError(t, err)
+
+	require.False(t, s.HasFileChanged("testfile"))
+
+	touch(t, path)
+	require.True(t, s.HasFileChanged("testfile"))
+}

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -3,25 +3,20 @@ package store
 import (
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/devbuddy/devbuddy/pkg/utils"
 	"github.com/stretchr/testify/require"
 
 	"github.com/Flaque/filet"
 )
-
-func touchNow(t *testing.T, path string) {
-	now := time.Now()
-	require.NoError(t, utils.Touch(path, now, now))
-}
 
 func TestWithoutFile(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
 	s := New(tmpdir)
 
-	require.True(t, s.HasFileChanged("testfile"))
+	result, err := s.HasFileChanged("testfile")
+	require.NoError(t, err)
+	require.True(t, result)
 }
 
 func TestFirstTime(t *testing.T) {
@@ -29,10 +24,11 @@ func TestFirstTime(t *testing.T) {
 	tmpdir := filet.TmpDir(t, "")
 	s := New(tmpdir)
 
-	path := filepath.Join(tmpdir, "testfile")
-	touchNow(t, path)
+	filet.File(t, filepath.Join(tmpdir, "testfile"), "some-value")
 
-	require.True(t, s.HasFileChanged("testfile"))
+	result, err := s.HasFileChanged("testfile")
+	require.NoError(t, err)
+	require.True(t, result)
 }
 
 func TestRecordWithoutFile(t *testing.T) {
@@ -49,14 +45,18 @@ func TestRecord(t *testing.T) {
 	tmpdir := filet.TmpDir(t, "")
 	s := New(tmpdir)
 
-	path := filepath.Join(tmpdir, "testfile")
-	touchNow(t, path)
+	filet.File(t, filepath.Join(tmpdir, "testfile"), "some-value")
 
 	err := s.RecordFileChange("testfile")
 	require.NoError(t, err)
 
-	require.False(t, s.HasFileChanged("testfile"))
+	result, err := s.HasFileChanged("testfile")
+	require.NoError(t, err)
+	require.False(t, result)
 
-	touchNow(t, path)
-	require.True(t, s.HasFileChanged("testfile"))
+	filet.File(t, filepath.Join(tmpdir, "testfile"), "some-OTHER-value")
+
+	result, err = s.HasFileChanged("testfile")
+	require.NoError(t, err)
+	require.True(t, result)
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devbuddy/devbuddy/pkg/utils"
 	"github.com/stretchr/testify/require"
 
 	"github.com/Flaque/filet"
@@ -12,7 +13,7 @@ import (
 
 func touchNow(t *testing.T, path string) {
 	now := time.Now()
-	require.NoError(t, touch(path, now, now))
+	require.NoError(t, utils.Touch(path, now, now))
 }
 
 func TestWithoutFile(t *testing.T) {

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -11,14 +10,9 @@ import (
 	"github.com/Flaque/filet"
 )
 
-func touch(t *testing.T, path string) {
-	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
-	require.NoError(t, err)
-	require.NoError(t, f.Close())
-
+func touchNow(t *testing.T, path string) {
 	now := time.Now()
-	err = os.Chtimes(path, now, now)
-	require.NoError(t, err)
+	require.NoError(t, touch(path, now, now))
 }
 
 func TestWithoutFile(t *testing.T) {
@@ -35,7 +29,7 @@ func TestFirstTime(t *testing.T) {
 	s := New(tmpdir)
 
 	path := filepath.Join(tmpdir, "testfile")
-	touch(t, path)
+	touchNow(t, path)
 
 	require.True(t, s.HasFileChanged("testfile"))
 }
@@ -55,7 +49,7 @@ func TestRecord(t *testing.T) {
 	s := New(tmpdir)
 
 	path := filepath.Join(tmpdir, "testfile")
-	touch(t, path)
+	touchNow(t, path)
 
 	err := s.RecordFileChange("testfile")
 	require.NoError(t, err)
@@ -63,6 +57,6 @@ func TestRecord(t *testing.T) {
 	require.False(t, s.HasFileChanged("testfile"))
 
 	// time.Sleep(100 * time.Millisecond)
-	touch(t, path)
+	touchNow(t, path)
 	require.True(t, s.HasFileChanged("testfile"))
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -56,6 +57,7 @@ func TestRecord(t *testing.T) {
 
 	require.False(t, s.HasFileChanged("testfile"))
 
+	time.Sleep(100 * time.Millisecond)
 	touch(t, path)
 	require.True(t, s.HasFileChanged("testfile"))
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -60,4 +61,23 @@ func TestRecord(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	touch(t, path)
 	require.True(t, s.HasFileChanged("testfile"))
+}
+
+func TestMtimeProperties(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+
+	test1 := filepath.Join(tmpdir, "test1")
+	test2 := filepath.Join(tmpdir, "test2")
+
+	ioutil.WriteFile(test1, []byte(""), 0644)
+	// time.Sleep(0)
+	ioutil.WriteFile(test2, []byte(""), 0644)
+
+	info1, err := os.Stat(test1)
+	require.NoError(t, err)
+	info2, err := os.Stat(test2)
+	require.NoError(t, err)
+
+	require.NotEqual(t, info1.ModTime(), info2.ModTime())
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,12 @@ import (
 )
 
 func touch(t *testing.T, path string) {
-	err := ioutil.WriteFile(path, []byte(""), 0644)
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	now := time.Now()
+	err = os.Chtimes(path, now, now)
 	require.NoError(t, err)
 }
 
@@ -58,26 +62,7 @@ func TestRecord(t *testing.T) {
 
 	require.False(t, s.HasFileChanged("testfile"))
 
-	time.Sleep(100 * time.Millisecond)
+	// time.Sleep(100 * time.Millisecond)
 	touch(t, path)
 	require.True(t, s.HasFileChanged("testfile"))
-}
-
-func TestMtimeProperties(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
-
-	test1 := filepath.Join(tmpdir, "test1")
-	test2 := filepath.Join(tmpdir, "test2")
-
-	ioutil.WriteFile(test1, []byte(""), 0644)
-	// time.Sleep(0)
-	ioutil.WriteFile(test2, []byte(""), 0644)
-
-	info1, err := os.Stat(test1)
-	require.NoError(t, err)
-	info2, err := os.Stat(test2)
-	require.NoError(t, err)
-
-	require.NotEqual(t, info1.ModTime(), info2.ModTime())
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -56,7 +56,6 @@ func TestRecord(t *testing.T) {
 
 	require.False(t, s.HasFileChanged("testfile"))
 
-	// time.Sleep(100 * time.Millisecond)
 	touchNow(t, path)
 	require.True(t, s.HasFileChanged("testfile"))
 }

--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -46,7 +46,7 @@ func (p *pythonDevelopInstall) description() string {
 }
 
 func (p *pythonDevelopInstall) needed(ctx *context) (bool, error) {
-	return store.New(ctx.proj.Path).HasFileChanged("setup.py"), nil
+	return store.New(ctx.proj.Path).HasFileChanged("setup.py")
 }
 
 func (p *pythonDevelopInstall) run(ctx *context) error {

--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -1,0 +1,59 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/devbuddy/devbuddy/pkg/helpers/store"
+)
+
+func init() {
+	allTasks["python_develop"] = newPythonDevelop
+}
+
+type pythonDevelop struct {
+}
+
+func newPythonDevelop(config *taskConfig) (Task, error) {
+	return &pythonDevelop{}, nil
+}
+
+func (p *pythonDevelop) name() string {
+	return "Python develop"
+}
+
+func (p *pythonDevelop) header() string {
+	return ""
+}
+
+func (p *pythonDevelop) preRunValidation(ctx *context) (err error) {
+	_, hasPythonFeature := ctx.features["python"]
+	if !hasPythonFeature {
+		return fmt.Errorf("You must specify a Python environment to use this task")
+	}
+	return nil
+}
+
+func (p *pythonDevelop) actions(ctx *context) (actions []taskAction) {
+	actions = append(actions, &pythonDevelopInstall{})
+	return
+}
+
+type pythonDevelopInstall struct {
+}
+
+func (p *pythonDevelopInstall) description() string {
+	return "install python package in develop mode"
+}
+
+func (p *pythonDevelopInstall) needed(ctx *context) (bool, error) {
+	return store.New(ctx.proj.Path).HasFileChanged("setup.py"), nil
+}
+
+func (p *pythonDevelopInstall) run(ctx *context) error {
+	err := command(ctx, "pip", "install", "--require-virtualenv", "-e", ".").AddOutputFilter("already satisfied").Run()
+	if err != nil {
+		return fmt.Errorf("Pip failed: %s", err)
+	}
+
+	return store.New(ctx.proj.Path).RecordFileChange("setup.py")
+}

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"fmt"
+	"hash/adler32"
+	"io/ioutil"
 	"os"
 	"time"
 )
@@ -24,4 +27,14 @@ func Touch(path string, atime, mtime time.Time) error {
 	}
 
 	return os.Chtimes(path, atime, mtime)
+}
+
+// FileChecksum reads a file and return the Adler32 checksum of its data as a string
+func FileChecksum(path string) (string, error) {
+	content, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	checksum := fmt.Sprint(adler32.Checksum(content))
+	return checksum, nil
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"time"
 )
 
 func PathExists(path string) (exists bool) {
@@ -9,4 +10,18 @@ func PathExists(path string) (exists bool) {
 		return false
 	}
 	return true
+}
+
+// Touch updates the atime and mtime of a file, after creating it if it doesn't exist.
+func Touch(path string, atime, mtime time.Time) error {
+	f, err := os.OpenFile(path, os.O_RDONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Chtimes(path, atime, mtime)
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,14 @@ def binary(binary_path):
 
 
 def build_pexpect_bash(workdir):
-    child = pexpect.spawn('bash', ['--norc', '--noprofile'], echo=False, encoding='utf-8', cwd=str(workdir))
+    child = pexpect.spawn(
+        'bash',
+        ['--norc', '--noprofile'],
+        echo=False,
+        encoding='utf-8',
+        cwd=str(workdir),
+        timeout=120,
+    )
 
     # If the user runs 'env', the value of PS1 will be in the output. To avoid
     # replwrap seeing that as the next prompt, we'll embed the marker characters
@@ -60,6 +67,7 @@ def build_pexpect_zsh(workdir):
         encoding='utf-8',
         env={'PROMPT': 'ps1'},
         cwd=str(workdir),
+        timeout=120,
     )
 
     return pexpect.replwrap.REPLWrapper(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,14 +40,7 @@ def binary(binary_path):
 
 
 def build_pexpect_bash(workdir):
-    child = pexpect.spawn(
-        'bash',
-        ['--norc', '--noprofile'],
-        echo=False,
-        encoding='utf-8',
-        cwd=str(workdir),
-        timeout=120,
-    )
+    child = pexpect.spawn('bash', ['--norc', '--noprofile'], echo=False, encoding='utf-8', cwd=str(workdir))
 
     # If the user runs 'env', the value of PS1 will be in the output. To avoid
     # replwrap seeing that as the next prompt, we'll embed the marker characters
@@ -67,7 +60,6 @@ def build_pexpect_zsh(workdir):
         encoding='utf-8',
         env={'PROMPT': 'ps1'},
         cwd=str(workdir),
-        timeout=120,
     )
 
     return pexpect.replwrap.REPLWrapper(

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -14,7 +14,7 @@ def make_setuppy(version):
 def test_with_modification(cmd, project):
     project.write_devyml("""
         up:
-        - python: 3.6.3
+        - python: 3.6.5
         - python_develop
     """)
 
@@ -34,7 +34,7 @@ def test_with_modification(cmd, project):
 def test_without_modification(cmd, project):
     project.write_devyml("""
         up:
-        - python: 3.6.3
+        - python: 3.6.5
         - python_develop
     """)
 

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -1,0 +1,51 @@
+import os
+import textwrap
+
+
+def make_setuppy(version):
+    return textwrap.dedent(f"""
+        from setuptools import setup, find_packages
+        setup(name='devbuddy-test-pkg', version='{version}')
+
+        open("sentinel", "w").write("")
+    """)
+
+
+def test_with_modification(cmd, project):
+    project.write_devyml("""
+        up:
+        - python: 3.6.3
+        - python_develop
+    """)
+
+    project.write_file("setup.py", make_setuppy(version=42))
+
+    cmd.run("bud up")
+    output = cmd.run("pip show devbuddy-test-pkg")
+    assert "Version: 42" in output
+
+    project.write_file("setup.py", make_setuppy(version=84))
+
+    cmd.run("bud up")
+    output = cmd.run("pip show devbuddy-test-pkg")
+    assert "Version: 84" in output
+
+
+def test_without_modification(cmd, project):
+    project.write_devyml("""
+        up:
+        - python: 3.6.3
+        - python_develop
+    """)
+
+    sentinel_path = os.path.join(project.path, "sentinel")
+
+    project.write_file("setup.py", make_setuppy(version=42))
+
+    cmd.run("bud up")
+    assert os.path.exists(sentinel_path)
+
+    os.unlink(sentinel_path)
+
+    cmd.run("bud up")
+    assert not os.path.exists(sentinel_path)


### PR DESCRIPTION
## Why

Add a task `python_develop` to run `pip install -e .` when `setup.py` has changed.


## How

- Started a project "store" which persisted as a `.devbuddy` directory in the project root.
- This "store" has methods to answer to specific needs like detecting that a file changed.


Resolves #135 