### PR TITLE
Fix ZSH prompt hook and improve shell detection 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - run: pyenv install 3.6.5 && pyenv global 3.6.5
       - run: pip install -U pip setuptools && pip install -r tests/requirements.txt
       - run: pytest --durations=1 -v tests
-      # - run: pytest --durations=1 --shell zsh -v tests
+      - run: pytest --durations=1 --shell zsh -v tests
 
   lint:
     docker:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,6 +35,12 @@
   revision = "d694e6f975a9109e2b063829d563a7c153c4b53c"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/mitchellh/go-ps"
+  packages = ["."]
+  revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
@@ -98,6 +104,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cb51793c5e019e70be6ebb2ce63cc0a2fd8753f5618606e997b5e96ecf2c682d"
+  inputs-digest = "5bdfa6c4938eda81401e42a1d06e813c39f41ecafcf4f749a25a502da5803679"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/integration/zsh.go
+++ b/pkg/integration/zsh.go
@@ -1,8 +1,7 @@
 package integration
 
 var zshSource = `
-promptcmd() { $("__bud_prompt_command") }
 if [[ ! "${precmd_functions[@]}" == *__bud_prompt_command* ]]; then
-  precmd_functions+=(promptcmd)
+  precmd_functions+=(__bud_prompt_command)
 fi
 `

--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -33,3 +33,11 @@ func (u *HookUI) HookFeatureFailure(name string, version string) {
 	ver := color.Sprintf("(version: %s)", version)
 	fmt.Fprintf(u.out, "🐼  %s %s\n", color.Red(msg), color.Brown(ver))
 }
+
+func HookShellDetectionError(err error) {
+	fmt.Fprintln(os.Stderr, color.Brown("Could not detect your shell:"), err.Error())
+}
+
+func HookIntegrationError(message string) {
+	fmt.Fprintf(os.Stderr, "%s: %s", color.Red("Shell integration error:"), message)
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def build_pexpect_zsh(workdir):
         'zsh', ['--no-globalrcs', '--no-rcs', '--no-zle', '--no-promptcr'],
         echo=False,
         encoding='utf-8',
-        env={'PROMPT': 'ps1'},
+        env={'PROMPT': 'ps1', 'PATH': os.getenv('PATH')},
         cwd=str(workdir),
     )
 

--- a/tests/test_task_go.py
+++ b/tests/test_task_go.py
@@ -15,6 +15,7 @@ def test_env(cmd, project, gopath):
     """)
 
     cmd.run("bud up")
+    cmd.assert_succeed()
 
     output = cmd.run("go version")
     assert "go version go1.5" in output
@@ -29,4 +30,6 @@ def test_warn_gopath_missing(cmd, project, gopath):
     """)
 
     output = cmd.run("bud up")
+    cmd.assert_failed()
+
     assert "The GOPATH environment variable should be set" in output

--- a/tests/test_task_python.py
+++ b/tests/test_task_python.py
@@ -5,7 +5,8 @@ def test_task(cmd, project):
         - python: 3.6.5
     """)
 
-    cmd.run("bud up")
+    output = cmd.run("bud up")
+    cmd.assert_succeed()
 
     output = cmd.run("python --version")
     assert output == "Python 3.6.5"

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -21,12 +21,16 @@ def test_with_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=42))
 
     cmd.run("bud up")
+    cmd.assert_succeed()
+
     output = cmd.run("pip show devbuddy-test-pkg")
     assert "Version: 42" in output
 
     project.write_file("setup.py", make_setuppy(version=84))
 
     cmd.run("bud up")
+    cmd.assert_succeed()
+
     output = cmd.run("pip show devbuddy-test-pkg")
     assert "Version: 84" in output
 
@@ -43,9 +47,13 @@ def test_without_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=42))
 
     cmd.run("bud up")
+    cmd.assert_succeed()
+
     assert os.path.exists(sentinel_path)
 
     os.unlink(sentinel_path)
 
+    cmd.assert_succeed()
     cmd.run("bud up")
+
     assert not os.path.exists(sentinel_path)


### PR DESCRIPTION
## Why

- The shell hook is not really working (on 5.3 and 5.5).
- ZSH is not always detected because the `SHELL` variable is not always set (at least in a verbatim zsh install).

## How

- Call the prompt shell function without subshelling (since it hides what the command send to stdout)
- Use another method to detect the shell: evaluating the name of the parent process. 

