### PR TITLE
Fix zsh prompt hook

### DIFF
--- a/pkg/integration/zsh.go
+++ b/pkg/integration/zsh.go
@@ -1,8 +1,7 @@
 package integration
 
 var zshSource = `
-promptcmd() { $("__bud_prompt_command") }
 if [[ ! "${precmd_functions[@]}" == *__bud_prompt_command* ]]; then
-  precmd_functions+=(promptcmd)
+  precmd_functions+=(__bud_prompt_command)
 fi
 `


### PR DESCRIPTION
## Why

The shell hook is not really working (on 5.3 and 5.5).

## How

Call the prompt shell function without subshelling (since it hides what the command send to stdout)
