### PR TITLE
Fix bug in pipfile task where PipEnv installation fails

### DIFF
--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -29,7 +29,8 @@ func (p *pipfileInstall) description() string {
 
 func (p *pipfileInstall) needed(ctx *context) (bool, error) {
 	pythonParam := ctx.features["python"]
-	venv := helpers.NewVirtualenv(ctx.cfg, pythonParam)
+	name := helpers.VirtualenvName(ctx.proj, pythonParam)
+	venv := helpers.NewVirtualenv(ctx.cfg, name)
 	pipenvCmd := venv.Which("pipenv")
 	return !utils.PathExists(pipenvCmd), nil
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,7 +58,7 @@ def build_pexpect_zsh(workdir):
         'zsh', ['--no-globalrcs', '--no-rcs', '--no-zle', '--no-promptcr'],
         echo=False,
         encoding='utf-8',
-        env={'PROMPT': 'ps1', 'PATH': os.getenv('PATH'), 'LANG': 'en_CA.UTF-8'},
+        env={'PROMPT': 'ps1', 'PATH': os.getenv('PATH'), 'LANG': 'en_CA.UTF-8', 'TERM': 'xterm'},
         cwd=str(workdir),
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,11 +54,18 @@ def build_pexpect_bash(workdir):
 
 
 def build_pexpect_zsh(workdir):
+    env = {
+        'PROMPT': 'ps1',
+        'PATH': os.getenv('PATH'),
+        'LANG': 'C.UTF-8',
+        'LC_ALL': 'C.UTF-8',
+    }
+
     child = pexpect.spawn(
         'zsh', ['--no-globalrcs', '--no-rcs', '--no-zle', '--no-promptcr'],
         echo=False,
         encoding='utf-8',
-        env={'PROMPT': 'ps1', 'PATH': os.getenv('PATH'), 'LANG': 'en_CA.UTF-8', 'TERM': 'xterm'},
+        env=env,
         cwd=str(workdir),
     )
 

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -31,10 +31,7 @@ def test_exit_code(cmd, project):
     """)
 
     cmd.run("bud success")
-    cmd.assert_succeed()
-
-    cmd.run("bud failure")
-    cmd.assert_failed()
+    cmd.run("bud failure", expect_exit_code=1)
 
 
 def test_with_arguments(cmd, project):

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,12 +12,10 @@ def test_invalid_manifest_with_string(cmd, project):
     """)
 
     output = cmd.run('bud inspect')
-    cmd.assert_succeed()
-
     assert 'Title' in output
     assert 'some-condition-command' in output
     assert 'requirements.txt' in output
 
 
 def test_without_manifest(cmd, project):
-    output = cmd.run('bud inspect', expect_exit_code=1)
+    cmd.run('bud inspect', expect_exit_code=1)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -20,5 +20,4 @@ def test_invalid_manifest_with_string(cmd, project):
 
 
 def test_without_manifest(cmd, project):
-    output = cmd.run('bud inspect')
-    cmd.assert_failed()
+    output = cmd.run('bud inspect', expect_exit_code=1)

--- a/tests/test_task_custom.py
+++ b/tests/test_task_custom.py
@@ -49,6 +49,5 @@ def test_should_run_and_fail(cmd, project):
             meet: 'false'
     """)
 
-    output = cmd.run("bud up")
-    cmd.assert_failed()
+    output = cmd.run("bud up", expect_exit_code=1)
     assert 'command failed' in output

--- a/tests/test_task_go.py
+++ b/tests/test_task_go.py
@@ -15,7 +15,6 @@ def test_env(cmd, project, gopath):
     """)
 
     cmd.run("bud up")
-    cmd.assert_succeed()
 
     output = cmd.run("go version")
     assert "go version go1.5" in output
@@ -29,7 +28,5 @@ def test_warn_gopath_missing(cmd, project, gopath):
         - go: '1.5'
     """)
 
-    output = cmd.run("bud up")
-    cmd.assert_failed()
-
+    output = cmd.run("bud up", expect_exit_code=1)
     assert "The GOPATH environment variable should be set" in output

--- a/tests/test_task_pip.py
+++ b/tests/test_task_pip.py
@@ -8,7 +8,6 @@ def test_requirements(cmd, project):
     project.write_file("requirements.txt", "test==2.3.4.5\n")
 
     cmd.run("bud up")
-    cmd.assert_succeed()
 
     output = cmd.run("pip freeze")
     assert 'test==2.3.4.5' in output

--- a/tests/test_task_pipfile.py
+++ b/tests/test_task_pipfile.py
@@ -8,7 +8,6 @@ def test_simple(cmd, project):
     project.write_file("Pipfile", """[packages]\n"test" = "==2.3.4.5"\n""")
 
     output = cmd.run("bud up")
-    cmd.assert_succeed()
 
     output = cmd.run("pip freeze")
     assert 'test==2.3.4.5' in output

--- a/tests/test_task_pipfile.py
+++ b/tests/test_task_pipfile.py
@@ -1,13 +1,13 @@
 
-def test_requirements(cmd, project):
+def test_simple(cmd, project):
     project.write_devyml("""
         up:
         - python: 3.6.5
-        - pip: [requirements.txt]
+        - pipfile
     """)
-    project.write_file("requirements.txt", "test==2.3.4.5\n")
+    project.write_file("Pipfile", """[packages]\n"test" = "==2.3.4.5"\n""")
 
-    cmd.run("bud up")
+    output = cmd.run("bud up")
     cmd.assert_succeed()
 
     output = cmd.run("pip freeze")

--- a/tests/test_task_python.py
+++ b/tests/test_task_python.py
@@ -5,8 +5,7 @@ def test_task(cmd, project):
         - python: 3.6.5
     """)
 
-    output = cmd.run("bud up")
-    cmd.assert_succeed()
+    cmd.run("bud up")
 
     output = cmd.run("python --version")
     assert output == "Python 3.6.5"

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -21,7 +21,6 @@ def test_with_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=42))
 
     cmd.run("bud up")
-    cmd.assert_succeed()
 
     output = cmd.run("pip show devbuddy-test-pkg")
     assert "Version: 42" in output
@@ -29,7 +28,6 @@ def test_with_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=84))
 
     cmd.run("bud up")
-    cmd.assert_succeed()
 
     output = cmd.run("pip show devbuddy-test-pkg")
     assert "Version: 84" in output
@@ -47,13 +45,11 @@ def test_without_modification(cmd, project):
     project.write_file("setup.py", make_setuppy(version=42))
 
     cmd.run("bud up")
-    cmd.assert_succeed()
 
     assert os.path.exists(sentinel_path)
 
     os.unlink(sentinel_path)
 
-    cmd.assert_succeed()
     cmd.run("bud up")
 
     assert not os.path.exists(sentinel_path)

--- a/tests/test_up.py
+++ b/tests/test_up.py
@@ -6,8 +6,7 @@ def test_invalid_manifest_with_string(cmd, project):
         up: somestring
     """)
 
-    output = cmd.run('bud up')
-    cmd.assert_failed()
+    output = cmd.run('bud up', expect_exit_code=1)
 
     # This test exists to show how bad the output is. This should be improved.
     assert 'yaml: unmarshal errors' in output
@@ -21,7 +20,6 @@ def test_unknown_task(cmd, project):
     """)
 
     output = cmd.run('bud up')
-    cmd.assert_succeed()
 
     assert 'notatask' in output
     assert 'Unknown task' in output
@@ -33,7 +31,5 @@ def test_invalid_task(cmd, project):
           - true
     """)
 
-    output = cmd.run('bud up')
-    cmd.assert_failed()
-
+    output = cmd.run('bud up', expect_exit_code=1)
     assert 'invalid task: "true"' in output


### PR DESCRIPTION
## Why

This [change](https://github.com/devbuddy/devbuddy/commit/8c786f0936c0312641c3a37390fe670490d1d7f3#diff-d24fb76f673acf2707bc5da63b2c450bL15) changed the value of the feature "param" for Python, from the full project virtualenv name to the python version.

The pipfile task should have been updated in the refacto PR.

## How

- update the pipfile task
- add integration test on this task

