### PR TITLE
Add a simple `init` command to create a `dev.yml` file

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/manifest"
+	"github.com/devbuddy/devbuddy/pkg/termui"
+
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Initialize a project in the current directory",
+	Run:   initRun,
+	Args:  noArgs,
+}
+
+func initRun(cmd *cobra.Command, args []string) {
+	cfg, err := config.Load()
+	checkError(err)
+
+	ui := termui.NewUI(cfg)
+
+	ui.ActionHeader("Creating a default dev.yml file.")
+
+	projectPath, err := os.Getwd()
+	checkError(err)
+
+	err = manifest.Create(projectPath)
+	checkError(err)
+
+	ui.ActionNotice("Open dev.yml to adjust for your needs.")
+	ui.ActionDone()
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,6 +28,7 @@ func build(version string) {
 	rootCmd.AddCommand(cdCmd)
 	rootCmd.AddCommand(cloneCmd)
 	rootCmd.AddCommand(createCmd)
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(inspectCmd)
 	rootCmd.AddCommand(openCmd)
 	rootCmd.AddCommand(upCmd)

--- a/pkg/manifest/create.go
+++ b/pkg/manifest/create.go
@@ -1,0 +1,48 @@
+package manifest
+
+import (
+	"path"
+
+	"github.com/devbuddy/devbuddy/pkg/utils"
+)
+
+const defaultManifestContent = `# Created by "bud init"
+
+up:
+  - go: 1.10.1
+  - golang_dep
+  - python: 3.6.5
+  - pip: [tests/requirements.txt]
+  - homebrew:
+    - curl
+  - custom:
+      name: Install gometalinter
+      met?: which gometalinter.v2 > /dev/null
+      meet: go get gopkg.in/alecthomas/gometalinter.v2
+
+commands:
+  test:
+    desc: Run the unittests
+    run: script/test
+
+  lint:
+    desc: Lint the project
+    run: script/lint
+
+  release:
+    desc: Create a new release (bud release [VERSION])
+    run: script/release
+
+  godoc:
+    desc: Starting GoDoc server on http://0.0.0.0:6060
+    run: (sleep 1; open http://0.0.0.0:6060)& godoc -http=:6060
+
+open:
+  devbuddy: https://github.com/devbuddy/devbuddy/blob/master/docs/Config.md#config-devyml
+`
+
+// Create writes a default project manifest in the specified path
+func Create(projectPath string) error {
+	manifestPath := path.Join(projectPath, manifestFilename)
+	return utils.WriteNewFile(manifestPath, []byte(defaultManifestContent), 0666)
+}

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -23,6 +23,18 @@ func NewUI(cfg *config.Config) *UI {
 	}
 }
 
+func (u *UI) ActionHeader(description string) {
+	fmt.Fprintf(u.out, "🐼  %s\n", color.Cyan(description))
+}
+
+func (u *UI) ActionNotice(text string) {
+	fmt.Fprintf(u.out, "⚠️   %s\n", color.Brown(text))
+}
+
+func (u *UI) ActionDone() {
+	fmt.Fprintf(u.out, "✅  %s\n", color.Green("Done!"))
+}
+
 func (u *UI) CommandHeader(cmdline string) {
 	fmt.Fprintf(os.Stderr, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
 }

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -38,3 +38,20 @@ func FileChecksum(path string) (string, error) {
 	checksum := fmt.Sprint(adler32.Checksum(content))
 	return checksum, nil
 }
+
+func WriteNewFile(filename string, data []byte, perm os.FileMode) error {
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, perm)
+	if err != nil {
+		return fmt.Errorf("creation failed: %s", err)
+	}
+
+	defer func() {
+		cerr := file.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	_, err = file.Write(data)
+	return err
+}

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,2 +1,3 @@
 pytest==3.6.1
 pexpect==4.6.0
+PyYAML==3.13

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,38 @@
+import yaml
+
+
+def test_create(cmd, tmpdir):
+    cmd.run(f"cd {tmpdir}")
+
+    output = cmd.run("bud init", check_activation_failure=False)
+    assert "Open dev.yml to adjust for your needs." in output
+    assert "Done" in output
+
+    manifest = tmpdir.join("dev.yml")
+    assert manifest.check(file=1)
+
+    validate_manifest(manifest.open().read())
+
+
+def test_create_existing(cmd, tmpdir):
+    cmd.run(f"cd {tmpdir}")
+    cmd.run("touch dev.yml")
+
+    output = cmd.run("bud init", expect_exit_code=1)
+    assert "creation failed" in output
+    assert "file exists" in output
+
+
+def validate_manifest(as_string: str) -> None:
+    content = yaml.load(as_string)
+
+    assert "up" in content
+    assert isinstance(content["up"], list)
+    for task in content["up"]:
+        assert isinstance(task, (str, dict))
+
+    if "commands" in content:
+        assert isinstance(content["commands"], dict)
+
+    if "open" in content:
+        assert isinstance(content["open"], dict)

--- a/tests/test_task_pipfile.py
+++ b/tests/test_task_pipfile.py
@@ -3,6 +3,10 @@ def test_simple(cmd, project):
     project.write_devyml("""
         up:
         - python: 3.6.5
+        - custom:
+            name: force pip version - https://github.com/pypa/pipenv/issues/2924
+            met?: pip --disable-pip-version-check freeze --all | grep -q 'pip==18.0'
+            meet: pip --disable-pip-version-check install 'pip==18.0'
         - pipfile
     """)
     project.write_file("Pipfile", """[packages]\n"test" = "==2.3.4.5"\n""")


### PR DESCRIPTION
## Why

- It would be handy to be able to convert an existing project.
- The `create` command should also create a `dev.yml` file.

## How

- Add a `init` command to create a manifest in the local directory
- Fail if a manifest already exists
- The content of the manifest is currently hardcoded.

Future improvements will include:
- asking the user about the desired language/features 
- detecting the features/tasks (requirements.txt -> python + pip, `Gopkg.toml` -> Go + golang_dep)

