### PR TITLE
Check err returned by fmt.Fprintf()

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+
+	"github.com/devbuddy/devbuddy/pkg/termui"
 )
 
 type Executor struct {
@@ -76,7 +78,7 @@ func (e *Executor) printPipe(wg *sync.WaitGroup, pipe io.Reader) {
 		if e.shouldSuppressLine(line) {
 			continue
 		}
-		fmt.Fprintf(e.outputWriter, "%s%s\n", e.outputPrefix, line)
+		termui.Fprintf(e.outputWriter, "%s%s\n", e.outputPrefix, line)
 	}
 }
 

--- a/pkg/termui/base.go
+++ b/pkg/termui/base.go
@@ -2,6 +2,8 @@ package termui
 
 import (
 	"fmt"
+	"io"
+	"log"
 	"os"
 
 	color "github.com/logrusorgru/aurora"
@@ -15,6 +17,13 @@ type baseUI struct {
 func (u *baseUI) Debug(format string, params ...interface{}) {
 	if u.debugEnabled {
 		msg := fmt.Sprintf(format, params...)
-		fmt.Fprintf(u.out, "BUD_DEBUG: %s\n", color.Gray(msg))
+		Fprintf(u.out, "BUD_DEBUG: %s\n", color.Gray(msg))
+	}
+}
+
+func Fprintf(w io.Writer, format string, a ...interface{}) {
+	_, err := fmt.Fprintf(w, format, a...)
+	if err != nil {
+		log.Fatalf("failed to write to console: %s", err)
 	}
 }

--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -1,7 +1,6 @@
 package termui
 
 import (
-	"fmt"
 	"os"
 
 	color "github.com/logrusorgru/aurora"
@@ -25,19 +24,19 @@ func NewHookUI(cfg *config.Config) *HookUI {
 func (u *HookUI) HookFeatureActivated(name string, version string) {
 	msg := color.Sprintf("%s activated.", name)
 	ver := color.Sprintf("(version: %s)", version)
-	fmt.Fprintf(u.out, "🐼  %s %s\n", color.Cyan(msg), color.Blue(ver))
+	Fprintf(u.out, "🐼  %s %s\n", color.Cyan(msg), color.Blue(ver))
 }
 
 func (u *HookUI) HookFeatureFailure(name string, version string) {
 	msg := color.Sprintf("failed to activate %s. Try running 'bud up' first!", name)
 	ver := color.Sprintf("(version: %s)", version)
-	fmt.Fprintf(u.out, "🐼  %s %s\n", color.Red(msg), color.Brown(ver))
+	Fprintf(u.out, "🐼  %s %s\n", color.Red(msg), color.Brown(ver))
 }
 
 func HookShellDetectionError(err error) {
-	fmt.Fprintln(os.Stderr, color.Brown("Could not detect your shell:"), err.Error())
+	Fprintf(os.Stderr, "%s %s\n", color.Brown("Could not detect your shell:"), err.Error())
 }
 
 func HookIntegrationError(message string) {
-	fmt.Fprintf(os.Stderr, "%s: %s", color.Red("Shell integration error:"), message)
+	Fprintf(os.Stderr, "%s: %s", color.Red("Shell integration error:"), message)
 }

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -24,68 +24,68 @@ func NewUI(cfg *config.Config) *UI {
 }
 
 func (u *UI) ActionHeader(description string) {
-	fmt.Fprintf(u.out, "🐼  %s\n", color.Cyan(description))
+	Fprintf(u.out, "🐼  %s\n", color.Cyan(description))
 }
 
 func (u *UI) ActionNotice(text string) {
-	fmt.Fprintf(u.out, "⚠️   %s\n", color.Brown(text))
+	Fprintf(u.out, "⚠️   %s\n", color.Brown(text))
 }
 
 func (u *UI) ActionDone() {
-	fmt.Fprintf(u.out, "✅  %s\n", color.Green("Done!"))
+	Fprintf(u.out, "✅  %s\n", color.Green("Done!"))
 }
 
 func (u *UI) CommandHeader(cmdline string) {
-	fmt.Fprintf(os.Stderr, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
+	Fprintf(os.Stderr, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
 }
 
 func (u *UI) CommandRun(cmdline string, args ...string) {
-	fmt.Fprint(u.out, color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")), "\n")
+	Fprintf(u.out, "%s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
 }
 
 func (u *UI) CommandActed() {
-	fmt.Fprintf(u.out, "  %s\n", color.Green("Done!"))
+	Fprintf(u.out, "  %s\n", color.Green("Done!"))
 }
 
 func (u *UI) TaskHeader(name string, param string) {
 	if param != "" {
 		param = fmt.Sprintf(" (%s)", color.Blue(param))
 	}
-	fmt.Fprintf(u.out, "%s %s%s\n", color.Brown("◼︎"), color.Magenta(name), param)
+	Fprintf(u.out, "%s %s%s\n", color.Brown("◼︎"), color.Magenta(name), param)
 }
 
 func (u *UI) TaskCommand(cmdline string, args ...string) {
-	fmt.Fprintf(u.out, "  Running: %s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
+	Fprintf(u.out, "  Running: %s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
 }
 
 func (u *UI) TaskShell(cmdline string) {
-	fmt.Fprintf(u.out, "  Running: %s\n", color.Cyan(cmdline))
+	Fprintf(u.out, "  Running: %s\n", color.Cyan(cmdline))
 }
 
 func (u *UI) TaskActed() {
-	fmt.Fprintf(u.out, "  %s\n", color.Green("Done!"))
+	Fprintf(u.out, "  %s\n", color.Green("Done!"))
 }
 
 func (u *UI) TaskAlreadyOk() {
-	fmt.Fprintf(u.out, "  %s\n", color.Green("Already OK!"))
+	Fprintf(u.out, "  %s\n", color.Green("Already OK!"))
 }
 
 func (u *UI) TaskError(err error) {
-	fmt.Fprintf(u.out, "  %s\n", color.Red(err.Error()))
+	Fprintf(u.out, "  %s\n", color.Red(err.Error()))
 }
 
 func (u *UI) TaskWarning(message string) {
-	fmt.Fprintf(u.out, "  Warning: %s\n", color.Brown(message))
+	Fprintf(u.out, "  Warning: %s\n", color.Brown(message))
 }
 
 func (u *UI) TaskActionHeader(desc string) {
-	fmt.Fprintf(u.out, "  %s%s\n", color.Brown("▪︎"), color.Magenta(desc))
+	Fprintf(u.out, "  %s%s\n", color.Brown("▪︎"), color.Magenta(desc))
 }
 
 func (u *UI) ProjectExists() {
-	fmt.Fprintf(u.out, "🐼  %s\n", color.Brown("project already exists locally"))
+	Fprintf(u.out, "🐼  %s\n", color.Brown("project already exists locally"))
 }
 
 func (u *UI) JumpProject(name string) {
-	fmt.Fprintf(u.out, "🐼  %s %s\n", color.Brown("jumping to"), color.Green(name))
+	Fprintf(u.out, "🐼  %s %s\n", color.Brown("jumping to"), color.Green(name))
 }

--- a/script/lint
+++ b/script/lint
@@ -5,7 +5,7 @@ gometalinter.v2 \
     --vendor \
     --deadline=120s \
     --disable=gotype \
-    --disable=gas \
+    --disable=gas --disable=gosec \
     --enable=gofmt \
     --exclude=".*should have comment or be unexported.*" \
     ./...


### PR DESCRIPTION
## Why

The new release of https://github.com/kisielk/errcheck now throws errors for `fmt.Fprintf`.

See issue: https://github.com/kisielk/errcheck/issues/140

## How

- Implement a local `Fprintf` function what will `log.Fatal` on error.

