### PR TITLE
Replace gometalinter by golangci-lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 bud
 devbuddy
 dist/
+bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+run:
+  tests: false
+
+linters:
+  enable:
+    - gofmt

--- a/dev.yml
+++ b/dev.yml
@@ -7,9 +7,9 @@ up:
     - curl
     - shellcheck
   - custom:
-      name: Install gometalinter
-      met?: which gometalinter.v2 > /dev/null
-      meet: go get gopkg.in/alecthomas/gometalinter.v2
+      name: Install golangci-lint in ./bin
+      met?: test -f bin/golangci-lint
+      meet: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.10.2
 
 commands:
   testup:

--- a/script/lint
+++ b/script/lint
@@ -1,11 +1,6 @@
 #!/bin/sh
 set -eu
 
-gometalinter.v2 \
-    --vendor \
-    --deadline=120s \
-    --disable=gotype \
-    --disable=gas \
-    --enable=gofmt \
-    --exclude=".*should have comment or be unexported.*" \
-    ./...
+export CGO_ENABLED=0
+
+exec bin/golangci-lint run


### PR DESCRIPTION
## Why

The linter runner we are using (gometalinter) is not 100% satisfying, it's quite slow, sometimes buggy, and rely on external linters (which brings a whole class of issues). 

## How

Replace it with [golangci-lint](https://github.com/golangci/golangci-lint) which seems faster, easier to deal with and better maintained.


