### PR TITLE
Accept full git url in clone command

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -17,7 +17,6 @@ type Project struct {
 	HostingPlatform  string // Name and directory name of the hosting platform like "github.com"
 	OrganisationName string // Name and directory name of the organisation owning this project
 	RepositoryName   string // Name and directory name of this project
-	id               string // Short id like "org/name"
 	Path             string // Full path of this project
 
 	Manifest *manifest.Manifest // Manifest of this project
@@ -32,7 +31,6 @@ func NewFromID(id string, conf *config.Config) (p *Project, err error) {
 			HostingPlatform:  "github.com",
 			OrganisationName: match[1],
 			RepositoryName:   match[2],
-			id:               id,
 		}
 	} else {
 		err = fmt.Errorf("Unrecognized remote project: %s", id)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -15,10 +15,10 @@ import (
 
 // Project represents a project whether it exists locally or not
 type Project struct {
-	HostingPlatform  string // Name and directory name of the hosting platform like "github.com"
-	OrganisationName string // Name and directory name of the organisation owning this project
-	RepositoryName   string // Name and directory name of this project
-	Path             string // Full path of this project
+	HostingPlatform  string // Name of the hosting platform like "github.com"
+	OrganisationName string // Name of the organisation owning this project
+	RepositoryName   string // Name of this project
+	Path             string // Local path of this project on disk
 
 	Manifest *manifest.Manifest // Manifest of this project
 }

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,0 +1,65 @@
+package project
+
+import (
+	"testing"
+
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+var cfg = &config.Config{SourceDir: "/src"}
+
+func TestNewFromID(t *testing.T) {
+	proj, err := NewFromID("golang/go", cfg)
+	require.NoError(t, err, "NewFromID() failed")
+	require.NotEqual(t, nil, proj)
+	require.Equal(t, "github.com", proj.HostingPlatform)
+	require.Equal(t, "golang", proj.OrganisationName)
+	require.Equal(t, "go", proj.RepositoryName)
+	require.Equal(t, "/src/github.com/golang/go", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.Equal(t, "git@github.com:golang/go.git", url)
+
+	require.Equal(t, "go-1999178051", proj.Slug())
+}
+
+func TestNewFromIDError(t *testing.T) {
+	proj, err := NewFromID("", cfg)
+	require.Error(t, err, "NewFromID() should fail")
+	require.Nil(t, proj)
+
+	proj, err = NewFromID("golang", cfg)
+	require.Error(t, err, "NewFromID() should fail")
+	require.Nil(t, proj)
+}
+
+func TestNewFromIDGithubFullURL(t *testing.T) {
+	proj, err := NewFromID("git@github.com:golang/go.git", cfg)
+	require.NoError(t, err, "NewFromID() failed")
+	require.NotEqual(t, nil, proj)
+	require.Equal(t, "github.com", proj.HostingPlatform)
+	require.Equal(t, "golang", proj.OrganisationName)
+	require.Equal(t, "go", proj.RepositoryName)
+	require.Equal(t, "/src/github.com/golang/go", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.Equal(t, "git@github.com:golang/go.git", url)
+
+	require.Equal(t, "go-1999178051", proj.Slug())
+}
+
+func TestNewFromIDBitbucketFullURL(t *testing.T) {
+	proj, err := NewFromID("git@bitbucket.org:zzzeek/dogpile.cache.git", cfg)
+	require.NoError(t, err, "NewFromID() failed")
+	require.NotEqual(t, nil, proj)
+	require.Equal(t, "bitbucket.org", proj.HostingPlatform)
+	require.Equal(t, "zzzeek", proj.OrganisationName)
+	require.Equal(t, "dogpile.cache", proj.RepositoryName)
+	require.Equal(t, "/src/bitbucket.org/zzzeek/dogpile.cache", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.Equal(t, "git@bitbucket.org:zzzeek/dogpile.cache.git", url)
+
+	require.Equal(t, "dogpile.cache-669781729", proj.Slug())
+}

--- a/pkg/project/search.go
+++ b/pkg/project/search.go
@@ -43,7 +43,7 @@ func projectMatch(expr string, projects []*Project) *Project {
 	// Then, extend match to the organisation name as well
 	names = []string{}
 	for _, p := range projects {
-		names = append(names, p.id)
+		names = append(names, p.OrganisationName+"/"+p.RepositoryName)
 	}
 	matches = fuzzy.Find(expr, names)
 	if matches.Len() >= 1 {
@@ -87,7 +87,6 @@ func GetAllProjects(sourceDir string) ([]*Project, error) {
 					HostingPlatform:  hostingPlatform,
 					OrganisationName: org,
 					RepositoryName:   repo,
-					id:               filepath.Join(org, repo),
 					Path:             projPath,
 				})
 			}


### PR DESCRIPTION
## Why

We should support full git url in the clone command, like `$ bud clone git@github.com:golang/go.git`.

See #128

## How

- Add support for git url for Github and Bitbucket in project ID parsing and *remote_url* generation

