### PR TITLE
Enable PipEnv quiet flag to hide courtesy notice about virtualenv

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/devbuddy/devbuddy/pkg/env"
 	"github.com/devbuddy/devbuddy/pkg/termui"
 )
 
@@ -39,6 +40,14 @@ func (e *Executor) SetCwd(cwd string) *Executor {
 // SetEnv changes the environment variables that will be used to run the command
 func (e *Executor) SetEnv(env []string) *Executor {
 	e.cmd.Env = env
+	return e
+}
+
+// SetEnvVar sets a single variable in the environment that will be used to run the command
+func (e *Executor) SetEnvVar(name, value string) *Executor {
+	env := env.New(e.cmd.Env)
+	env.Set(name, value)
+	e.cmd.Env = env.Environ()
 	return e
 }
 

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -77,10 +77,10 @@ func TestSetEnv(t *testing.T) {
 }
 
 func TestSetEnvVar(t *testing.T) {
-	output, err := NewShell("echo $POIPOI").SetEnvVar("POIPOI", "something").Capture()
+	output, err := NewShell("echo ${V1}-${V2}").SetEnvVar("V1", "v1").SetEnvVar("V2", "v2").Capture()
 
 	require.NoError(t, err)
-	require.Equal(t, "something\n", output)
+	require.Equal(t, "v1-v2\n", output)
 }
 
 func TestPrefix(t *testing.T) {

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -76,6 +76,13 @@ func TestSetEnv(t *testing.T) {
 	require.Equal(t, "something\n", output)
 }
 
+func TestSetEnvVar(t *testing.T) {
+	output, err := NewShell("echo $POIPOI").SetEnvVar("POIPOI", "something").Capture()
+
+	require.NoError(t, err)
+	require.Equal(t, "something\n", output)
+}
+
 func TestPrefix(t *testing.T) {
 	buf := &bytes.Buffer{}
 

--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -56,7 +56,7 @@ func (p *pipfileRun) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipfileRun) run(ctx *context) error {
-	err := command(ctx, "pipenv", "install", "--system", "--dev").Run()
+	err := command(ctx, "pipenv", "install", "--system", "--dev").SetEnvVar("PIPENV_QUIET", "1").Run()
 	if err != nil {
 		return fmt.Errorf("pipenv failed: %s", err)
 	}


### PR DESCRIPTION
## Why

PipEnv is a bit annoying with its "Courtesy Notice...":

```
$ bud up
◼︎ Python (3.7.0)
◼︎ Python develop
◼︎ Pipfile
  ▪︎install dependencies from the Pipfile
  Running: pipenv install --system --dev
  Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project. You can set PIPENV_IGNORE_VIRTUALENVS=1 to force pipenv to ignore that environment and create its own instead. You can set PIPENV_VERBOSITY=-1 to suppress this warning.
  Installing dependencies from Pipfile.lock (a34869)…
```

Resolves #170

## How

Enable the quiet mode with the `PIPENV_QUIET` envvar:

```
$ bud up
◼︎ Python (3.7.0)
◼︎ Python develop
◼︎ Pipfile
  ▪︎install dependencies from the Pipfile
  Running: pipenv install --system --dev
  Installing dependencies from Pipfile.lock (a34869)…
```
