### PR TITLE
Fix error message displayed twice in task.Runner

### DIFF
--- a/pkg/tasks/runner.go
+++ b/pkg/tasks/runner.go
@@ -49,7 +49,7 @@ func RunAll(cfg *config.Config, proj *project.Project, ui *termui.UI) (success b
 		err = runTask(ctx, task)
 		if err != nil {
 			ctx.ui.TaskError(err)
-			return false, err
+			return false, nil
 		}
 	}
 


### PR DESCRIPTION
## Why

An error was displayed AND returned in `task.Runner`

Resolves: #153

## How


