### PR TITLE
Add badge with link to Gitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CircleCI](https://circleci.com/gh/devbuddy/devbuddy.svg?style=svg)](https://circleci.com/gh/devbuddy/devbuddy)
 [![GitHub Release](https://img.shields.io/github/release/devbuddy/devbuddy.svg)](https://github.com/devbuddy/devbuddy/releases/latest)
 [![GitHub Release Date](https://img.shields.io/github/release-date/devbuddy/devbuddy.svg)](https://github.com/devbuddy/devbuddy/releases/latest)
+[![Gitter](https://img.shields.io/badge/Discussions%20on-Gitter-crimson.svg?logo=gitter&style=flat)](https://gitter.im/devbuddy)
 
 Contents:
 - [Install DevBuddy](#install)


### PR DESCRIPTION
## Why

The current chat room is on mtlpy.slack.com, which is private (registration is free, but the room is not public, linkable) 

## How

I created a Gitter room linked to the github repo DevBuddy: https://gitter.im/devbuddy/Lobby 

- Add a badge in the README with a link to this room 

