### PR TITLE
Ignore error from needed() method when testing if it should run

### DIFF
--- a/pkg/tasks/runner.go
+++ b/pkg/tasks/runner.go
@@ -79,7 +79,7 @@ func runAction(ctx *context, action taskAction) error {
 	desc := action.description()
 
 	needed, err := action.needed(ctx)
-	if err != nil {
+	if !needed && err != nil {
 		return fmt.Errorf("The task action (%s) failed to detect whether it need to run: %s", desc, err)
 	}
 


### PR DESCRIPTION
## Why

The `needed()` method on actions is called twice: 
1. when testing whether the action must run
2. after the action ran, to confirm its impact

We should ignore the error in 1. and use it to explain why the task failed in 2.

## How


