### PR TITLE
Create a simple Apt task

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,4 @@ Authors:
 - Pior Bastida (pior@pbastida.net)
 - Mathieu Leduc-Hamel (mathieu.leduchamel@shopify.com)
 - Emmanuel Milou <manumilou@mykolab.com>
+- John Duff @jduff

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -50,7 +50,8 @@ func (a *aptInstall) needed(ctx *context) (bool, error) {
 		}
 	}
 
-	return len(a.missingPackageNames) > 0, nil
+	err := fmt.Errorf("packages are not installed: %s", strings.Join(a.missingPackageNames, ", "))
+	return len(a.missingPackageNames) > 0, err
 }
 
 func (a *aptInstall) run(ctx *context) error {

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -40,8 +40,8 @@ func (a *aptInstall) description() string {
 
 func (a *aptInstall) needed(ctx *context) (bool, error) {
 	result := commandSilent(ctx, "dpkg", "-s", a.packageName).Capture()
-	if result.Code == -1 {
-		return false, fmt.Errorf("failed to check if package is installed: %s", result.Error)
+	if result.LaunchError != nil {
+		return false, fmt.Errorf("failed to check if package is installed: %s", result.LaunchError)
 	}
 	return result.Code != 0, nil
 }

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -40,7 +40,7 @@ func (a *aptInstall) description() string {
 
 func (a *aptInstall) needed(ctx *context) (bool, error) {
 	result := commandSilent(ctx, "dpkg", "-s", a.packageName).Capture()
-	if result.Error != nil {
+	if result.Code == -1 {
 		return false, fmt.Errorf("failed to check if package is installed: %s", result.Error)
 	}
 	return result.Code != 0, nil

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -39,18 +39,18 @@ func (a *aptInstall) description() string {
 }
 
 func (a *aptInstall) needed(ctx *context) (bool, error) {
-	code, err := commandSilent(ctx, "dpkg", "-s", a.packageName).RunWithCode()
-	if err != nil {
-		return false, fmt.Errorf("failed to check if package is installed: %s", err)
+	result := commandSilent(ctx, "dpkg", "-s", a.packageName).Capture()
+	if result.Error != nil {
+		return false, fmt.Errorf("failed to check if package is installed: %s", result.Error)
 	}
-	return code != 0, nil
+	return result.Code != 0, nil
 }
 
 func (a *aptInstall) run(ctx *context) error {
-	err := command(ctx, "apt", "install", a.packageName).Run()
+	result := command(ctx, "apt", "install", a.packageName).Run()
 
-	if err != nil {
-		return fmt.Errorf("Apt failed: %s", err)
+	if result.Error != nil {
+		return fmt.Errorf("Apt failed: %s", result.Error)
 	}
 
 	return nil

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -54,10 +54,13 @@ func (a *aptInstall) needed(ctx *context) (bool, error) {
 }
 
 func (a *aptInstall) run(ctx *context) error {
+	result := sudoCommand(ctx, "apt-get", "update").Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to run apt-get update: %s", result.Error)
+	}
+
 	args := append([]string{"install", "--no-install-recommends", "-y"}, a.missingPackageNames...)
-
-	result := command(ctx, "apt-get", args...).Run()
-
+	result = sudoCommand(ctx, "apt-get", args...).Run()
 	if result.Error != nil {
 		return fmt.Errorf("failed to run apt-get install: %s", result.Error)
 	}

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -1,0 +1,57 @@
+package tasks
+
+import (
+	"fmt"
+	"strings"
+)
+
+func init() {
+	t := registerTaskDefinition("apt")
+	t.name = "Apt"
+	t.parser = parserApt
+}
+
+func parserApt(config *taskConfig, task *Task) error {
+	packages, err := config.getListOfStrings()
+	if err != nil {
+		return err
+	}
+
+	if len(packages) == 0 {
+		return fmt.Errorf("no Apt packages specified")
+	}
+
+	task.header = strings.Join(packages, ", ")
+
+	for _, p := range packages {
+		task.addAction(&aptInstall{packageName: p})
+	}
+
+	return nil
+}
+
+type aptInstall struct {
+	packageName string
+}
+
+func (a *aptInstall) description() string {
+	return fmt.Sprintf("installing %s", a.packageName)
+}
+
+func (a *aptInstall) needed(ctx *context) (bool, error) {
+	code, err := commandSilent(ctx, "dpkg", "-s", a.packageName).RunWithCode()
+	if err != nil {
+		return false, fmt.Errorf("failed to check if package is installed: %s", err)
+	}
+	return code != 0, nil
+}
+
+func (a *aptInstall) run(ctx *context) error {
+	err := command(ctx, "apt", "install", a.packageName).Run()
+
+	if err != nil {
+		return fmt.Errorf("Apt failed: %s", err)
+	}
+
+	return nil
+}

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -47,10 +47,10 @@ func (a *aptInstall) needed(ctx *context) (bool, error) {
 }
 
 func (a *aptInstall) run(ctx *context) error {
-	result := command(ctx, "apt", "install", a.packageName).Run()
+	result := command(ctx, "apt-get", "install", "-y", a.packageName).Run()
 
 	if result.Error != nil {
-		return fmt.Errorf("Apt failed: %s", result.Error)
+		return fmt.Errorf("failed to run apt-get install: %s", result.Error)
 	}
 
 	return nil

--- a/pkg/tasks/apt_test.go
+++ b/pkg/tasks/apt_test.go
@@ -1,0 +1,25 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestApt(t *testing.T) {
+	task := ensureLoadTestTask(t, `
+apt:
+  - curl
+  - git
+`)
+
+	require.Equal(t, "curl, git", task.header)
+	require.Equal(t, 1, len(task.actions))
+}
+
+func TestAptEmpty(t *testing.T) {
+	_, err := loadTestTask(t, `
+apt: []
+`)
+	require.Error(t, err)
+}

--- a/pkg/tasks/helper.go
+++ b/pkg/tasks/helper.go
@@ -24,6 +24,10 @@ func asString(value interface{}) (string, error) {
 
 func command(ctx *context, program string, args ...string) *executor.Executor {
 	ctx.ui.TaskCommand(program, args...)
+	return commandSilent(ctx, program, args...)
+}
+
+func commandSilent(ctx *context, program string, args ...string) *executor.Executor {
 	return executor.New(program, args...).SetOutputPrefix("  ").SetCwd(ctx.proj.Path).SetEnv(ctx.env.Environ())
 }
 

--- a/pkg/tasks/helper.go
+++ b/pkg/tasks/helper.go
@@ -27,6 +27,13 @@ func command(ctx *context, program string, args ...string) *executor.Executor {
 	return commandSilent(ctx, program, args...)
 }
 
+func sudoCommand(ctx *context, program string, args ...string) *executor.Executor {
+	args = append([]string{program}, args...)
+	program = "sudo"
+	ctx.ui.TaskCommand(program, args...)
+	return commandSilent(ctx, program, args...)
+}
+
 func commandSilent(ctx *context, program string, args ...string) *executor.Executor {
 	return executor.New(program, args...).SetOutputPrefix("  ").SetCwd(ctx.proj.Path).SetEnv(ctx.env.Environ())
 }

--- a/pkg/tasks/task_config.go
+++ b/pkg/tasks/task_config.go
@@ -46,6 +46,15 @@ func (c *taskConfig) getStringPropertyDefault(name string, defaultValue string, 
 	return str, nil
 }
 
+func (c *taskConfig) getListOfStrings() ([]string, error) {
+	strings, ok := c.payload.([]string)
+	if ok {
+		return strings, nil
+	}
+
+	return nil, fmt.Errorf("not a list of strings: type %T (\"%+v\")", c.payload, c.payload)
+}
+
 func parseTaskConfig(definition interface{}) (*taskConfig, error) {
 	val := reflect.ValueOf(definition)
 

--- a/pkg/tasks/task_config.go
+++ b/pkg/tasks/task_config.go
@@ -47,12 +47,21 @@ func (c *taskConfig) getStringPropertyDefault(name string, defaultValue string, 
 }
 
 func (c *taskConfig) getListOfStrings() ([]string, error) {
-	strings, ok := c.payload.([]string)
-	if ok {
-		return strings, nil
+
+	elements, ok := c.payload.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("not a list of strings: type %T (\"%+v\")", c.payload, c.payload)
 	}
 
-	return nil, fmt.Errorf("not a list of strings: type %T (\"%+v\")", c.payload, c.payload)
+	var strings []string
+	for _, element := range elements {
+		str, ok := element.(string)
+		if !ok {
+			return nil, fmt.Errorf("not a list of strings: invalid element: type %T (\"%+v\")", element, element)
+		}
+		strings = append(strings, str)
+	}
+	return strings, nil
 }
 
 func parseTaskConfig(definition interface{}) (*taskConfig, error) {

--- a/pkg/tasks/task_config_test.go
+++ b/pkg/tasks/task_config_test.go
@@ -60,3 +60,36 @@ func TestTaskConfigMapWithInvalidValues(t *testing.T) {
 	require.Contains(t, err.Error(), "3.6")
 	require.Contains(t, err.Error(), "float64")
 }
+
+func TestTaskConfigListOfStrings(t *testing.T) {
+	config := &taskConfig{name: "test", payload: []string{"one", "two"}}
+
+	result, err := config.getListOfStrings()
+	require.NoError(t, err)
+	require.Equal(t, []string{"one", "two"}, result)
+}
+
+func TestTaskConfigListOfStringsEmpty(t *testing.T) {
+	config := &taskConfig{name: "test", payload: []string{}}
+
+	result, err := config.getListOfStrings()
+	require.NoError(t, err)
+	require.Equal(t, []string{}, result)
+}
+
+func TestTaskConfigListOfStringsInvalid(t *testing.T) {
+	config := &taskConfig{name: "test", payload: "plop"}
+	_, err := config.getListOfStrings()
+	require.Error(t, err)
+	require.Equal(t, "not a list of strings: type string (\"plop\")", err.Error())
+
+	config = &taskConfig{name: "test", payload: true}
+	_, err = config.getListOfStrings()
+	require.Error(t, err)
+	require.Equal(t, "not a list of strings: type bool (\"true\")", err.Error())
+
+	config = &taskConfig{name: "test", payload: 1.23}
+	_, err = config.getListOfStrings()
+	require.Error(t, err)
+	require.Equal(t, "not a list of strings: type float64 (\"1.23\")", err.Error())
+}

--- a/pkg/tasks/task_config_test.go
+++ b/pkg/tasks/task_config_test.go
@@ -62,7 +62,8 @@ func TestTaskConfigMapWithInvalidValues(t *testing.T) {
 }
 
 func TestTaskConfigListOfStrings(t *testing.T) {
-	config := &taskConfig{name: "test", payload: []string{"one", "two"}}
+	value := []interface{}{"one", "two"}
+	config := &taskConfig{name: "test", payload: value}
 
 	result, err := config.getListOfStrings()
 	require.NoError(t, err)
@@ -70,26 +71,25 @@ func TestTaskConfigListOfStrings(t *testing.T) {
 }
 
 func TestTaskConfigListOfStringsEmpty(t *testing.T) {
-	config := &taskConfig{name: "test", payload: []string{}}
+	config := &taskConfig{name: "test", payload: []interface{}{}}
 
 	result, err := config.getListOfStrings()
 	require.NoError(t, err)
-	require.Equal(t, []string{}, result)
+	require.Equal(t, []string(nil), result)
 }
 
-func TestTaskConfigListOfStringsInvalid(t *testing.T) {
+func TestTaskConfigListOfStringsInvalidElement(t *testing.T) {
+	config := &taskConfig{name: "test", payload: []interface{}{"one", 2}}
+
+	_, err := config.getListOfStrings()
+	require.Error(t, err)
+	require.Equal(t, "not a list of strings: invalid element: type int (\"2\")", err.Error())
+}
+
+func TestTaskConfigListOfStringsInvalidType(t *testing.T) {
 	config := &taskConfig{name: "test", payload: "plop"}
+
 	_, err := config.getListOfStrings()
 	require.Error(t, err)
 	require.Equal(t, "not a list of strings: type string (\"plop\")", err.Error())
-
-	config = &taskConfig{name: "test", payload: true}
-	_, err = config.getListOfStrings()
-	require.Error(t, err)
-	require.Equal(t, "not a list of strings: type bool (\"true\")", err.Error())
-
-	config = &taskConfig{name: "test", payload: 1.23}
-	_, err = config.getListOfStrings()
-	require.Error(t, err)
-	require.Equal(t, "not a list of strings: type float64 (\"1.23\")", err.Error())
 }


### PR DESCRIPTION
## Why

Start implementing #180 

## How

- Add a simple `Apt` task that run `apt install <pkg>` if `dpkg -s <pkg>` fails
- Ignore the OS compatibility issue for now.

