### PR TITLE
Add support for Github HTTPS remote URL

### DIFF
--- a/pkg/project/hosting.go
+++ b/pkg/project/hosting.go
@@ -24,12 +24,17 @@ func newHostingInfoByURL(url string) (*hostingInfo, error) {
 
 	reGithubFull := regexp.MustCompile(`^([\w.-]+)/([\w.-]+)$`)
 	if match := reGithubFull.FindStringSubmatch(url); match != nil {
-		return newGithubHostingInfo(match[1], match[2]), nil
+		return newGithubHostingInfo("", match[1], match[2]), nil
 	}
 
 	reGithubGitURL := regexp.MustCompile(`^git@github.com:([\w.-]+)/([\w.-]+).git$`)
 	if match := reGithubGitURL.FindStringSubmatch(url); match != nil {
-		return newGithubHostingInfo(match[1], match[2]), nil
+		return newGithubHostingInfo(url, match[1], match[2]), nil
+	}
+
+	reGithubGitHTTPURL := regexp.MustCompile(`^https://github.com/([\w.-]+)/([\w.-]+).git$`)
+	if match := reGithubGitHTTPURL.FindStringSubmatch(url); match != nil {
+		return newGithubHostingInfo(url, match[1], match[2]), nil
 	}
 
 	reBitbucketGitURL := regexp.MustCompile(`^git@bitbucket.org:([\w.-]+)/([\w.-]+).git$`)
@@ -46,12 +51,15 @@ func newHostingInfoByPath(path string) *hostingInfo {
 	}
 }
 
-func newGithubHostingInfo(organisation, repository string) *hostingInfo {
+func newGithubHostingInfo(remoteURL, organisation, repository string) *hostingInfo {
+	if remoteURL == "" {
+		remoteURL = fmt.Sprintf("git@github.com:%s/%s.git", organisation, repository)
+	}
 	return &hostingInfo{
 		platform:     "github.com",
 		organisation: organisation,
 		repository:   repository,
-		remoteURL:    fmt.Sprintf("git@github.com:%s/%s.git", organisation, repository),
+		remoteURL:    remoteURL,
 	}
 }
 

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -48,6 +48,20 @@ func TestNewFromIDGithubFullURL(t *testing.T) {
 	require.Equal(t, "go-1999178051", proj.Slug())
 }
 
+func TestNewFromIDGithubFullHTTPURL(t *testing.T) {
+	proj, err := NewFromID("https://github.com/golang/go.git", cfg)
+	require.NoError(t, err, "NewFromID() failed")
+	require.NotEqual(t, nil, proj)
+	require.Equal(t, "go", proj.Name())
+	require.Equal(t, "github.com:golang/go", proj.FullName())
+	require.Equal(t, "/src/github.com/golang/go", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.Equal(t, "https://github.com/golang/go.git", url)
+
+	require.Equal(t, "go-1999178051", proj.Slug())
+}
+
 func TestNewFromIDBitbucketFullURL(t *testing.T) {
 	proj, err := NewFromID("git@bitbucket.org:zzzeek/dogpile.cache.git", cfg)
 	require.NoError(t, err, "NewFromID() failed")


### PR DESCRIPTION
## Why

When cloning a project from a host that does not have a SSH key registered on Github, the HTTPS url must be used.

## How

- Keep the url provided to the `bud clone <url>` and use it as remote_url

