### PR TITLE
Build binaries in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,17 @@ jobs:
       - run: dep ensure -v -vendor-only
       - run: script/lint
 
+  binaries:
+    docker:
+      - image: devbuddy/testing:latest
+    working_directory: /go/src/github.com/devbuddy/devbuddy
+    steps:
+      - checkout
+      - run: dep ensure -v -vendor-only
+      - run: script/buildall
+      - store_artifacts:
+          path: dist/
+
   deploy-release:
     docker:
       - image: devbuddy/testing:latest
@@ -67,6 +78,10 @@ workflows:
             tags:
               only: /.*/
       - lint:
+          filters:
+            tags:
+              only: /.*/
+      - binaries:
           filters:
             tags:
               only: /.*/


### PR DESCRIPTION
## Why

Making binaries from branches available will help doing manual testing on different architectures.

## How

- Store binaries as CircleCI artifacts: https://circleci.com/docs/2.0/artifacts/#artifacts-overview
