### PR TITLE
Add a executor Result type

### DIFF
--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -41,7 +41,7 @@ func customCommandRun(cmd *cobra.Command, args []string) error {
 
 	ui.CommandHeader(cmdline)
 
-	return executor.NewShell(cmdline).SetCwd(proj.Path).Run()
+	return executor.NewShell(cmdline).SetCwd(proj.Path).Run().Error
 }
 
 func buildCustomCommands() {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -24,10 +24,10 @@ type Executor struct {
 
 // Result represents the result of a command execution
 type Result struct {
-	Code       int    // code returned by the process
-	Error      error  // error including a non-zero return code
-	StartError error  // error when starting the process
-	Output     string // command output if captured, otherwise empty
+	Code        int    // code returned by the process
+	Error       error  // error about the process launch and exit
+	LaunchError error  // error about the process launch
+	Output      string // command output if captured, otherwise empty
 }
 
 // New returns an *Executor that will run the program with arguments
@@ -126,10 +126,6 @@ func (e *Executor) runWithOutputFilter() error {
 func (e *Executor) buildResult(output string, err error) *Result {
 	code := 0
 
-	// We probably don't need this:
-	// if err == nil {
-	// 	code = e.cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-	// }
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			code = exitError.Sys().(syscall.WaitStatus).ExitStatus()
@@ -145,10 +141,10 @@ func (e *Executor) buildResult(output string, err error) *Result {
 	}
 
 	return &Result{
-		Error:      errForCode,
-		StartError: err,
-		Code:       code,
-		Output:     output,
+		Error:       errForCode,
+		LaunchError: err,
+		Code:        code,
+		Output:      output,
 	}
 }
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -113,7 +113,7 @@ func (e *Executor) runWithOutputFilter() error {
 	return e.cmd.Wait()
 }
 
-// Run executes the command. Returns a Result. Code is -1 if the command failed to start
+// Run executes the command and returns a Result
 func (e *Executor) Run() *Result {
 	err := e.runWithOutputFilter()
 	return buildResult("", err)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -24,9 +24,8 @@ type Executor struct {
 
 // Result represents the result of a command execution
 type Result struct {
-	Code  int
-	Error error
-	// Success bool
+	Code   int
+	Error  error
 	Output string
 }
 
@@ -146,14 +145,13 @@ func (e *Executor) buildResult(output string, err error) *Result {
 		err = fmt.Errorf("command failed with exit code %d", code)
 	}
 	return &Result{
-		Error: err,
-		Code:  code,
-		// Success: err == nil && code == 0,
+		Error:  err,
+		Code:   code,
 		Output: output,
 	}
 }
 
-// Run executes the command. Returns a Result
+// Run executes the command. Returns a Result. Code is -1 if the command failed to start
 func (e *Executor) Run() *Result {
 	err := e.runWithOutputFilter()
 	return e.buildResult("", err)

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -12,6 +12,7 @@ func TestCommandFalse(t *testing.T) {
 
 	require.Error(t, result.Error)
 	require.Equal(t, "command failed with exit code 1", result.Error.Error())
+	require.NoError(t, result.StartError)
 	require.Equal(t, 1, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -20,6 +21,7 @@ func TestCommandTrue(t *testing.T) {
 	result := New("true").Run()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -37,6 +39,7 @@ func TestShellFalse(t *testing.T) {
 
 	require.Error(t, result.Error)
 	require.Equal(t, "command failed with exit code 1", result.Error.Error())
+	require.NoError(t, result.StartError)
 	require.Equal(t, 1, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -45,6 +48,7 @@ func TestShellCapture(t *testing.T) {
 	result := NewShell("echo poipoi").Capture()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "poipoi\n", result.Output)
 }
@@ -53,6 +57,7 @@ func TestShellCaptureAndTrim(t *testing.T) {
 	result := NewShell("echo poipoi").CaptureAndTrim()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "poipoi", result.Output)
 }
@@ -61,6 +66,7 @@ func TestShellCapturePWD(t *testing.T) {
 	result := NewShell("echo $PWD").SetCwd("/bin").Capture()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "/bin\n", result.Output)
 }
@@ -69,10 +75,14 @@ func TestCommandNotFound(t *testing.T) {
 	result := New("cmd-that-does-not-exist").Run()
 
 	require.Error(t, result.Error)
-	require.Equal(t, -1, result.Code)
 	require.Equal(t,
 		"command failed with: exec: \"cmd-that-does-not-exist\": executable file not found in $PATH",
 		result.Error.Error())
+	require.Error(t, result.StartError)
+	require.Equal(t,
+		"command failed with: exec: \"cmd-that-does-not-exist\": executable file not found in $PATH",
+		result.StartError.Error())
+	require.Equal(t, 0, result.Code)
 	require.Equal(t, "", result.Output)
 }
 
@@ -80,6 +90,7 @@ func TestSetEnv(t *testing.T) {
 	result := NewShell("echo $POIPOI").SetEnv([]string{"POIPOI=something"}).Capture()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "something\n", result.Output)
 }
@@ -88,6 +99,7 @@ func TestSetEnvVar(t *testing.T) {
 	result := NewShell("echo ${V1}-${V2}").SetEnvVar("V1", "v1").SetEnvVar("V2", "v2").Capture()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "v1-v2\n", result.Output)
 }
@@ -101,6 +113,7 @@ func TestPrefix(t *testing.T) {
 	result := executor.Run()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "---line1\n---line2\n---line3\n", buf.String())
 }
@@ -115,6 +128,7 @@ func TestFilter(t *testing.T) {
 	result := executor.Run()
 
 	require.NoError(t, result.Error)
+	require.NoError(t, result.StartError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "line1\nline3\n", buf.String())
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -7,80 +7,89 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandFalseWithoutCode(t *testing.T) {
-	err := New("false").Run()
-
-	require.Error(t, err)
-}
-
 func TestCommandFalse(t *testing.T) {
-	code, err := New("false").RunWithCode()
+	result := New("false").Run()
 
-	require.NoError(t, err)
-	require.Equal(t, 1, code)
+	require.Error(t, result.Error)
+	require.Equal(t, "command failed with exit code 1", result.Error.Error())
+	require.Equal(t, 1, result.Code)
+	require.Equal(t, "", result.Output)
 }
 
 func TestCommandTrue(t *testing.T) {
-	code, err := New("true").RunWithCode()
+	result := New("true").Run()
 
-	require.NoError(t, err)
-	require.Equal(t, 0, code)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "", result.Output)
 }
 
 func TestShellTrue(t *testing.T) {
-	code, err := NewShell("true").RunWithCode()
+	result := NewShell("true").Run()
 
-	require.NoError(t, err)
-	require.Equal(t, 0, code)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "", result.Output)
 }
 
 func TestShellFalse(t *testing.T) {
-	code, err := NewShell("false").RunWithCode()
+	result := NewShell("false").Run()
 
-	require.NoError(t, err)
-	require.Equal(t, 1, code)
+	require.Error(t, result.Error)
+	require.Equal(t, "command failed with exit code 1", result.Error.Error())
+	require.Equal(t, 1, result.Code)
+	require.Equal(t, "", result.Output)
 }
 
 func TestShellCapture(t *testing.T) {
-	output, err := NewShell("echo poipoi").Capture()
+	result := NewShell("echo poipoi").Capture()
 
-	require.NoError(t, err)
-	require.Equal(t, "poipoi\n", output)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "poipoi\n", result.Output)
 }
 
 func TestShellCaptureAndTrim(t *testing.T) {
-	output, err := NewShell("echo poipoi").CaptureAndTrim()
+	result := NewShell("echo poipoi").CaptureAndTrim()
 
-	require.NoError(t, err)
-	require.Equal(t, "poipoi", output)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "poipoi", result.Output)
 }
 
 func TestShellCapturePWD(t *testing.T) {
-	output, err := NewShell("echo $PWD").SetCwd("/bin").Capture()
+	result := NewShell("echo $PWD").SetCwd("/bin").Capture()
 
-	require.NoError(t, err)
-	require.Equal(t, "/bin\n", output)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "/bin\n", result.Output)
 }
 
 func TestCommandNotFound(t *testing.T) {
-	code, err := New("never-ever-cmd").RunWithCode()
+	result := New("never-ever-cmd").Run()
 
-	require.Error(t, err)
-	require.Equal(t, -1, code)
+	require.Error(t, result.Error)
+	require.Equal(t, -1, result.Code)
+	require.Equal(t,
+		"command failed with: exec: \"never-ever-cmd\": executable file not found in $PATH",
+		result.Error.Error())
+	require.Equal(t, "", result.Output)
 }
 
 func TestSetEnv(t *testing.T) {
-	output, err := NewShell("echo $POIPOI").SetEnv([]string{"POIPOI=something"}).Capture()
+	result := NewShell("echo $POIPOI").SetEnv([]string{"POIPOI=something"}).Capture()
 
-	require.NoError(t, err)
-	require.Equal(t, "something\n", output)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "something\n", result.Output)
 }
 
 func TestSetEnvVar(t *testing.T) {
-	output, err := NewShell("echo ${V1}-${V2}").SetEnvVar("V1", "v1").SetEnvVar("V2", "v2").Capture()
+	result := NewShell("echo ${V1}-${V2}").SetEnvVar("V1", "v1").SetEnvVar("V2", "v2").Capture()
 
-	require.NoError(t, err)
-	require.Equal(t, "v1-v2\n", output)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
+	require.Equal(t, "v1-v2\n", result.Output)
 }
 
 func TestPrefix(t *testing.T) {
@@ -89,9 +98,10 @@ func TestPrefix(t *testing.T) {
 	executor := NewShell("echo \"line1\nline2\nline3\"")
 	executor.outputWriter = buf
 	executor.SetOutputPrefix("---")
-	err := executor.Run()
+	result := executor.Run()
 
-	require.NoError(t, err)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
 	require.Equal(t, "---line1\n---line2\n---line3\n", buf.String())
 }
 
@@ -102,8 +112,9 @@ func TestFilter(t *testing.T) {
 	executor.outputWriter = buf
 	executor.AddOutputFilter("line2")
 	executor.AddOutputFilter("line4")
-	err := executor.Run()
+	result := executor.Run()
 
-	require.NoError(t, err)
+	require.NoError(t, result.Error)
+	require.Equal(t, 0, result.Code)
 	require.Equal(t, "line1\nline3\n", buf.String())
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -66,12 +66,12 @@ func TestShellCapturePWD(t *testing.T) {
 }
 
 func TestCommandNotFound(t *testing.T) {
-	result := New("never-ever-cmd").Run()
+	result := New("cmd-that-does-not-exist").Run()
 
 	require.Error(t, result.Error)
 	require.Equal(t, -1, result.Code)
 	require.Equal(t,
-		"command failed with: exec: \"never-ever-cmd\": executable file not found in $PATH",
+		"command failed with: exec: \"cmd-that-does-not-exist\": executable file not found in $PATH",
 		result.Error.Error())
 	require.Equal(t, "", result.Output)
 }

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -12,7 +12,7 @@ func TestCommandFalse(t *testing.T) {
 
 	require.Error(t, result.Error)
 	require.Equal(t, "command failed with exit code 1", result.Error.Error())
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 1, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -21,7 +21,7 @@ func TestCommandTrue(t *testing.T) {
 	result := New("true").Run()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -39,7 +39,7 @@ func TestShellFalse(t *testing.T) {
 
 	require.Error(t, result.Error)
 	require.Equal(t, "command failed with exit code 1", result.Error.Error())
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 1, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -48,7 +48,7 @@ func TestShellCapture(t *testing.T) {
 	result := NewShell("echo poipoi").Capture()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "poipoi\n", result.Output)
 }
@@ -57,7 +57,7 @@ func TestShellCaptureAndTrim(t *testing.T) {
 	result := NewShell("echo poipoi").CaptureAndTrim()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "poipoi", result.Output)
 }
@@ -66,7 +66,7 @@ func TestShellCapturePWD(t *testing.T) {
 	result := NewShell("echo $PWD").SetCwd("/bin").Capture()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "/bin\n", result.Output)
 }
@@ -78,10 +78,10 @@ func TestCommandNotFound(t *testing.T) {
 	require.Equal(t,
 		"command failed with: exec: \"cmd-that-does-not-exist\": executable file not found in $PATH",
 		result.Error.Error())
-	require.Error(t, result.StartError)
+	require.Error(t, result.LaunchError)
 	require.Equal(t,
 		"command failed with: exec: \"cmd-that-does-not-exist\": executable file not found in $PATH",
-		result.StartError.Error())
+		result.LaunchError.Error())
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "", result.Output)
 }
@@ -90,7 +90,7 @@ func TestSetEnv(t *testing.T) {
 	result := NewShell("echo $POIPOI").SetEnv([]string{"POIPOI=something"}).Capture()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "something\n", result.Output)
 }
@@ -99,7 +99,7 @@ func TestSetEnvVar(t *testing.T) {
 	result := NewShell("echo ${V1}-${V2}").SetEnvVar("V1", "v1").SetEnvVar("V2", "v2").Capture()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "v1-v2\n", result.Output)
 }
@@ -113,7 +113,7 @@ func TestPrefix(t *testing.T) {
 	result := executor.Run()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "---line1\n---line2\n---line3\n", buf.String())
 }
@@ -128,7 +128,7 @@ func TestFilter(t *testing.T) {
 	result := executor.Run()
 
 	require.NoError(t, result.Error)
-	require.NoError(t, result.StartError)
+	require.NoError(t, result.LaunchError)
 	require.Equal(t, 0, result.Code)
 	require.Equal(t, "line1\nline3\n", buf.String())
 }

--- a/pkg/executor/result.go
+++ b/pkg/executor/result.go
@@ -1,0 +1,40 @@
+package executor
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// Result represents the result of a command execution
+type Result struct {
+	Code        int    // code returned by the process
+	Error       error  // error about the process launch and exit
+	LaunchError error  // error about the process launch
+	Output      string // command output if captured, otherwise empty
+}
+
+func buildResult(output string, err error) *Result {
+	code := 0
+
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			code = exitError.Sys().(syscall.WaitStatus).ExitStatus()
+			err = nil
+		} else {
+			err = fmt.Errorf("command failed with: %s", err)
+		}
+	}
+
+	errForCode := err
+	if code > 0 {
+		errForCode = fmt.Errorf("command failed with exit code %d", code)
+	}
+
+	return &Result{
+		Error:       errForCode,
+		LaunchError: err,
+		Code:        code,
+		Output:      output,
+	}
+}

--- a/pkg/helpers/git.go
+++ b/pkg/helpers/git.go
@@ -18,21 +18,21 @@ func NewGitRepo(path string) *GitRepo {
 }
 
 // GetRemoteURL returns the URL of the origin remote
-func (r *GitRepo) GetRemoteURL() (url string, err error) {
-	url, err = executor.New("git", "config", "--get", "remote.origin.url").SetCwd(r.path).CaptureAndTrim()
-	if err != nil {
-		return "", fmt.Errorf("failed to get the origin remote url: %s", err)
+func (r *GitRepo) GetRemoteURL() (string, error) {
+	result := executor.New("git", "config", "--get", "remote.origin.url").SetCwd(r.path).CaptureAndTrim()
+	if result.Error != nil {
+		return "", fmt.Errorf("failed to get the origin remote url: %s", result.Error)
 	}
-	return
+	return result.Output, nil
 }
 
 // GetCurrentBranch returns the name of the branch or "HEAD" for special cases
-func (r *GitRepo) GetCurrentBranch() (url string, err error) {
-	url, err = executor.New("git", "rev-parse", "--abbrev-ref", "HEAD").SetCwd(r.path).CaptureAndTrim()
-	if err != nil {
-		return "", fmt.Errorf("failed to get the current branch: %s", err)
+func (r *GitRepo) GetCurrentBranch() (string, error) {
+	result := executor.New("git", "rev-parse", "--abbrev-ref", "HEAD").SetCwd(r.path).CaptureAndTrim()
+	if result.Error != nil {
+		return "", fmt.Errorf("failed to get the current branch: %s", result.Error)
 	}
-	return
+	return result.Output, nil
 }
 
 func (r *GitRepo) buildGithubURL() (string, error) {

--- a/pkg/helpers/golang.go
+++ b/pkg/helpers/golang.go
@@ -63,9 +63,9 @@ func (g *Golang) Install() (err error) {
 		return
 	}
 
-	err = executor.New("tar", "--strip", "1", "-xzC", g.path, "-f", tarPath).Run()
-	if err != nil {
-		return fmt.Errorf("failed to extract %s to %s: %s", tarPath, g.path, err)
+	result := executor.New("tar", "--strip", "1", "-xzC", g.path, "-f", tarPath).Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to extract %s to %s: %s", tarPath, g.path, result.Error)
 	}
 
 	return nil

--- a/pkg/helpers/pyenv.go
+++ b/pkg/helpers/pyenv.go
@@ -13,11 +13,11 @@ type PyEnv struct {
 }
 
 func NewPyEnv() (*PyEnv, error) {
-	root, err := executor.New("pyenv", "root").CaptureAndTrim()
-	if err != nil {
-		return nil, fmt.Errorf("Command 'pyenv root' failed: %s", err)
+	result := executor.New("pyenv", "root").CaptureAndTrim()
+	if result.Error != nil {
+		return nil, fmt.Errorf("Command 'pyenv root' failed: %s", result.Error)
 	}
-	v := PyEnv{root: root}
+	v := PyEnv{root: result.Output}
 	return &v, nil
 }
 
@@ -36,12 +36,12 @@ func (p *PyEnv) VersionInstalled(version string) (installed bool, err error) {
 }
 
 func (p *PyEnv) listVersions() ([]string, error) {
-	output, err := executor.New("pyenv", "versions", "--bare", "--skip-aliases").Capture()
-	if err != nil {
-		return nil, fmt.Errorf("failed to run pyenv versions: %s", err)
+	result := executor.New("pyenv", "versions", "--bare", "--skip-aliases").Capture()
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to run pyenv versions: %s", result.Error)
 	}
 
-	versions := strings.Split(strings.TrimSpace(output), "\n")
+	versions := strings.Split(strings.TrimSpace(result.Output), "\n")
 	return versions, nil
 }
 

--- a/pkg/helpers/upgrader.go
+++ b/pkg/helpers/upgrader.go
@@ -67,7 +67,7 @@ func (u *Upgrader) Perform(ui *termui.UI, destinationPath string, sourceURL stri
 
 	ui.CommandHeader(cmdline)
 
-	return executor.NewShell(cmdline).Run()
+	return executor.NewShell(cmdline).Run().Error
 }
 
 // LatestRelease get latest release item for current platform

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -79,7 +79,7 @@ func (p *Project) Clone() (err error) {
 		return
 	}
 
-	return executor.New("git", "clone", p.hosting.remoteURL, p.Path).Run()
+	return executor.New("git", "clone", p.hosting.remoteURL, p.Path).Run().Error
 }
 
 // Create creates the project directory locally

--- a/pkg/tasks/custom.go
+++ b/pkg/tasks/custom.go
@@ -42,9 +42,8 @@ func (c *customAction) description() string {
 func (c *customAction) needed(ctx *context) (bool, error) {
 	result := shellSilent(ctx, c.condition).Run()
 
-	// Fail if we could not even start the command
-	if result.Code == -1 {
-		return false, fmt.Errorf("failed to run the condition command: %s", result.Error)
+	if result.StartError != nil {
+		return false, fmt.Errorf("failed to run the condition command: %s", result.StartError)
 	}
 
 	return result.Code != 0, nil

--- a/pkg/tasks/custom.go
+++ b/pkg/tasks/custom.go
@@ -40,17 +40,14 @@ func (c *customAction) description() string {
 }
 
 func (c *customAction) needed(ctx *context) (bool, error) {
-	code, err := shellSilent(ctx, c.condition).RunWithCode()
-	if err != nil {
-		return false, fmt.Errorf("failed to run the condition command: %s", err)
+	result := shellSilent(ctx, c.condition).Run()
+	if result.Error != nil {
+		return false, fmt.Errorf("failed to run the condition command: %s", result.Error)
 	}
-	return code != 0, nil
+	return result.Code != 0, nil
 }
 
 func (c *customAction) run(ctx *context) error {
-	err := shell(ctx, c.command).Run()
-	if err != nil {
-		return fmt.Errorf("command failed: %s", err)
-	}
-	return nil
+	result := shell(ctx, c.command).Run()
+	return result.Error
 }

--- a/pkg/tasks/custom.go
+++ b/pkg/tasks/custom.go
@@ -41,9 +41,12 @@ func (c *customAction) description() string {
 
 func (c *customAction) needed(ctx *context) (bool, error) {
 	result := shellSilent(ctx, c.condition).Run()
-	if result.Error != nil {
+
+	// Fail if we could not even start the command
+	if result.Code == -1 {
 		return false, fmt.Errorf("failed to run the condition command: %s", result.Error)
 	}
+
 	return result.Code != 0, nil
 }
 

--- a/pkg/tasks/custom.go
+++ b/pkg/tasks/custom.go
@@ -42,8 +42,8 @@ func (c *customAction) description() string {
 func (c *customAction) needed(ctx *context) (bool, error) {
 	result := shellSilent(ctx, c.condition).Run()
 
-	if result.StartError != nil {
-		return false, fmt.Errorf("failed to run the condition command: %s", result.StartError)
+	if result.LaunchError != nil {
+		return false, fmt.Errorf("failed to run the condition command: %s", result.LaunchError)
 	}
 
 	return result.Code != 0, nil

--- a/pkg/tasks/golang_dep.go
+++ b/pkg/tasks/golang_dep.go
@@ -32,9 +32,9 @@ func (p *golangDepInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *golangDepInstall) run(ctx *context) error {
-	err := command(ctx, "go", "get", "-u", "github.com/golang/dep/cmd/dep").Run()
-	if err != nil {
-		return fmt.Errorf("failed to install Go GolangDep: %s", err)
+	result := command(ctx, "go", "get", "-u", "github.com/golang/dep/cmd/dep").Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to install Go GolangDep: %s", result.Error)
 	}
 	return nil
 }
@@ -72,9 +72,9 @@ func (p *golangDepEnsure) needed(ctx *context) (bool, error) {
 }
 
 func (p *golangDepEnsure) run(ctx *context) error {
-	err := command(ctx, "dep", "ensure").Run()
-	if err != nil {
-		return fmt.Errorf("failed to run dep ensure: %s", err)
+	result := command(ctx, "dep", "ensure").Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to run dep ensure: %s", result.Error)
 	}
 	return nil
 }

--- a/pkg/tasks/homebrew.go
+++ b/pkg/tasks/homebrew.go
@@ -55,10 +55,10 @@ func (b *brewInstall) needed(ctx *context) (bool, error) {
 }
 
 func (b *brewInstall) run(ctx *context) error {
-	err := command(ctx, "brew", "install", b.formula).Run()
+	result := command(ctx, "brew", "install", b.formula).Run()
 
-	if err != nil {
-		return fmt.Errorf("Homebrew failed: %s", err)
+	if result.Error != nil {
+		return fmt.Errorf("failed to run brew install: %s", result.Error)
 	}
 
 	b.success = true

--- a/pkg/tasks/pip.go
+++ b/pkg/tasks/pip.go
@@ -49,10 +49,11 @@ func (p *pipInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipInstall) run(ctx *context) error {
-	err := command(ctx, "pip", "install", "--require-virtualenv", "-r", p.file).AddOutputFilter("already satisfied").Run()
+	result := command(ctx, "pip", "install", "--require-virtualenv", "-r", p.file).
+		AddOutputFilter("already satisfied").Run()
 
-	if err != nil {
-		return fmt.Errorf("Pip failed: %s", err)
+	if result.Error != nil {
+		return fmt.Errorf("Pip failed: %s", result.Error)
 	}
 	p.success = true
 	return nil

--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -36,9 +36,9 @@ func (p *pipfileInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipfileInstall) run(ctx *context) error {
-	err := command(ctx, "pip", "install", "--require-virtualenv", "pipenv").Run()
-	if err != nil {
-		return fmt.Errorf("failed to install pipenv: %s", err)
+	result := command(ctx, "pip", "install", "--require-virtualenv", "pipenv").Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to install pipenv: %s", result.Error)
 	}
 	return nil
 }
@@ -56,9 +56,9 @@ func (p *pipfileRun) needed(ctx *context) (bool, error) {
 }
 
 func (p *pipfileRun) run(ctx *context) error {
-	err := command(ctx, "pipenv", "install", "--system", "--dev").SetEnvVar("PIPENV_QUIET", "1").Run()
-	if err != nil {
-		return fmt.Errorf("pipenv failed: %s", err)
+	result := command(ctx, "pipenv", "install", "--system", "--dev").SetEnvVar("PIPENV_QUIET", "1").Run()
+	if result.Error != nil {
+		return fmt.Errorf("pipenv failed: %s", result.Error)
 	}
 	p.success = true
 	return nil

--- a/pkg/tasks/python.go
+++ b/pkg/tasks/python.go
@@ -51,9 +51,9 @@ func (p *pyenv) needed(ctx *context) (bool, error) {
 }
 
 func (p *pyenv) run(ctx *context) error {
-	err := command(ctx, "brew", "install", "pyenv").Run()
-	if err != nil {
-		return fmt.Errorf("failed to install pyenv: %s", err)
+	result := command(ctx, "brew", "install", "pyenv").Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to install pyenv: %s", result.Error)
 	}
 	return nil
 }
@@ -77,9 +77,9 @@ func (p *pythonPyenv) needed(ctx *context) (bool, error) {
 }
 
 func (p *pythonPyenv) run(ctx *context) error {
-	err := command(ctx, "pyenv", "install", p.version).Run()
-	if err != nil {
-		return fmt.Errorf("failed to install the required python version: %s", err)
+	result := command(ctx, "pyenv", "install", p.version).Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to install the required python version: %s", result.Error)
 	}
 	return nil
 }
@@ -106,9 +106,9 @@ func (p *pythonInstallVenv) run(ctx *context) error {
 	if err != nil {
 		return err
 	}
-	err = command(ctx, pyEnv.Which(p.version, "python"), "-m", "pip", "install", "virtualenv").Run()
-	if err != nil {
-		return fmt.Errorf("failed to install virtualenv: %s", err)
+	result := command(ctx, pyEnv.Which(p.version, "python"), "-m", "pip", "install", "virtualenv").Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to install virtualenv: %s", result.Error)
 	}
 
 	return nil
@@ -142,9 +142,9 @@ func (p *pythonCreateVenv) run(ctx *context) error {
 		return err
 	}
 
-	err = command(ctx, pyEnv.Which(p.version, "virtualenv"), venv.Path()).Run()
-	if err != nil {
-		return fmt.Errorf("failed to create the virtualenv: %s", err)
+	result := command(ctx, pyEnv.Which(p.version, "virtualenv"), venv.Path()).Run()
+	if result.Error != nil {
+		return fmt.Errorf("failed to create the virtualenv: %s", result.Error)
 	}
 
 	return nil

--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -30,9 +30,11 @@ func (p *pythonDevelopInstall) needed(ctx *context) (bool, error) {
 }
 
 func (p *pythonDevelopInstall) run(ctx *context) error {
-	err := command(ctx, "pip", "install", "--require-virtualenv", "-e", ".").AddOutputFilter("already satisfied").Run()
-	if err != nil {
-		return fmt.Errorf("Pip failed: %s", err)
+	result := command(ctx, "pip", "install", "--require-virtualenv", "-e", ".").
+		AddOutputFilter("already satisfied").Run()
+
+	if result.Error != nil {
+		return fmt.Errorf("Pip failed: %s", result.Error)
 	}
 
 	return store.New(ctx.proj.Path).RecordFileChange("setup.py")


### PR DESCRIPTION
## Why

The executor API is pretty clumsy with a Run and a RunWithCode command, but no CaptureWithCode variant.

## How

- Run() and Capture() returns a `Result` type with code, error and output.

