### PR TITLE
Change actions to return a struct with a error and reason

### DIFF
--- a/pkg/tasks/custom.go
+++ b/pkg/tasks/custom.go
@@ -1,9 +1,5 @@
 package tasks
 
-import (
-	"fmt"
-)
-
 func init() {
 	t := registerTaskDefinition("custom")
 	t.name = "Custom"
@@ -39,14 +35,17 @@ func (c *customAction) description() string {
 	return ""
 }
 
-func (c *customAction) needed(ctx *context) (bool, error) {
+func (c *customAction) needed(ctx *context) *actionResult {
 	result := shellSilent(ctx, c.condition).Run()
 
 	if result.LaunchError != nil {
-		return false, fmt.Errorf("failed to run the condition command: %s", result.LaunchError)
+		return actionFailed("failed to run the condition command: %s", result.LaunchError)
 	}
 
-	return result.Code != 0, nil
+	if result.Code != 0 {
+		return actionNeeded("the met? command exited with a non-zero code")
+	}
+	return actionNotNeeded()
 }
 
 func (c *customAction) run(ctx *context) error {

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -34,8 +34,11 @@ func (g *golangGoPath) description() string {
 	return ""
 }
 
-func (g *golangGoPath) needed(ctx *context) (bool, error) {
-	return ctx.env.Get("GOPATH") == "", nil
+func (g *golangGoPath) needed(ctx *context) *actionResult {
+	if ctx.env.Get("GOPATH") == "" {
+		return actionNeeded("GOPATH is not set")
+	}
+	return actionNotNeeded()
 }
 
 func (g *golangGoPath) run(ctx *context) error {
@@ -51,8 +54,11 @@ func (g *golangInstall) description() string {
 	return fmt.Sprintf("Install Go version %s", g.version)
 }
 
-func (g *golangInstall) needed(ctx *context) (bool, error) {
-	return !helpers.NewGolang(ctx.cfg, g.version).Exists(), nil
+func (g *golangInstall) needed(ctx *context) *actionResult {
+	if !helpers.NewGolang(ctx.cfg, g.version).Exists() {
+		return actionNeeded("golang distribution is not installed")
+	}
+	return actionNotNeeded()
 }
 
 func (g *golangInstall) run(ctx *context) error {

--- a/pkg/tasks/homebrew.go
+++ b/pkg/tasks/homebrew.go
@@ -39,28 +39,26 @@ func parserHomebrew(config *taskConfig, task *Task) error {
 
 type brewInstall struct {
 	formula string
-	success bool
 }
 
 func (b *brewInstall) description() string {
 	return fmt.Sprintf("installing %s", b.formula)
 }
 
-func (b *brewInstall) needed(ctx *context) (bool, error) {
+func (b *brewInstall) needed(ctx *context) *actionResult {
 	brew := helpers.NewHomebrew()
 
-	installed := brew.IsInstalled(b.formula)
-
-	return !installed, nil
+	if brew.IsInstalled(b.formula) {
+		return actionNotNeeded()
+	}
+	return actionNeeded("package %s is not installed", b.formula)
 }
 
 func (b *brewInstall) run(ctx *context) error {
 	result := command(ctx, "brew", "install", b.formula).Run()
-
 	if result.Error != nil {
 		return fmt.Errorf("failed to run brew install: %s", result.Error)
 	}
 
-	b.success = true
 	return nil
 }

--- a/pkg/tasks/pip.go
+++ b/pkg/tasks/pip.go
@@ -44,8 +44,11 @@ func (p *pipInstall) description() string {
 	return fmt.Sprintf("install %s", p.file)
 }
 
-func (p *pipInstall) needed(ctx *context) (bool, error) {
-	return !p.success, nil
+func (p *pipInstall) needed(ctx *context) *actionResult {
+	if !p.success {
+		return actionNeeded("")
+	}
+	return actionNotNeeded()
 }
 
 func (p *pipInstall) run(ctx *context) error {

--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -27,12 +27,16 @@ func (p *pipfileInstall) description() string {
 	return "install pipfile command"
 }
 
-func (p *pipfileInstall) needed(ctx *context) (bool, error) {
+func (p *pipfileInstall) needed(ctx *context) *actionResult {
 	pythonParam := ctx.features["python"]
 	name := helpers.VirtualenvName(ctx.proj, pythonParam)
 	venv := helpers.NewVirtualenv(ctx.cfg, name)
 	pipenvCmd := venv.Which("pipenv")
-	return !utils.PathExists(pipenvCmd), nil
+
+	if !utils.PathExists(pipenvCmd) {
+		return actionNeeded("Pipenv is not installed in the virtualenv")
+	}
+	return actionNotNeeded()
 }
 
 func (p *pipfileInstall) run(ctx *context) error {
@@ -51,8 +55,11 @@ func (p *pipfileRun) description() string {
 	return "install dependencies from the Pipfile"
 }
 
-func (p *pipfileRun) needed(ctx *context) (bool, error) {
-	return !p.success, nil
+func (p *pipfileRun) needed(ctx *context) *actionResult {
+	if !p.success {
+		actionNeeded("")
+	}
+	return actionNotNeeded()
 }
 
 func (p *pipfileRun) run(ctx *context) error {

--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -57,7 +57,7 @@ func (p *pipfileRun) description() string {
 
 func (p *pipfileRun) needed(ctx *context) *actionResult {
 	if !p.success {
-		actionNeeded("")
+		return actionNeeded("")
 	}
 	return actionNotNeeded()
 }

--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -25,8 +25,15 @@ func (p *pythonDevelopInstall) description() string {
 	return "install python package in develop mode"
 }
 
-func (p *pythonDevelopInstall) needed(ctx *context) (bool, error) {
-	return store.New(ctx.proj.Path).HasFileChanged("setup.py")
+func (p *pythonDevelopInstall) needed(ctx *context) *actionResult {
+	changed, err := store.New(ctx.proj.Path).HasFileChanged("setup.py")
+	if err != nil {
+		return actionFailed("failed to check if setup.py has changed: %s", err)
+	}
+	if changed {
+		return actionNeeded("setup.py was modified")
+	}
+	return actionNotNeeded()
 }
 
 func (p *pythonDevelopInstall) run(ctx *context) error {

--- a/pkg/tasks/runner.go
+++ b/pkg/tasks/runner.go
@@ -75,37 +75,6 @@ func runTask(ctx *context, task *Task) (err error) {
 	return err
 }
 
-func runAction(ctx *context, action taskAction) error {
-	desc := action.description()
-
-	needed, err := action.needed(ctx)
-	if !needed && err != nil {
-		return fmt.Errorf("The task action (%s) failed to detect whether it need to run: %s", desc, err)
-	}
-
-	if needed {
-		if desc != "" {
-			ctx.ui.TaskActionHeader(desc)
-		}
-
-		err = action.run(ctx)
-		if err != nil {
-			return fmt.Errorf("The task action failed to run: %s", err)
-		}
-	}
-
-	stillNeeded, err := action.needed(ctx)
-	if err != nil {
-		return fmt.Errorf("The task action failed to detect if it is resolved: %s", err)
-	}
-
-	if stillNeeded {
-		return fmt.Errorf("The task action is not resolved after running it")
-	}
-
-	return nil
-}
-
 func activateFeature(ctx *context, task *Task) (err error) {
 	if task.featureName == "" {
 		return nil

--- a/pkg/tasks/task_action.go
+++ b/pkg/tasks/task_action.go
@@ -1,0 +1,59 @@
+package tasks
+
+import "fmt"
+
+type taskAction interface {
+	description() string
+	needed(*context) *actionResult
+	run(*context) error
+}
+
+type actionResult struct {
+	Needed bool
+	Reason string
+	Error  error
+}
+
+func actionFailed(error_message string, args ...interface{}) *actionResult {
+	return &actionResult{Error: fmt.Errorf(error_message, args...)}
+}
+
+func actionNeeded(message string, args ...interface{}) *actionResult {
+	return &actionResult{Needed: true, Reason: fmt.Sprintf(message, args...)}
+}
+
+func actionNotNeeded() *actionResult {
+	return &actionResult{Needed: false}
+}
+
+func runAction(ctx *context, action taskAction) error {
+	desc := action.description()
+
+	result := action.needed(ctx)
+	if result.Error != nil {
+		return fmt.Errorf("The task action (%s) failed to detect whether it need to run: %s", desc, result.Error)
+	}
+
+	if result.Needed {
+		if desc != "" {
+			ctx.ui.TaskActionHeader(desc)
+		}
+		ctx.ui.Debug("Reason: \"%s\"", result.Reason)
+
+		err := action.run(ctx)
+		if err != nil {
+			return fmt.Errorf("The task action failed to run: %s", err)
+		}
+	}
+
+	result = action.needed(ctx)
+	if result.Error != nil {
+		return fmt.Errorf("The task action failed to detect if it is resolved: %s", result.Error)
+	}
+
+	if result.Needed {
+		return fmt.Errorf("The task action did not produce the expected result: %s", result.Reason)
+	}
+
+	return nil
+}

--- a/pkg/tasks/task_action.go
+++ b/pkg/tasks/task_action.go
@@ -14,8 +14,8 @@ type actionResult struct {
 	Error  error
 }
 
-func actionFailed(error_message string, args ...interface{}) *actionResult {
-	return &actionResult{Error: fmt.Errorf(error_message, args...)}
+func actionFailed(errorMessage string, args ...interface{}) *actionResult {
+	return &actionResult{Error: fmt.Errorf(errorMessage, args...)}
 }
 
 func actionNeeded(message string, args ...interface{}) *actionResult {

--- a/pkg/tasks/tasks.go
+++ b/pkg/tasks/tasks.go
@@ -40,12 +40,6 @@ func (t *Task) addAction(action taskAction) {
 	t.actions = append(t.actions, action)
 }
 
-type taskAction interface {
-	description() string
-	needed(*context) (bool, error)
-	run(*context) error
-}
-
 func GetTasksFromProject(proj *project.Project) (taskList []*Task, err error) {
 	var task *Task
 


### PR DESCRIPTION
## Why

- The current `(bool, error)` return signature is not great
- Using the error to provide a "reason" to the failure is especially confusing

## How


