### PR TITLE
Add test coverage on the task execution logic

### DIFF
--- a/pkg/tasks/runner_test.go
+++ b/pkg/tasks/runner_test.go
@@ -1,0 +1,170 @@
+package tasks
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/env"
+	"github.com/devbuddy/devbuddy/pkg/project"
+	"github.com/devbuddy/devbuddy/pkg/termui"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testingAction struct {
+	desc            string
+	neededResults   []*actionResult
+	neededCallCount int
+
+	runResult    error
+	runCallCount int
+}
+
+func (a *testingAction) description() string {
+	return a.desc
+}
+
+func (a *testingAction) needed(ctx *context) *actionResult {
+	result := a.neededResults[a.neededCallCount]
+	if result == nil {
+		panic("the task should not have been called")
+	}
+	a.neededCallCount++
+	return result
+}
+
+func (a *testingAction) run(ctx *context) error {
+	a.runCallCount++
+	return a.runResult
+}
+
+func newTestingAction(desc string, resultBefore, resultAfter *actionResult, runResult error) *testingAction {
+	return &testingAction{
+		desc:          desc,
+		neededResults: []*actionResult{resultBefore, resultAfter},
+		runResult:     runResult,
+	}
+}
+
+func setupTaskTesting() (*context, *bytes.Buffer) {
+	buf, ui := termui.NewTesting(false)
+
+	ctx := &context{
+		proj:     project.NewFromPath("/srv/myproject"),
+		ui:       ui,
+		cfg:      config.NewTestConfig(),
+		env:      env.New([]string{}),
+		features: map[string]string{},
+	}
+
+	return ctx, buf
+}
+
+func TestRunActionNeeded(t *testing.T) {
+	ctx, output := setupTaskTesting()
+	action := newTestingAction("Action X", actionNeeded("some-reason"), actionNotNeeded(), nil)
+
+	err := runAction(ctx, action)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, action.neededCallCount)
+	require.Equal(t, 1, action.runCallCount)
+
+	require.Contains(t, output.String(), "Action X")
+}
+
+func TestRunActionNotNeeded(t *testing.T) {
+	ctx, output := setupTaskTesting()
+	action := newTestingAction("Action X", actionNotNeeded(), nil, nil)
+
+	err := runAction(ctx, action)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, action.neededCallCount)
+	require.Equal(t, 0, action.runCallCount)
+
+	require.NotContains(t, output.String(), "Action X")
+}
+
+func TestRunActionFailureOnNeeded(t *testing.T) {
+	ctx, _ := setupTaskTesting()
+	action := newTestingAction("Action X", actionFailed("ERROR_X"), nil, nil)
+
+	err := runAction(ctx, action)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to detect whether it need to run: ERROR_X")
+
+	require.Equal(t, 1, action.neededCallCount)
+	require.Equal(t, 0, action.runCallCount)
+}
+
+func TestRunActionFailureOnRun(t *testing.T) {
+	ctx, output := setupTaskTesting()
+	action := newTestingAction("Action X", actionNeeded("some-reason"), nil, errors.New("RunFailed"))
+
+	err := runAction(ctx, action)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to run: RunFailed")
+
+	require.Equal(t, 1, action.neededCallCount)
+	require.Equal(t, 1, action.runCallCount)
+
+	require.Contains(t, output.String(), "Action X")
+}
+
+func TestRunActionStillNeeded(t *testing.T) {
+	ctx, _ := setupTaskTesting()
+	action := newTestingAction("Action X", actionNeeded("some-reason"), actionNeeded("some-reason"), nil)
+
+	err := runAction(ctx, action)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "did not produce the expected result: some-reason")
+
+	require.Equal(t, 2, action.neededCallCount)
+	require.Equal(t, 1, action.runCallCount)
+}
+
+func TestRunTask(t *testing.T) {
+	ctx, output := setupTaskTesting()
+	action1 := newTestingAction("Action 1", actionNeeded("some-reason"), actionNotNeeded(), nil)
+	action2 := newTestingAction("Action 2", actionNeeded("some-reason"), actionNotNeeded(), nil)
+
+	task := &Task{
+		taskDefinition: &taskDefinition{name: "testtask"},
+		actions:        []taskAction{action1, action2},
+	}
+
+	err := runTask(ctx, task)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, action1.neededCallCount)
+	require.Equal(t, 1, action1.runCallCount)
+
+	require.Equal(t, 2, action2.neededCallCount)
+	require.Equal(t, 1, action2.runCallCount)
+
+	require.Contains(t, output.String(), "Action 1")
+}
+
+func TestRunTaskWithError(t *testing.T) {
+	ctx, _ := setupTaskTesting()
+	action1 := newTestingAction("Action 1", actionFailed("CRASH 1"), nil, nil)
+	action2 := newTestingAction("Action 2", nil, nil, nil)
+
+	task := &Task{
+		taskDefinition: &taskDefinition{name: "testtask"},
+		actions:        []taskAction{action1, action2},
+	}
+
+	err := runTask(ctx, task)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "The task action (Action 1) failed to detect whether it need to run: CRASH 1")
+
+	require.Equal(t, 1, action1.neededCallCount)
+	require.Equal(t, 0, action1.runCallCount)
+
+	require.Equal(t, 0, action2.neededCallCount)
+	require.Equal(t, 0, action2.runCallCount)
+}

--- a/pkg/tasks/task_action.go
+++ b/pkg/tasks/task_action.go
@@ -44,15 +44,15 @@ func runAction(ctx *context, action taskAction) error {
 		if err != nil {
 			return fmt.Errorf("The task action failed to run: %s", err)
 		}
-	}
 
-	result = action.needed(ctx)
-	if result.Error != nil {
-		return fmt.Errorf("The task action failed to detect if it is resolved: %s", result.Error)
-	}
+		result = action.needed(ctx)
+		if result.Error != nil {
+			return fmt.Errorf("The task action failed to detect if it is resolved: %s", result.Error)
+		}
 
-	if result.Needed {
-		return fmt.Errorf("The task action did not produce the expected result: %s", result.Reason)
+		if result.Needed {
+			return fmt.Errorf("The task action did not produce the expected result: %s", result.Reason)
+		}
 	}
 
 	return nil

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -1,6 +1,7 @@
 package termui
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log"
@@ -35,6 +36,14 @@ func NewHook(cfg *config.Config) *UI {
 	return &UI{
 		out:          os.Stderr,
 		debugEnabled: cfg.DebugEnabled,
+	}
+}
+
+func NewTesting(debugEnabled bool) (*bytes.Buffer, *UI) {
+	buffer := bytes.NewBufferString("")
+	return buffer, &UI{
+		out:          buffer,
+		debugEnabled: debugEnabled,
 	}
 }
 


### PR DESCRIPTION
## Why

The task execution logic is not tested yet.

## How

- Add unittests
- Fix a sub-optimal behavior: `action.needed()` method was called a second time even if it was not needed the first time.
