### PR TITLE
Improve interface and implementation of the store

### DIFF
--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -95,10 +95,6 @@ func (s *Store) GetString(key string) (string, error) {
 	return string(value), err
 }
 
-func normalizeKey(key string) string {
-	return
-}
-
 // DEPRECATED: don't use the RecordFileChange/HasFileChanged methods, they will be removed.
 // It should not be part of the Store
 
@@ -108,7 +104,7 @@ func (s *Store) RecordFileChange(path string) error {
 	if err != nil {
 		return err
 	}
-	return s.Set("checksum-"+KeyFromPath(path), []byte(checksum))
+	return s.SetString(s.pathForKey("checksum-"+path), checksum)
 }
 
 // HasFileChanged detects whether a path has changed since the last call to RecordFileChange().
@@ -119,10 +115,10 @@ func (s *Store) HasFileChanged(path string) (bool, error) {
 		return true, nil
 	}
 
-	content, err := s.Get("checksum-" + KeyFromPath(path))
+	content, err := s.GetString(s.pathForKey("checksum-" + path))
 	if err != nil {
 		return true, nil
 	}
 
-	return checksum != string(content), nil
+	return checksum != content, nil
 }

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -70,11 +70,6 @@ func (s *Store) SetString(key string, value string) error {
 
 // Get retrieves a byte slice for a key
 func (s *Store) Get(key string) ([]byte, error) {
-	err := s.ensureInit()
-	if err != nil {
-		return nil, err
-	}
-
 	pathForKey := s.pathForKey(key)
 
 	if _, err := os.Stat(pathForKey); os.IsNotExist(err) {

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -17,9 +17,6 @@ type Store struct {
 	projectPath string
 }
 
-// Key represents the key used to identify a stored
-type Key string
-
 // New returns an instance of Store
 func New(projectPath string) *Store {
 	return &Store{projectPath: projectPath}
@@ -27,6 +24,11 @@ func New(projectPath string) *Store {
 
 func (s *Store) path() string {
 	return filepath.Join(s.projectPath, dirName)
+}
+
+func (s *Store) pathForKey(key string) string {
+	filePathForKey := strings.Replace(key, string(filepath.Separator), "--", -1)
+	return filepath.Join(s.path(), filePathForKey)
 }
 
 func (s *Store) ensureInit() (err error) {
@@ -52,34 +54,34 @@ func (s *Store) ensureInit() (err error) {
 }
 
 // Set stores a byte slice for a key
-func (s *Store) Set(key Key, value []byte) error {
+func (s *Store) Set(key string, value []byte) error {
 	err := s.ensureInit()
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(filepath.Join(s.path(), string(key)), value, 0644)
+	return ioutil.WriteFile(s.pathForKey(key), value, 0644)
 }
 
 // SetString stores a string for a key
-func (s *Store) SetString(key Key, value string) error {
+func (s *Store) SetString(key string, value string) error {
 	return s.Set(key, []byte(value))
 }
 
 // Get retrieves a byte slice for a key
-func (s *Store) Get(key Key) ([]byte, error) {
+func (s *Store) Get(key string) ([]byte, error) {
 	err := s.ensureInit()
 	if err != nil {
 		return nil, err
 	}
 
-	stateFilePath := filepath.Join(s.path(), string(key))
+	pathForKey := s.pathForKey(key)
 
-	if _, err := os.Stat(stateFilePath); os.IsNotExist(err) {
+	if _, err := os.Stat(pathForKey); os.IsNotExist(err) {
 		return nil, nil
 	}
 
-	content, err := ioutil.ReadFile(stateFilePath)
+	content, err := ioutil.ReadFile(pathForKey)
 	if err != nil {
 		return nil, err
 	}
@@ -88,19 +90,17 @@ func (s *Store) Get(key Key) ([]byte, error) {
 }
 
 // GetString retrieves a string for a key
-func (s *Store) GetString(key Key) (string, error) {
+func (s *Store) GetString(key string) (string, error) {
 	value, err := s.Get(key)
 	return string(value), err
 }
 
+func normalizeKey(key string) string {
+	return
+}
+
 // DEPRECATED: don't use the RecordFileChange/HasFileChanged methods, they will be removed.
 // It should not be part of the Store
-
-// KeyFromPath builds a Key for the path of a file in the project
-func KeyFromPath(path string) Key {
-	value := strings.Replace(path, string(filepath.Separator), "--", -1)
-	return Key(value)
-}
 
 // RecordFileChange stores the modification time of a file.
 func (s *Store) RecordFileChange(path string) error {

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -55,6 +56,10 @@ func (s *Store) ensureInit() (err error) {
 
 // Set stores a byte slice for a key
 func (s *Store) Set(key string, value []byte) error {
+	if key == "" {
+		return errors.New("empty string is an invalid key")
+	}
+
 	err := s.ensureInit()
 	if err != nil {
 		return err
@@ -70,6 +75,10 @@ func (s *Store) SetString(key string, value string) error {
 
 // Get retrieves a byte slice for a key
 func (s *Store) Get(key string) ([]byte, error) {
+	if key == "" {
+		return nil, errors.New("empty string is an invalid key")
+	}
+
 	pathForKey := s.pathForKey(key)
 
 	if _, err := os.Stat(pathForKey); os.IsNotExist(err) {

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -9,6 +9,93 @@ import (
 	"github.com/Flaque/filet"
 )
 
+func TestProjectPathMissing(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir + "/nopenope")
+
+	val, err := s.Get("dummy")
+	require.Error(t, err)
+	require.Equal(t, []byte(nil), val)
+}
+
+func TestInitialization(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	err := s.SetString("dummykey", "dummy")
+	require.NoError(t, err)
+
+	filet.DirContains(t, tmpdir, ".devbuddy")
+	filet.DirContains(t, tmpdir, ".devbuddy/dummykey")
+
+	filet.DirContains(t, tmpdir, ".devbuddy/.gitignore")
+	filet.FileSays(t, tmpdir+"/.devbuddy/.gitignore", []byte("*"))
+}
+
+func TestSetGet(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	testValues := [][]byte{
+		[]byte("DUMMY"),
+		[]byte(""),
+		[]byte("   "),
+	}
+
+	for _, testVal := range testValues {
+		err := s.Set("key", testVal)
+		require.NoError(t, err)
+
+		val, err := s.Get("key")
+		require.NoError(t, err)
+		require.Equal(t, testVal, val)
+	}
+}
+
+func TestSetGetString(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	testValues := []string{
+		"DUMMY",
+		"",
+		"   ",
+	}
+
+	for _, testVal := range testValues {
+		err := s.SetString("key", testVal)
+		require.NoError(t, err)
+
+		val, err := s.GetString("key")
+		require.NoError(t, err)
+		require.Equal(t, testVal, val)
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	val, err := s.Get("nope")
+	require.NoError(t, err)
+	require.Equal(t, []byte(nil), val)
+}
+
+func TestGetStringNotFound(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	val, err := s.GetString("nope")
+	require.NoError(t, err)
+	require.Equal(t, "", val)
+}
+
 func TestWithoutFile(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -75,6 +75,18 @@ func TestSetGetString(t *testing.T) {
 	}
 }
 
+func TestKeyEmpty(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+	s := New(tmpdir)
+
+	_, err := s.Get("")
+	require.Error(t, err)
+
+	err = s.Set("", []byte(""))
+	require.Error(t, err)
+}
+
 func TestGetNotFound(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -14,9 +14,8 @@ func TestProjectPathMissing(t *testing.T) {
 	tmpdir := filet.TmpDir(t, "")
 	s := New(tmpdir + "/nopenope")
 
-	val, err := s.Get("dummy")
+	err := s.Set("dummy", []byte(""))
 	require.Error(t, err)
-	require.Equal(t, []byte(nil), val)
 }
 
 func TestInitialization(t *testing.T) {


### PR DESCRIPTION
## Why

The store api is currently overly specific to detecting file changes and not a real _store api_.
To refactor the task action api, we need a real _store api_.

## How

- Implement `Get`/`GetString`/`Set`/`SetString`.
- Deprecate the method for file change detection.


