### PR TITLE
Adds a check for the golang bin path in PATH.

### DIFF
--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/devbuddy/devbuddy/pkg/helpers"
 )

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -40,8 +40,8 @@ func (g *golangGoPath) needed(ctx *Context) *actionResult {
 		return actionNeeded("GOPATH is not set")
 	}
 
-	if !strings.Contains(ctx.env.Get("PATH"), g.bin()) {
-		return actionNeeded(fmt.Sprintf("%s is not in PATH", g.bin()))
+	if !strings.Contains(ctx.env.Get("PATH"), g.binPath(ctx)) {
+		return actionNeeded(fmt.Sprintf("%s is not in PATH", g.binPath()))
 	}
 
 	return actionNotNeeded()
@@ -52,7 +52,7 @@ func (g *golangGoPath) run(ctx *Context) error {
 	return nil
 }
 
-func (g *golangGoPath) bin() string {
+func (g *golangGoPath) binPath(ctx *Context) string {
 	return fmt.Sprintf("%s/bin", ctx.env.Get("GOPATH"))
 }
 

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -41,7 +41,7 @@ func (g *golangGoPath) needed(ctx *Context) *actionResult {
 	}
 
 	if !strings.Contains(ctx.env.Get("PATH"), g.binPath(ctx)) {
-		return actionNeeded(fmt.Sprintf("%s is not in PATH", g.binPath()))
+		return actionNeeded(fmt.Sprintf("%s is not in PATH", g.binPath(ctx)))
 	}
 
 	return actionNotNeeded()

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -38,12 +38,21 @@ func (g *golangGoPath) needed(ctx *context) *actionResult {
 	if ctx.env.Get("GOPATH") == "" {
 		return actionNeeded("GOPATH is not set")
 	}
+
+	if !strings.Contains(ctx.env.Get("PATH"), g.bin()) {
+		return actionNeeded(fmt.Sprintf("%s is not in PATH", g.bin()))
+	}
+
 	return actionNotNeeded()
 }
 
 func (g *golangGoPath) run(ctx *context) error {
 	ctx.ui.TaskWarning("The GOPATH environment variable should be set to ~/")
 	return nil
+}
+
+func (g *golangGoPath) bin() string {
+	return fmt.Sprintf("%s/bin", ctx.env.Get("GOPATH"))
 }
 
 type golangInstall struct {


### PR DESCRIPTION
## Why

Fixes https://github.com/devbuddy/devbuddy/issues/202

By default, when installing GO in HOME `dep` is installed in `~/bin` but sadly `~/bin` is not necessarily parth of PATH.

## How

This PR is adding a check for `GOPATH/bin` part of `PATH`


