### PR TITLE
Adds platform specific tests.

### DIFF
--- a/pkg/helpers/osidentity/osidentity_darwin_test.go
+++ b/pkg/helpers/osidentity/osidentity_darwin_test.go
@@ -9,4 +9,5 @@ import (
 func TestDetectIsMacOS(t *testing.T) {
 	i := Detect()
 	require.True(t, i.IsMacOS())
+	require.False(t, i.IsDebianLike())
 }

--- a/pkg/helpers/osidentity/osidentity_darwin_test.go
+++ b/pkg/helpers/osidentity/osidentity_darwin_test.go
@@ -1,0 +1,12 @@
+package osidentity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectIsMacOS(t *testing.T) {
+	i := Detect()
+	require.True(t, i.IsMacOS())
+}

--- a/pkg/helpers/osidentity/osidentity_darwin_test.go
+++ b/pkg/helpers/osidentity/osidentity_darwin_test.go
@@ -9,5 +9,9 @@ import (
 func TestDetectIsMacOS(t *testing.T) {
 	i := Detect()
 	require.True(t, i.IsMacOS())
+}
+
+func TestDetectIsDebianLike(t *testing.T) {
+	i := Detect()
 	require.False(t, i.IsDebianLike())
 }

--- a/pkg/helpers/osidentity/osidentity_linux_test.go
+++ b/pkg/helpers/osidentity/osidentity_linux_test.go
@@ -1,0 +1,12 @@
+package osidentity
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetectIsDebianLike(t *testing.T) {
+	i := Detect()
+	require.True(t, i.IsDebianLike())
+}

--- a/pkg/helpers/osidentity/osidentity_linux_test.go
+++ b/pkg/helpers/osidentity/osidentity_linux_test.go
@@ -9,5 +9,9 @@ import (
 func TestDetectIsDebianLike(t *testing.T) {
 	i := Detect()
 	require.True(t, i.IsDebianLike())
+}
+
+func TestDetectIsMacOS(t *testing.T) {
+	i := Detect()
 	require.False(t, i.IsMacOS())
 }

--- a/pkg/helpers/osidentity/osidentity_linux_test.go
+++ b/pkg/helpers/osidentity/osidentity_linux_test.go
@@ -9,4 +9,5 @@ import (
 func TestDetectIsDebianLike(t *testing.T) {
 	i := Detect()
 	require.True(t, i.IsDebianLike())
+	require.False(t, i.IsMacOS())
 }


### PR DESCRIPTION
## Why

Following previous PR for introducing os detection, we need to make `Detect` run minimally on your current platform.

## How


