### PR TITLE
Adds apt task for installing dependencies on debian like platform

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,6 +6,9 @@ up:
   - homebrew:
     - curl
     - shellcheck
+  - apt:
+    - curl
+    - shellcheck
   - custom:
       name: Install golangci-lint
       met?: test -f $GOPATH/bin/golangci-lint


### PR DESCRIPTION
## Why

Now that tasks are possibly platform specific we need to make devbuddy work on linux


## How

This PR is adding what's needed for installing devbuddy using apt


