### PR TITLE
Add support for setuptools extra in python_develop task

### DIFF
--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"fmt"
+	"strings"
 )
 
 func init() {
@@ -12,17 +13,19 @@ func init() {
 }
 
 func parserPythonDevelop(config *taskConfig, task *Task) error {
-	_, err := config.getListOfStringsPropertyDefault("extras", []string{})
+	extras, err := config.getListOfStringsPropertyDefault("extras", []string{})
 	if err != nil {
 		return err
 	}
 
-	// TODO(pior): implement the logic for the extras
+	pipTarget := "."
+	if len(extras) > 0 {
+		pipTarget = fmt.Sprintf(".[%s]", strings.Join(extras, ","))
+	}
+	pipArgs := []string{"install", "--require-virtualenv", "-e", pipTarget}
 
 	builder := actionBuilder("install python package in develop mode", func(ctx *Context) error {
-		result := command(ctx, "pip", "install", "--require-virtualenv", "-e", ".").
-			AddOutputFilter("already satisfied").Run()
-
+		result := command(ctx, "pip", pipArgs...).AddOutputFilter("already satisfied").Run()
 		if result.Error != nil {
 			return fmt.Errorf("Pip failed: %s", result.Error)
 		}

--- a/pkg/tasks/python_develop_test.go
+++ b/pkg/tasks/python_develop_test.go
@@ -1,0 +1,29 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPythonDevelop(t *testing.T) {
+	task := ensureLoadTestTask(t, `
+python_develop
+`)
+
+	require.Equal(t, taskDefinitions["python_develop"], task.taskDefinition)
+	require.Equal(t, 1, len(task.actions))
+	require.Equal(t, "install python package in develop mode", task.actions[0].description())
+}
+
+func TestPythonDevelopWithExtras(t *testing.T) {
+	task := ensureLoadTestTask(t, `
+python_develop:
+  extras: [dev, test]
+`)
+
+	require.Equal(t, taskDefinitions["python_develop"], task.taskDefinition)
+	require.Equal(t, 1, len(task.actions))
+	require.Equal(t, "install python package in develop mode", task.actions[0].description())
+
+}

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -2,13 +2,13 @@ import os
 import textwrap
 
 
-def make_setuppy(version):
-    return textwrap.dedent(f"""
+def make_setuppy(version=1):
+    return textwrap.dedent("""
         from setuptools import setup, find_packages
-        setup(name='devbuddy-test-pkg', version='{version}')
+        setup(name='devbuddy-test-pkg', version='%s', extras_require={'test': ['test==2.3.4.5']})
 
         open("sentinel", "w").write("")
-    """)
+    """) % version
 
 
 def test_with_modification(cmd, project):
@@ -53,3 +53,18 @@ def test_without_modification(cmd, project):
     cmd.run("bud up")
 
     assert not os.path.exists(sentinel_path)
+
+
+def test_with_extra(cmd, project):
+    project.write_devyml("""
+        up:
+        - python: 3.6.5
+        - python_develop:
+            extras: [test]
+    """)
+    project.write_file("setup.py", make_setuppy())
+
+    cmd.run("bud up")
+
+    output = cmd.run("pip freeze")
+    assert 'test==2.3.4.5' in output.splitlines(False)

--- a/tests/test_task_python_develop.py
+++ b/tests/test_task_python_develop.py
@@ -55,6 +55,20 @@ def test_without_modification(cmd, project):
     assert not os.path.exists(sentinel_path)
 
 
+def test_without_extra(cmd, project):
+    project.write_devyml("""
+        up:
+        - python: 3.6.5
+        - python_develop
+    """)
+    project.write_file("setup.py", make_setuppy())
+
+    cmd.run("bud up")
+
+    output = cmd.run("pip freeze")
+    assert 'test==2.3.4.5' not in output.splitlines(False)
+
+
 def test_with_extra(cmd, project):
     project.write_devyml("""
         up:
@@ -68,3 +82,17 @@ def test_with_extra(cmd, project):
 
     output = cmd.run("pip freeze")
     assert 'test==2.3.4.5' in output.splitlines(False)
+
+
+def test_with_unknown_extra(cmd, project):
+    # Unknown extra are ignored: https://github.com/devbuddy/devbuddy/issues/229
+
+    project.write_devyml("""
+        up:
+        - python: 3.6.5
+        - python_develop:
+            extras: [nope]
+    """)
+    project.write_file("setup.py", make_setuppy())
+
+    cmd.run("bud up")


### PR DESCRIPTION
## Why

The `python_develop` task can become useless if _extras_ need to be installed.

## How

```yaml
up:
  - python_develop:
      extras: [dev, docs]
```


