### PR TITLE
Add install instruction for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Others:
 
 ### Homebrew
 
-Coming soon.
+```bash
+$ brew install devbuddy/devbuddy/devbuddy
+```
 
 ### Automatic
 


### PR DESCRIPTION
## Why

Resolves https://github.com/devbuddy/devbuddy/issues/184

## How

Created a custom Homebrew tap at https://github.com/devbuddy/homebrew-devbuddy because `homebrew-core` is only available for well known projects.

