### PR TITLE
Fix the automatic features when the task change in dev.yml

### DIFF
--- a/pkg/features/definitions/definitions.go
+++ b/pkg/features/definitions/definitions.go
@@ -11,7 +11,6 @@ import (
 type Definition struct {
 	Name       string
 	Activate   func(string, *config.Config, *project.Project, *env.Env) (bool, error)
-	Refresh    func(string, *config.Config, *project.Project, *env.Env) (bool, error)
 	Deactivate func(string, *config.Config, *env.Env)
 }
 

--- a/pkg/features/feature.go
+++ b/pkg/features/feature.go
@@ -20,17 +20,6 @@ func Activate(name string, param string, conf *config.Config, proj *project.Proj
 	return false, nil
 }
 
-func Refresh(name string, param string, conf *config.Config, proj *project.Project, env *env.Env) (bool, error) {
-	def := definitions.Get(name)
-	if def == nil {
-		panic(fmt.Sprintf("unknown feature: %s", name))
-	}
-	if def.Refresh != nil {
-		return def.Refresh(param, conf, proj, env)
-	}
-	return false, nil
-}
-
 func Deactivate(name string, param string, conf *config.Config, env *env.Env) {
 	def := definitions.Get(name)
 	if def == nil {

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -50,10 +50,6 @@ func TestDeactivate(t *testing.T) {
 	require.False(t, devUpNeeded)
 	require.NoError(t, err)
 
-	devUpNeeded, err = Refresh("test-deactivate", "testparam", nil, nil, nil)
-	require.False(t, devUpNeeded)
-	require.NoError(t, err)
-
 	Deactivate("test-deactivate", "testparam", nil, nil)
 	require.True(t, deactivated)
 }

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -34,33 +34,7 @@ func TestActivation(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, activated)
 
-	devUpNeeded, err = Refresh("test-activation", "testparam", nil, nil, nil)
-	require.False(t, devUpNeeded)
-	require.NoError(t, err)
-
 	Deactivate("test-activation", "testparam", nil, nil)
-}
-
-func TestRefresh(t *testing.T) {
-	refreshed := false
-
-	d := definitions.Register("test-refresh")
-	d.Refresh = func(param string, cfg *config.Config, proj *project.Project, env *env.Env) (bool, error) {
-		require.Equal(t, "testparam", param)
-		refreshed = true
-		return true, nil
-	}
-
-	devUpNeeded, err := Activate("test-refresh", "testparam", nil, nil, nil)
-	require.False(t, devUpNeeded)
-	require.NoError(t, err)
-
-	devUpNeeded, err = Refresh("test-refresh", "testparam", nil, nil, nil)
-	require.True(t, devUpNeeded)
-	require.NoError(t, err)
-	require.True(t, refreshed)
-
-	Deactivate("test-refresh", "testparam", nil, nil)
 }
 
 func TestDeactivate(t *testing.T) {

--- a/pkg/features/feature_test.go
+++ b/pkg/features/feature_test.go
@@ -12,11 +12,8 @@ import (
 
 func TestRegister(t *testing.T) {
 	names := definitions.Names()
-	require.ElementsMatch(t, []string{"python", "golang"}, names)
-
-	for _, name := range names {
-		require.NotNil(t, definitions.Get(name))
-	}
+	require.Contains(t, names, "python")
+	require.Contains(t, names, "golang")
 }
 
 func TestActivation(t *testing.T) {

--- a/pkg/features/runner.go
+++ b/pkg/features/runner.go
@@ -29,7 +29,6 @@ func (r *Runner) Run(features map[string]string) {
 		if want {
 			if active {
 				if wantVersion != activeVersion {
-					// r.refreshFeature(name, wantVersion)
 					r.deactivateFeature(name, activeVersion)
 					r.activateFeature(name, wantVersion)
 				}
@@ -56,20 +55,6 @@ func (r *Runner) activateFeature(name string, param string) {
 	}
 	r.ui.HookFeatureActivated(name, param)
 	r.env.SetFeature(name, param)
-}
-
-func (r *Runner) refreshFeature(name string, param string) {
-	devUpNeeded, err := Refresh(name, param, r.cfg, r.proj, r.env)
-	if err != nil {
-		r.ui.Debug("failed: %s", err)
-		return
-	}
-	if devUpNeeded {
-		r.ui.HookFeatureFailure(name, param)
-		return
-	}
-
-	r.ui.Debug("%s refreshed", name)
 }
 
 func (r *Runner) deactivateFeature(name string, param string) {

--- a/pkg/features/runner.go
+++ b/pkg/features/runner.go
@@ -44,6 +44,8 @@ func (r *Runner) Run(features map[string]string) {
 }
 
 func (r *Runner) activateFeature(name string, param string) {
+	r.ui.Debug("activating %s (%s)", name, param)
+
 	devUpNeeded, err := Activate(name, param, r.cfg, r.proj, r.env)
 	if err != nil {
 		r.ui.Debug("failed: %s", err)
@@ -58,7 +60,8 @@ func (r *Runner) activateFeature(name string, param string) {
 }
 
 func (r *Runner) deactivateFeature(name string, param string) {
+	r.ui.Debug("deactivating %s (%s)", name, param)
+
 	Deactivate(name, param, r.cfg, r.env)
 	r.env.UnsetFeature(name)
-	r.ui.Debug("%s deactivated", name)
 }

--- a/pkg/features/runner.go
+++ b/pkg/features/runner.go
@@ -27,10 +27,14 @@ func (r *Runner) Run(features map[string]string) {
 		activeVersion, active := activeFeatures[name]
 
 		if want {
-			if !active || wantVersion != activeVersion {
-				r.activateFeature(name, wantVersion)
+			if active {
+				if wantVersion != activeVersion {
+					// r.refreshFeature(name, wantVersion)
+					r.deactivateFeature(name, activeVersion)
+					r.activateFeature(name, wantVersion)
+				}
 			} else {
-				r.refreshFeature(name, wantVersion)
+				r.activateFeature(name, wantVersion)
 			}
 		} else {
 			if active {

--- a/pkg/features/runner_test.go
+++ b/pkg/features/runner_test.go
@@ -1,0 +1,87 @@
+package features
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/devbuddy/devbuddy/pkg/termui"
+
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/env"
+	"github.com/devbuddy/devbuddy/pkg/features/definitions"
+	"github.com/devbuddy/devbuddy/pkg/project"
+)
+
+type recorder struct {
+	entries []string
+}
+
+func (r *recorder) record(s ...string) {
+	r.entries = append(r.entries, strings.Join(s, " "))
+}
+
+func (r *recorder) assert(t *testing.T, s ...string) {
+	require.Equal(t, s, r.entries)
+}
+
+func (r *recorder) reset() {
+	r.entries = []string{}
+}
+
+var featureCalls *recorder
+
+func init() {
+	featureCalls = &recorder{}
+
+	rust := definitions.Register("rust")
+	rust.Activate = func(param string, cfg *config.Config, proj *project.Project, env *env.Env) (bool, error) {
+		featureCalls.record("activate", "rust", param)
+		return false, nil
+	}
+	rust.Deactivate = func(param string, cfg *config.Config, env *env.Env) {
+		featureCalls.record("deactivate", "rust", param)
+	}
+
+	elixir := definitions.Register("elixir")
+	elixir.Activate = func(param string, cfg *config.Config, proj *project.Project, env *env.Env) (bool, error) {
+		featureCalls.record("activate", "elixir", param)
+		return false, nil
+	}
+	elixir.Deactivate = func(param string, cfg *config.Config, env *env.Env) {
+		featureCalls.record("deactivate", "elixir", param)
+	}
+}
+
+func TestRunner(t *testing.T) {
+	_, ui := termui.NewTesting(false)
+
+	runner := &Runner{
+		cfg:  nil,
+		proj: nil,
+		ui:   ui,
+		env:  env.New([]string{}),
+	}
+
+	wantedFeatures := map[string]string{}
+	runner.Run(wantedFeatures)
+
+	featureCalls.assert(t)
+
+	wantedFeatures["rust"] = "1.0"
+	runner.Run(wantedFeatures)
+	featureCalls.assert(t, "activate rust 1.0")
+
+	featureCalls.reset()
+
+	wantedFeatures["rust"] = "2.0"
+	runner.Run(wantedFeatures)
+	featureCalls.assert(t, "deactivate rust 1.0", "activate rust 2.0")
+
+	featureCalls.reset()
+
+	delete(wantedFeatures, "rust")
+	runner.Run(wantedFeatures)
+	featureCalls.assert(t, "deactivate rust 2.0")
+}


### PR DESCRIPTION
## Why

When a feature parameter (like the python or go version) is updated in `dev.yml`, the feature is activated again with the new parameter value, but not deactivated with the previous value before.

In case of Python feature, this leads to multiple entries for the virtualenv in the PATH.
It's not obvious since the order of the entries in the PATH is: new virtualenv, then old virtualenv.

## How

- remove the `refresh` feature operation that was actually not used
- fix the execution logic to:
    - deactivate the feature with the old param
    - activate the feature with the new param
- add tests on the feature execution logic


