### PR TITLE
Install golangci-lint with Homebrew (keep curl-sh as fallback)

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,12 +6,13 @@ up:
   - homebrew:
     - curl
     - shellcheck
+    - golangci/tap/golangci-lint
   - apt:
     - curl
     - shellcheck
   - custom:
       name: Install golangci-lint
-      met?: test -f $GOPATH/bin/golangci-lint
+      met?: which golangci-lint
       meet: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.10.2
 
 commands:


### PR DESCRIPTION
## Why

Homebrew > curl-sh

## How

- Install golangci-lint with the official Homebrew tap
- Keep the custom task to install it with curl-sh as fallback for Linux

