### PR TITLE
Hide the met? command output in the custom task

### DIFF
--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -12,9 +12,9 @@ def test_invalid_manifest_with_string(cmd, project):
     """)
 
     output = cmd.run('bud inspect')
-    assert 'Title' in output
-    assert 'some-condition-command' in output
-    assert 'requirements.txt' in output
+    assert 'Task Custom (Title)' in output
+    assert 'Task Pip (requirements.txt)' in output
+    assert 'Requires: python' in output
 
 
 def test_without_manifest(cmd, project):


### PR DESCRIPTION
## Why

The `custom` task runs a command, declared in the `met?` property to determine whether the `meet` command should run.
If the `met?` command prints to _stdout_, it is displayed to the console, like this:

<img width="529" alt="screen shot 2018-12-26 at 22 38 07" src="https://user-images.githubusercontent.com/60219/50464468-f5fbb380-095e-11e9-8871-3ae5fc5bfb79.png">

## How

- refactor to use the actionBuilder
- replace `Executor.Run()` by `Executor.Capture()`
