### PR TITLE
Adds better api for osidentity.

### DIFF
--- a/pkg/helpers/osidentity/osidentity.go
+++ b/pkg/helpers/osidentity/osidentity.go
@@ -1,5 +1,7 @@
 package osidentity
 
+import "runtime"
+
 // Identity represent how your os behave
 type Identity struct {
 	platform string
@@ -9,6 +11,16 @@ type Identity struct {
 // NewMacOSForTest returns new mac os like identity
 func NewMacOSForTest() *Identity {
 	return &Identity{"darwin", ""}
+}
+
+// NewFromRuntime returns new identity from runtime platform
+func NewFromRuntime() *Identity {
+	return &Identity{runtime.GOOS, ""}
+}
+
+// NewFromRuntimeWithVariant returns new identity from runtime platform and variant
+func NewFromRuntimeWithVariant(variant string) *Identity {
+	return &Identity{runtime.GOOS, variant}
 }
 
 // IsDebianLike returns true if current platform behave like debian (including ubuntu)

--- a/pkg/helpers/osidentity/osidentity_darwin.go
+++ b/pkg/helpers/osidentity/osidentity_darwin.go
@@ -1,8 +1,6 @@
 package osidentity
 
-import "runtime"
-
 // Detect returns an OS identifier.
 func Detect() *Identity {
-	return &Identity{runtime.GOOS, ""}
+	return NewFromRuntime()
 }

--- a/pkg/helpers/osidentity/osidentity_linux.go
+++ b/pkg/helpers/osidentity/osidentity_linux.go
@@ -1,8 +1,6 @@
 package osidentity
 
 import (
-	"runtime"
-
 	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
@@ -14,5 +12,5 @@ func Detect() *Identity {
 		variant = "debian"
 	}
 
-	return &Identity{runtime.GOOS, variant}
+	return NewFromRuntimeWithVariant(variant)
 }


### PR DESCRIPTION
## Why

Simplying api for indentifying os identity and allowing later to use the identity api in many other places



## How


