### PR TITLE
Remove deprecated Task.perform

### DIFF
--- a/pkg/tasks/task.go
+++ b/pkg/tasks/task.go
@@ -5,7 +5,6 @@ type Task struct {
 	*taskDefinition
 	header       string
 	actions      []taskAction
-	perform      func(*Context) error
 	featureName  string
 	featureParam string
 }

--- a/pkg/tasks/task_runner.go
+++ b/pkg/tasks/task_runner.go
@@ -48,13 +48,6 @@ type TaskRunner interface {
 type TaskRunnerImpl struct{}
 
 func (r *TaskRunnerImpl) Run(ctx *Context, task *Task) (err error) {
-	if task.perform != nil {
-		err = task.perform(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
 	for _, action := range task.actions {
 		err = runAction(ctx, action)
 		if err != nil {

--- a/pkg/tasks/unknown.go
+++ b/pkg/tasks/unknown.go
@@ -5,9 +5,10 @@ import (
 )
 
 func parseUnknown(config *taskConfig, task *Task) error {
-	task.perform = func(ctx *Context) (err error) {
+	builder := actionBuilder("", func(ctx *Context) error {
 		ctx.ui.TaskWarning(fmt.Sprintf("Unknown task: \"%s\"", config.name))
 		return nil
-	}
+	})
+	task.addAction(builder.Build())
 	return nil
 }


### PR DESCRIPTION
## Why

The `unknown` task was the last one to use the deprecated `perform` function.

## How


