### PR TITLE
Json store

### DIFF
--- a/pkg/helpers/projectmetadata/projectmetadata.go
+++ b/pkg/helpers/projectmetadata/projectmetadata.go
@@ -13,36 +13,43 @@ var dirName = ".devbuddy"
 
 // ProjectMetadata is the place to store metadata files about a project
 type ProjectMetadata struct {
-	projectPath string
+	path string
 }
 
 // New returns an instance of ProjectMetadata
 func New(projectPath string) *ProjectMetadata {
-	return &ProjectMetadata{projectPath: projectPath}
-}
-
-func (p *ProjectMetadata) Path() string {
-	return filepath.Join(p.projectPath, dirName)
-}
-
-// Prepare makes sure the metadata directory is ready
-func (p *ProjectMetadata) Prepare() (err error) {
-	if !utils.PathExists(p.projectPath) {
-		return fmt.Errorf("failed to initialize the project metadata dir: path does not exist: %s", p.projectPath)
+	if !utils.PathExists(projectPath) {
+		panic("project path does not exist: " + projectPath)
 	}
 
-	if !utils.PathExists(p.Path()) {
-		err = os.MkdirAll(p.Path(), 0755)
+	return &ProjectMetadata{
+		path: filepath.Join(projectPath, dirName),
+	}
+}
+
+// Path returns the path of the project metadata directory.
+func (p *ProjectMetadata) Path() (string, error) {
+	err := p.prepare()
+	if err != nil {
+		return "", fmt.Errorf("failed to initialize the project metadata dir: %s", err)
+	}
+
+	return p.path, nil
+}
+
+func (p *ProjectMetadata) prepare() error {
+	if !utils.PathExists(p.path) {
+		err := os.MkdirAll(p.path, 0755)
 		if err != nil {
-			return
+			return err
 		}
 	}
 
-	gitignore := filepath.Join(p.Path(), ".gitignore")
+	gitignore := filepath.Join(p.path, ".gitignore")
 	if !utils.PathExists(gitignore) {
-		err = ioutil.WriteFile(gitignore, []byte("*"), 0644)
+		err := ioutil.WriteFile(gitignore, []byte("*"), 0644)
 		if err != nil {
-			return
+			return err
 		}
 	}
 	return nil

--- a/pkg/helpers/projectmetadata/projectmetadata.go
+++ b/pkg/helpers/projectmetadata/projectmetadata.go
@@ -1,0 +1,49 @@
+package projectmetadata
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/devbuddy/devbuddy/pkg/utils"
+)
+
+var dirName = ".devbuddy"
+
+// ProjectMetadata is the place to store metadata files about a project
+type ProjectMetadata struct {
+	projectPath string
+}
+
+// New returns an instance of ProjectMetadata
+func New(projectPath string) *ProjectMetadata {
+	return &ProjectMetadata{projectPath: projectPath}
+}
+
+func (p *ProjectMetadata) Path() string {
+	return filepath.Join(p.projectPath, dirName)
+}
+
+// Prepare makes sure the metadata directory is ready
+func (p *ProjectMetadata) Prepare() (err error) {
+	if !utils.PathExists(p.projectPath) {
+		return fmt.Errorf("failed to initialize the project metadata dir: path does not exist: %s", p.projectPath)
+	}
+
+	if !utils.PathExists(p.Path()) {
+		err = os.MkdirAll(p.Path(), 0755)
+		if err != nil {
+			return
+		}
+	}
+
+	gitignore := filepath.Join(p.Path(), ".gitignore")
+	if !utils.PathExists(gitignore) {
+		err = ioutil.WriteFile(gitignore, []byte("*"), 0644)
+		if err != nil {
+			return
+		}
+	}
+	return nil
+}

--- a/pkg/helpers/projectmetadata/projectmetadata_test.go
+++ b/pkg/helpers/projectmetadata/projectmetadata_test.go
@@ -1,0 +1,25 @@
+package projectmetadata_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Flaque/filet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/devbuddy/devbuddy/pkg/helpers/projectmetadata"
+)
+
+func Test(t *testing.T) {
+	defer filet.CleanUp(t)
+	tmpdir := filet.TmpDir(t, "")
+
+	path, err := projectmetadata.New(tmpdir).Path()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(tmpdir, ".devbuddy"), path)
+	require.DirExists(t, path)
+
+	gitignorePath := filepath.Join(path, ".gitignore")
+	require.FileExists(t, gitignorePath)
+	require.True(t, filet.FileSays(t, gitignorePath, []byte("*")))
+}

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -16,32 +16,24 @@ type fileData struct {
 
 // Store is the place to record information or keep files about a project
 type Store struct {
-	projectMetadata *projectmetadata.ProjectMetadata
+	path string
 }
 
-// New returns an instance of Store
-func New(projectPath string) *Store {
-	return &Store{projectMetadata: projectmetadata.New(projectPath)}
-}
-
-func (s *Store) path() (string, error) {
-	path, err := s.projectMetadata.Path()
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(path, "store"), nil
-}
-
-func (s *Store) read() (*fileData, error) {
-	path, err := s.path()
+// Open returns an instance of Store
+func Open(projectPath, tableName string) (*Store, error) {
+	path, err := projectmetadata.New(projectPath).Path()
 	if err != nil {
 		return nil, err
 	}
+	filename := "store-" + tableName
+	return &Store{path: filepath.Join(path, filename)}, nil
+}
 
+func (s *Store) read() (*fileData, error) {
 	data := &fileData{Entries: make(map[string]string)}
 
-	if utils.PathExists(path) {
-		serialized, err := ioutil.ReadFile(path)
+	if utils.PathExists(s.path) {
+		serialized, err := ioutil.ReadFile(s.path)
 		if err != nil {
 			return nil, err
 		}
@@ -55,21 +47,16 @@ func (s *Store) read() (*fileData, error) {
 }
 
 func (s *Store) write(data *fileData) error {
-	path, err := s.path()
-	if err != nil {
-		return err
-	}
-
 	serialized, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
 		return err
 	}
 
-	return ioutil.WriteFile(path, serialized, 0644)
+	return ioutil.WriteFile(s.path, serialized, 0644)
 }
 
 // SetString stores a string for a key
-func (s *Store) SetString(key string, value string) error {
+func (s *Store) SetString(key, value string) error {
 	if key == "" {
 		return errors.New("empty string is not a valid key")
 	}
@@ -78,6 +65,7 @@ func (s *Store) SetString(key string, value string) error {
 	if err != nil {
 		return err
 	}
+
 	data.Entries[key] = value
 	return s.write(data)
 }
@@ -92,5 +80,6 @@ func (s *Store) GetString(key string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return data.Entries[key], nil
 }

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -1,128 +1,94 @@
 package store
 
 import (
+	"encoding/json"
 	"errors"
-	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
-	"strings"
 
+	"github.com/devbuddy/devbuddy/pkg/helpers/projectmetadata"
 	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
-var dirName = ".devbuddy"
+type fileData struct {
+	Entries map[string]string `json:"entries"`
+}
+
+func newFileData() *fileData {
+	return &fileData{Entries: make(map[string]string)}
+}
 
 // Store is the place to record information or keep files about a project
 type Store struct {
-	projectPath string
+	projectMetadata *projectmetadata.ProjectMetadata
 }
 
 // New returns an instance of Store
 func New(projectPath string) *Store {
-	return &Store{projectPath: projectPath}
+	return &Store{projectMetadata: projectmetadata.New(projectPath)}
 }
 
 func (s *Store) path() string {
-	return filepath.Join(s.projectPath, dirName)
+	return filepath.Join(s.projectMetadata.Path(), "store")
 }
 
-func (s *Store) pathForKey(key string) string {
-	filePathForKey := strings.Replace(key, string(filepath.Separator), "--", -1)
-	return filepath.Join(s.path(), filePathForKey)
-}
-
-func (s *Store) ensureInit() (err error) {
-	if !utils.PathExists(s.projectPath) {
-		return fmt.Errorf("failed to initialize the store: project path does not exist: %s", s.projectPath)
-	}
+func (s *Store) read() (*fileData, error) {
+	data := newFileData()
 
 	if !utils.PathExists(s.path()) {
-		err = os.MkdirAll(s.path(), 0755)
-		if err != nil {
-			return
-		}
+		return data, nil
 	}
 
-	gitignore := filepath.Join(s.path(), ".gitignore")
-	if !utils.PathExists(gitignore) {
-		err = ioutil.WriteFile(gitignore, []byte("*"), 0644)
-		if err != nil {
-			return
-		}
+	serialized, err := ioutil.ReadFile(s.path())
+	if err != nil {
+		return nil, err
 	}
-	return nil
+	err = json.Unmarshal(serialized, data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
-// Set stores a byte slice for a key
-func (s *Store) Set(key string, value []byte) error {
-	if key == "" {
-		return errors.New("empty string is an invalid key")
-	}
-
-	err := s.ensureInit()
+func (s *Store) write(data *fileData) error {
+	serialized, err := json.MarshalIndent(data, "", "    ")
 	if err != nil {
 		return err
 	}
-
-	return ioutil.WriteFile(s.pathForKey(key), value, 0644)
+	return ioutil.WriteFile(s.path(), serialized, 0644)
 }
 
 // SetString stores a string for a key
 func (s *Store) SetString(key string, value string) error {
-	return s.Set(key, []byte(value))
-}
-
-// Get retrieves a byte slice for a key
-func (s *Store) Get(key string) ([]byte, error) {
 	if key == "" {
-		return nil, errors.New("empty string is an invalid key")
+		return errors.New("empty string is not a valid key")
 	}
 
-	pathForKey := s.pathForKey(key)
-
-	if _, err := os.Stat(pathForKey); os.IsNotExist(err) {
-		return nil, nil
-	}
-
-	content, err := ioutil.ReadFile(pathForKey)
+	err := s.projectMetadata.Prepare()
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return content, nil
+	data, err := s.read()
+	if err != nil {
+		return err
+	}
+	data.Entries[key] = value
+	return s.write(data)
 }
 
 // GetString retrieves a string for a key
 func (s *Store) GetString(key string) (string, error) {
-	value, err := s.Get(key)
-	return string(value), err
-}
-
-// DEPRECATED: don't use the RecordFileChange/HasFileChanged methods, they will be removed.
-// It should not be part of the Store
-
-// RecordFileChange stores the modification time of a file.
-func (s *Store) RecordFileChange(path string) error {
-	checksum, err := utils.FileChecksum(filepath.Join(s.projectPath, path))
-	if err != nil {
-		return err
-	}
-	return s.SetString(s.pathForKey("checksum-"+path), checksum)
-}
-
-// HasFileChanged detects whether a path has changed since the last call to RecordFileChange().
-// Defaults to true if path doesn't exists or RecordFileChange() was never called.
-func (s *Store) HasFileChanged(path string) (bool, error) {
-	checksum, err := utils.FileChecksum(filepath.Join(s.projectPath, path))
-	if err != nil {
-		return true, nil
+	if key == "" {
+		return "", errors.New("empty string is not a valid key")
 	}
 
-	content, err := s.GetString(s.pathForKey("checksum-" + path))
+	err := s.projectMetadata.Prepare()
 	if err != nil {
-		return true, nil
+		return "", err
 	}
-
-	return checksum != content, nil
+	data, err := s.read()
+	if err != nil {
+		return "", err
+	}
+	return data.Entries[key], nil
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/Flaque/filet"
 )
 
+func open(path string) *Store {
+	store, err := Open(path, "testTable")
+	if err != nil {
+		panic("failed to open the store")
+	}
+	return store
+}
+
 func TestSetGetString(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
@@ -16,10 +24,10 @@ func TestSetGetString(t *testing.T) {
 	testValues := []string{"DUMMY", "", "   "}
 
 	for _, testVal := range testValues {
-		err := New(tmpdir).SetString("key", testVal)
+		err := open(tmpdir).SetString("key", testVal)
 		require.NoError(t, err)
 
-		val, err := New(tmpdir).GetString("key")
+		val, err := open(tmpdir).GetString("key")
 		require.NoError(t, err)
 		assert.Equal(t, testVal, val)
 	}
@@ -29,10 +37,10 @@ func TestKeyEmpty(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
 
-	_, err := New(tmpdir).GetString("")
+	_, err := open(tmpdir).GetString("")
 	require.EqualError(t, err, "empty string is not a valid key")
 
-	err = New(tmpdir).SetString("", "")
+	err = open(tmpdir).SetString("", "")
 	require.EqualError(t, err, "empty string is not a valid key")
 }
 
@@ -40,7 +48,7 @@ func TestGetStringNotFound(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
 
-	val, err := New(tmpdir).GetString("doesnotexist")
+	val, err := open(tmpdir).GetString("doesnotexist")
 	require.NoError(t, err)
 	require.Equal(t, "", val)
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -9,45 +9,17 @@ import (
 	"github.com/Flaque/filet"
 )
 
-func TestProjectPathMissing(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
-	s := New(tmpdir + "/nopenope")
-
-	err := s.SetString("dummy", "")
-	require.Error(t, err)
-}
-
-func TestInitialization(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
-	s := New(tmpdir)
-
-	err := s.SetString("dummykey", "dummy")
-	require.NoError(t, err)
-
-	filet.DirContains(t, tmpdir, ".devbuddy/store")
-
-	filet.DirContains(t, tmpdir, ".devbuddy/.gitignore")
-	filet.FileSays(t, tmpdir+"/.devbuddy/.gitignore", []byte("*"))
-}
-
 func TestSetGetString(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
-	s := New(tmpdir)
 
-	testValues := []string{
-		"DUMMY",
-		"",
-		"   ",
-	}
+	testValues := []string{"DUMMY", "", "   "}
 
 	for _, testVal := range testValues {
-		err := s.SetString("key", testVal)
+		err := New(tmpdir).SetString("key", testVal)
 		require.NoError(t, err)
 
-		val, err := s.GetString("key")
+		val, err := New(tmpdir).GetString("key")
 		require.NoError(t, err)
 		assert.Equal(t, testVal, val)
 	}
@@ -56,21 +28,19 @@ func TestSetGetString(t *testing.T) {
 func TestKeyEmpty(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
-	s := New(tmpdir)
 
-	_, err := s.GetString("")
+	_, err := New(tmpdir).GetString("")
 	require.EqualError(t, err, "empty string is not a valid key")
 
-	err = s.SetString("", "")
+	err = New(tmpdir).SetString("", "")
 	require.EqualError(t, err, "empty string is not a valid key")
 }
 
 func TestGetStringNotFound(t *testing.T) {
 	defer filet.CleanUp(t)
 	tmpdir := filet.TmpDir(t, "")
-	s := New(tmpdir)
 
-	val, err := s.GetString("doesnotexist")
+	val, err := New(tmpdir).GetString("doesnotexist")
 	require.NoError(t, err)
 	require.Equal(t, "", val)
 }

--- a/pkg/tasks/taskapi/task_action_generic.go
+++ b/pkg/tasks/taskapi/task_action_generic.go
@@ -101,7 +101,12 @@ func genericTaskActionPreConditionForFile(ctx *Context, path string) *ActionResu
 		return ActionFailed("failed to get the file checksum: %s", err)
 	}
 
-	storedChecksum, err := store.New(ctx.Project.Path).GetString("checksum" + path)
+	checksumStore, err := store.Open(ctx.Project.Path, "checksum")
+	if err != nil {
+		return ActionFailed("failed to open the internal project state: %s", err)
+	}
+
+	storedChecksum, err := checksumStore.GetString(path)
 	if err != nil {
 		return ActionFailed("failed to read the previous file checksum: %s", err)
 	}
@@ -124,7 +129,12 @@ func genericTaskActionPostConditionForFile(ctx *Context, path string) *ActionRes
 		return ActionFailed("failed to get the file checksum: %s", err)
 	}
 
-	err = store.New(ctx.Project.Path).SetString("checksum"+path, fileChecksum)
+	checksumStore, err := store.Open(ctx.Project.Path, "checksum")
+	if err != nil {
+		return ActionFailed("failed to open the internal project state: %s", err)
+	}
+
+	err = checksumStore.SetString(path, fileChecksum)
 	if err != nil {
 		return ActionFailed("failed to store the current file checksum: %s", err)
 	}


### PR DESCRIPTION
## Why

The current store implementation is sketchy and sometimes annoying (#204).

## How

- Split the implementation into a store and a projectmetadata package 
- projectmetadata is handling the `.devbuddy` dir itself, and the `.gitignore` file
- store the entries in a JSON file like `{"entries": {"KEY": "VALUE"}}`

