### PR TITLE
Add support for Go modules

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,7 @@
 up:
-  - go: '1.12'
+  - go:
+      version: '1.12'
+      modules: true
   - python: 3.6.5
   - pip: [tests/requirements.txt]
   - homebrew:

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -17,7 +17,9 @@ The `open` section describes the project links available through `bud open <name
 **`dev.yml`**:
 ```yaml
 up:
-  - go: 1.10.1
+  - go:
+      version: '1.12'
+      modules: true
   - golang_dep
   - python: 3.6.5
   - apt: [git, curl]
@@ -125,6 +127,14 @@ in your shell (with `GOROOT`).
 ```yaml
 up:
   - go: 1.10.1
+```
+
+Force the usage of Go modules:
+```yaml
+up:
+  - go:
+      version: '1.12'
+      modules: true
 ```
 
 ### `golang_dep`

--- a/pkg/autoenv/features/golang.go
+++ b/pkg/autoenv/features/golang.go
@@ -38,7 +38,7 @@ func golangDeactivate(ctx *context.Context, version string) {
 	ctx.Env.Unset("GOROOT")
 }
 
-const golangModulesSuffix = "+modules"
+const golangModulesSuffix = "+mod"
 
 func golangExtractVersion(version string) string {
 	return strings.TrimSuffix(version, golangModulesSuffix)

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -15,6 +15,19 @@ func parseGolang(config *taskapi.TaskConfig, task *taskapi.Task) error {
 	if err != nil {
 		return err
 	}
+
+	modulesEnabled := false
+	if config.IsHash() {
+		modulesEnabled, err = config.GetBooleanPropertyDefault("modules", false)
+		if err != nil {
+			return err
+		}
+	}
+	featureVersion := version
+	if modulesEnabled {
+		featureVersion += "+modules"
+	}
+
 	task.Info = version
 
 	checkPATHVar := func(ctx *context.Context) *taskapi.ActionResult {
@@ -40,7 +53,7 @@ func parseGolang(config *taskapi.TaskConfig, task *taskapi.Task) error {
 	}
 	task.AddActionWithBuilder("install golang distribution", installGo).
 		OnFunc(installNeeded).
-		SetFeature("golang", version)
+		SetFeature("golang", featureVersion)
 
 	return nil
 }

--- a/pkg/tasks/golang.go
+++ b/pkg/tasks/golang.go
@@ -25,7 +25,7 @@ func parseGolang(config *taskapi.TaskConfig, task *taskapi.Task) error {
 	}
 	featureVersion := version
 	if modulesEnabled {
-		featureVersion += "+modules"
+		featureVersion += "+mod"
 	}
 
 	task.Info = version

--- a/pkg/tasks/taskapi/task_config.go
+++ b/pkg/tasks/taskapi/task_config.go
@@ -42,6 +42,11 @@ func NewTaskConfig(definition interface{}) (*TaskConfig, error) {
 	return nil, fmt.Errorf("invalid task: \"%+v\"", definition)
 }
 
+// IsHash returns a boolean indicating whether the payload is a hash
+func (c *TaskConfig) IsHash() bool {
+	return reflect.ValueOf(c.payload).Kind() == reflect.Map
+}
+
 // GetListOfStrings expects the payload to be a list of string, returns it.
 //
 // YAML Example:

--- a/pkg/tasks/taskapi/task_config_test.go
+++ b/pkg/tasks/taskapi/task_config_test.go
@@ -6,6 +6,20 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTaskConfigIsHash(t *testing.T) {
+	config := &TaskConfig{
+		payload: map[interface{}]interface{}{},
+	}
+
+	require.True(t, config.IsHash())
+
+	config = &TaskConfig{
+		payload: "",
+	}
+
+	require.False(t, config.IsHash())
+}
+
 func TestTaskConfigProperty(t *testing.T) {
 	config := &TaskConfig{
 		name:    "test",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,6 +143,9 @@ class ProjectTestHelper:
         with open(os.path.join(self.path, local_path), 'w') as fp:
             fp.write(data)
 
+    def write_file_dedent(self, local_path, data):
+        self.write_file(local_path, textwrap.dedent(data).lstrip())
+
     def assert_file(self, local_path, expect_content=None, present=True):
         path = os.path.join(self.path, local_path)
 

--- a/tests/test_task_go.py
+++ b/tests/test_task_go.py
@@ -30,3 +30,50 @@ def test_warn_gopath_missing(cmd, project, gopath):
 
     output = cmd.run("bud up", expect_exit_code=1)
     assert "The GOPATH environment variable should be set" in output
+
+
+def test_with_modules(cmd, project, gopath):
+    # We want to support pre-modules and modules projects in the same environment
+    # so we set a GOPATH as it would be for pre-modules setup
+    # Devbuddy will set GO111MODULES=on to force-enable Go modules even if we are in the GOPATH
+    cmd.run(f"export GOPATH={gopath}")
+
+    project.write_devyml("""
+        up:
+        - go:
+            version: '1.12'
+            modules: true
+    """)
+
+    output = cmd.run("bud up")
+
+    project.write_file_dedent("main.go", """
+        package main
+
+        import (
+            "fmt"
+            "github.com/spf13/pflag"
+        )
+
+        func main() {
+            pflag.Parse()
+            fmt.Println(pflag.Arg(0))
+        }
+    """)
+
+    project.write_file_dedent("go.mod", """
+        module poipoi
+
+        require github.com/spf13/pflag v1.0.3
+    """)
+
+    project.write_file_dedent("go.sum", """
+        github.com/spf13/pflag v1.0.3 h1:zPAT6CGy6wXeQ7NtTnaTerfKOsV6V6F8agHXFiazDkg=
+        github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+    """)
+
+    cmd.run("go mod tidy")
+    cmd.run("go mod download")
+
+    output = cmd.run("go run main.go Test1234")
+    assert output == "Test1234"


### PR DESCRIPTION
## Why

Since Go 1.11, the Go modules are available if the project is located outside GOPATH or `GO111MODULES` is set to `on`. 

We should expect users to continue set GOPATH to `~` and cloning their projects in `~/src` (since it's a static config in DevBuddy).
So supporting pre-modules and modules projects means that DevBuddy should set `GO111MODULES` to `on` for projects with modules.

To stay compatible with Dev, we should expect the user to set a `modules: true` in `dev.yml`

## How


Resolves #282

