### PR TITLE
Improve error message when shell integration is incorrect

### DIFF
--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -47,14 +47,24 @@ func AddFinalizerCd(path string) error {
 	return addFinalizer("cd", path)
 }
 
+func formatError(message string) error {
+	return fmt.Errorf(`there is something wrong this the shell integration:
+
+    %s
+
+Please follow the setup steps: https://github.com/devbuddy/devbuddy/tree/v0.9.0#setup
+
+If you did already, then please open an issue on https://github.com/devbuddy/devbuddy/issues/new?labels=bug
+`, message)
+}
+
 func addFinalizer(action, arg string) (err error) {
 	content := fmt.Sprintf("%s:%s\n", action, arg)
 
 	finalizerPath := os.Getenv("BUD_FINALIZER_FILE")
 
 	if finalizerPath == "" {
-		termui.HookIntegrationError("can't run a finalizer action: " + content)
-		return nil
+		return formatError("the BUD_FINALIZER_FILE environment variable is missing or empty")
 	}
 
 	return writeFile(finalizerPath, content)

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -52,9 +52,11 @@ func formatError(message string) error {
 
     %s
 
+This usually means that DevBuddy is not setup properly.
 Please follow the setup steps: https://github.com/devbuddy/devbuddy/tree/v0.9.0#setup
 
-If you did already, then please open an issue on https://github.com/devbuddy/devbuddy/issues/new?labels=bug
+If DevBuddy is already setup, then please open an issue on https://github.com/devbuddy/devbuddy/issues/new?labels=bug
+You can use "bud --report-issue" to do that.
 `, message)
 }
 

--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -21,7 +21,3 @@ func (u *UI) HookFeatureFailure(name string, version string) {
 func HookShellDetectionError(err error) {
 	Fprintf(os.Stderr, "%s %s\n", color.Brown("Could not detect your shell:"), err.Error())
 }
-
-func HookIntegrationError(message string) {
-	Fprintf(os.Stderr, "%s: %s", color.Red("Shell integration error:"), message)
-}


### PR DESCRIPTION
## Why

When the shell integration is incorrect, the error message is pretty unhelpful:

```
bud clone devbuddy/devbuddy Cloning into '/Users/xxx/src/github.com/devbuddy/devbuddy'... 
🐼 jumping to github.com:devbuddy/devbuddy 
Shell integration error:: can't run a finalizer action: cd:/Users/xxx/src/github.com/devbuddy/devbuddy
```

Ping @celsodantas

## How

Update the error message
