### PR TITLE
Fix silent and harmless error in hook caused by printing to stdout

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -16,13 +16,16 @@ type Context struct {
 }
 
 // Load returns a Context, even if the project was not found
-func Load() (*Context, error) {
+func Load(hookMode bool) (*Context, error) {
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
 	}
 
 	ui := termui.New(cfg)
+	if hookMode {
+		ui.SetOutputToStderr()
+	}
 
 	proj, err := project.FindCurrent()
 	if err != nil {
@@ -46,7 +49,7 @@ func Load() (*Context, error) {
 
 // LoadWithProject returns a Context, fails if the project is not found
 func LoadWithProject() (*Context, error) {
-	ctx, err := Load()
+	ctx, err := Load(false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hook/hook.go
+++ b/pkg/hook/hook.go
@@ -17,11 +17,10 @@ func Run() {
 
 	// Also, we can't annoy the user here, so we always just quit silently
 
-	ctx, err := context.Load()
+	ctx, err := context.Load(true)
 	if err != nil {
 		return
 	}
-	ctx.UI.SetOutputToStderr()
 
 	err = run(ctx)
 	if err != nil {

--- a/pkg/integration/common.go
+++ b/pkg/integration/common.go
@@ -17,7 +17,7 @@ bud() {
     # Perform finalizers
     local fin
     while read -r fin; do
-        [ -n "${BUD_DEBUG:-}" ] && echo "BUD_DEBUG: finalizer: ${fin}"
+        __bud_log_debug "finalizer: ${fin}"
 
         case "${fin}" in
             cd:*)
@@ -44,18 +44,23 @@ __bud_prompt_command() {
 
     local hook_eval
     hook_eval="$(command bud --shell-hook)"
-    [ -n "${BUD_DEBUG:-}" ] && echo -e "BUD_DEBUG: Hook eval:\n${hook_eval}\n---"
+    __bud_log_debug "Hook eval:\n--------\n${hook_eval}\n--------"
     eval "${hook_eval}"
+}
+
+__bud_log_debug() {
+    [ -n "${BUD_DEBUG:-}" ] || return
+    echo -e "BUD_HOOK_DEBUG: $@"
 }
 
 bud-enable-debug() {
     export BUD_DEBUG=1
-    echo "BUD_DEBUG: enabled"
+    __bud_log_debug "debug log enabled"
 }
 
 bud-disable-debug() {
+    __bud_log_debug "debug log disable"
     unset BUD_DEBUG
-    echo "BUD_DEBUG: disable"
 }
 
 if [[ -n "${BUD_DEBUG:-}" ]]; then


### PR DESCRIPTION
## Why

The hook code was printing a debug statement into stdout:

```
[pior] ~ $
BUD_DEBUG: features: map[]
BUD_DEBUG: Hook eval:
BUD_DEBUG: Project not found
---
-bash: BUD_DEBUG:: command not found
```

This was caused by a recent change with the context loader.

## How

- improve the debug logs in the shell prompt hook to improve debuggability 
- fix the context loader to stop logging to the wrong fd
