### PR TITLE
Install version 0.9.1 when using install script.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-VERSION="v0.7.0"
+VERSION="v0.9.1"
 DEST="/usr/local/bin"
 SHELL_LINE='eval "$(bud --shell-init --with-completion)"'
 


### PR DESCRIPTION
## Why

Install version 0.9.1 in place of version 0.7.0


