### PR TITLE
Add an option to open a GH issue and display debug info

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/devbuddy/devbuddy/pkg/helpers/debug"
-	"github.com/devbuddy/devbuddy/pkg/helpers/open"
-
 	"github.com/spf13/cobra"
 
+	"github.com/devbuddy/devbuddy/pkg/helpers/debug"
+	"github.com/devbuddy/devbuddy/pkg/helpers/open"
 	"github.com/devbuddy/devbuddy/pkg/hook"
 	"github.com/devbuddy/devbuddy/pkg/integration"
 )

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -25,7 +25,7 @@ func build(version string) {
 	rootCmd.Flags().Bool("shell-init", false, "Shell initialization")
 	rootCmd.Flags().Bool("with-completion", false, "Enable completion during initialization")
 
-	rootCmd.Flags().Bool("debug-info", false, "Show debug information to create an issue")
+	rootCmd.Flags().Bool("debug-info", false, "Print some debug information")
 	rootCmd.Flags().Bool("report-issue", false, "Create an issue about DevBuddy on Github")
 
 	rootCmd.Flags().Bool("shell-hook", false, "Shell prompt hook")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -65,7 +65,8 @@ func rootRun(cmd *cobra.Command, args []string) {
 
 	if GetFlagBool(cmd, "report-issue") {
 		url := debug.NewGithubIssueURL(rootCmd.Version, os.Environ(), debug.SafeFindCurrentProject())
-		open.Open(url)
+		err := open.Open(url)
+		checkError(err)
 		os.Exit(0)
 	}
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -25,7 +25,7 @@ func build(version string) {
 	rootCmd.Flags().Bool("shell-init", false, "Shell initialization")
 	rootCmd.Flags().Bool("with-completion", false, "Enable completion during initialization")
 
-	rootCmd.Flags().Bool("show-debug-info", false, "Show debug information to create an issue")
+	rootCmd.Flags().Bool("debug-info", false, "Show debug information to create an issue")
 	rootCmd.Flags().Bool("report-issue", false, "Create an issue about DevBuddy on Github")
 
 	rootCmd.Flags().Bool("shell-hook", false, "Shell prompt hook")
@@ -59,7 +59,7 @@ func rootRun(cmd *cobra.Command, args []string) {
 		os.Exit(0)
 	}
 
-	if GetFlagBool(cmd, "show-debug-info") {
+	if GetFlagBool(cmd, "debug-info") {
 		fmt.Println(debug.FormatDebugInfo(rootCmd.Version, os.Environ(), debug.SafeFindCurrentProject()))
 		os.Exit(0)
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -1,7 +1,11 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+
+	"github.com/devbuddy/devbuddy/pkg/helpers/debug"
+	"github.com/devbuddy/devbuddy/pkg/helpers/open"
 
 	"github.com/spf13/cobra"
 
@@ -20,6 +24,9 @@ func build(version string) {
 
 	rootCmd.Flags().Bool("shell-init", false, "Shell initialization")
 	rootCmd.Flags().Bool("with-completion", false, "Enable completion during initialization")
+
+	rootCmd.Flags().Bool("show-debug-info", false, "Show debug information to create an issue")
+	rootCmd.Flags().Bool("report-issue", false, "Create an issue about DevBuddy on Github")
 
 	rootCmd.Flags().Bool("shell-hook", false, "Shell prompt hook")
 	err := rootCmd.Flags().MarkHidden("shell-hook")
@@ -49,6 +56,17 @@ func rootRun(cmd *cobra.Command, args []string) {
 
 	if GetFlagBool(cmd, "shell-hook") {
 		hook.Run()
+		os.Exit(0)
+	}
+
+	if GetFlagBool(cmd, "show-debug-info") {
+		fmt.Println(debug.FormatDebugInfo(rootCmd.Version, os.Environ(), debug.SafeFindCurrentProject()))
+		os.Exit(0)
+	}
+
+	if GetFlagBool(cmd, "report-issue") {
+		url := debug.NewGithubIssueURL(rootCmd.Version, os.Environ(), debug.SafeFindCurrentProject())
+		open.Open(url)
 		os.Exit(0)
 	}
 

--- a/pkg/helpers/debug/debug.go
+++ b/pkg/helpers/debug/debug.go
@@ -46,7 +46,7 @@ What happened? What did you expect?
 `
 	body += FormatDebugInfo(version, environ, projectPath)
 	bodyParam := url.QueryEscape(body)
-	return fmt.Sprintf("https://github.com/devbuddy/devbuddy/issues/new?body=%s", bodyParam)
+	return fmt.Sprintf("https://github.com/devbuddy/devbuddy/issues/new?labels=user-bug&body=%s", bodyParam)
 }
 
 // SafeFindCurrentProject returns the path of the project if found, and an empty string otherwise

--- a/pkg/helpers/debug/debug.go
+++ b/pkg/helpers/debug/debug.go
@@ -1,0 +1,122 @@
+package debug
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/devbuddy/devbuddy/pkg/manifest"
+	"github.com/devbuddy/devbuddy/pkg/project"
+)
+
+func FormatDebugInfo(version string, environ []string, projectPath string) string {
+	tmpl := `
+**DevBuddy version**
+
+` + "`%s`" + `
+
+**Environment**
+
+%s
+**dev.yml**
+
+%s
+`
+
+	man := "Project not found."
+	if projectPath != "" {
+		man = fmtManifest(projectPath)
+	}
+
+	return fmt.Sprintf(tmpl, version, fmtEnvVar(environ), man)
+}
+
+func NewGithubIssueURL(version string, environ []string, projectPath string) string {
+	body := `
+## Describe the issue
+
+What happened? What did you expect?
+
+## Steps to reproduce
+
+1. ...
+2. ...
+
+## Debug Information
+`
+	body += FormatDebugInfo(version, environ, projectPath)
+	bodyParam := url.QueryEscape(body)
+	return fmt.Sprintf("https://github.com/devbuddy/devbuddy/issues/new?body=%s", bodyParam)
+}
+
+// SafeFindCurrentProject returns the path of the project if found, and an empty string otherwise
+func SafeFindCurrentProject() string {
+	proj, err := project.FindCurrent()
+	if err != nil {
+		return ""
+	}
+	return proj.Path
+}
+
+func fmtEnvVar(environ []string) string {
+	names := [][]string{
+		[]string{
+			"SHELL",
+			"SHLVL",
+			"TERM",
+		},
+		[]string{
+			"PATH",
+			"USER",
+			"PWD",
+		},
+		[]string{
+			"BUD_DEBUG",
+			"BUD_FINALIZER_FILE",
+			"BUD_AUTO_ENV_FEATURES",
+		},
+		[]string{
+			"GOROOT",
+			"GOPATH",
+			"GO111MODULE",
+			"VIRTUAL_ENV",
+		},
+	}
+
+	vars := environAsMap(environ)
+
+	out := "```shell\n"
+	for idx, section := range names {
+		if idx != 0 {
+			out += "\n"
+		}
+		for _, name := range section {
+			out += fmt.Sprintf("%s=\"%s\"\n", name, vars[name])
+		}
+	}
+	out += "```\n"
+	return out
+}
+
+func environAsMap(environ []string) map[string]string {
+	vars := map[string]string{}
+	for _, entry := range environ {
+		splitted := strings.SplitN(entry, "=", 2)
+		vars[splitted[0]] = splitted[1]
+	}
+	return vars
+}
+
+func fmtManifest(path string) string {
+	man, err := manifest.Load(path)
+	if err != nil {
+		return fmt.Sprintf("Failed to read manifest: %s", err)
+	}
+
+	out := fmt.Sprintf("Project path: `%s`\n\n", path)
+
+	for idx, task := range man.Up {
+		out += fmt.Sprintf("%d. `%+v`\n", idx, task)
+	}
+	return out
+}

--- a/pkg/helpers/debug/debug.go
+++ b/pkg/helpers/debug/debug.go
@@ -60,22 +60,22 @@ func SafeFindCurrentProject() string {
 
 func fmtEnvVar(environ []string) string {
 	names := [][]string{
-		[]string{
+		{
 			"SHELL",
 			"SHLVL",
 			"TERM",
 		},
-		[]string{
+		{
 			"PATH",
 			"USER",
 			"PWD",
 		},
-		[]string{
+		{
 			"BUD_DEBUG",
 			"BUD_FINALIZER_FILE",
 			"BUD_AUTO_ENV_FEATURES",
 		},
-		[]string{
+		{
 			"GOROOT",
 			"GOPATH",
 			"GO111MODULE",

--- a/pkg/helpers/debug/debug_test.go
+++ b/pkg/helpers/debug/debug_test.go
@@ -1,0 +1,1 @@
+package debug

--- a/pkg/helpers/debug/debug_test.go
+++ b/pkg/helpers/debug/debug_test.go
@@ -31,6 +31,6 @@ func TestFormatDebugInfo(t *testing.T) {
 
 func TestNewGithubIssueURL(t *testing.T) {
 	url := NewGithubIssueURL("", []string{}, "")
-	require.Contains(t, url, "https://github.com/devbuddy/devbuddy/issues/new?body=")
+	require.Contains(t, url, "https://github.com/devbuddy/devbuddy/issues/new?")
 	require.Contains(t, url, "Project+not+found")
 }

--- a/pkg/helpers/debug/debug_test.go
+++ b/pkg/helpers/debug/debug_test.go
@@ -1,1 +1,36 @@
 package debug
+
+import (
+	"testing"
+
+	"github.com/Flaque/filet"
+	"github.com/stretchr/testify/require"
+
+	"github.com/devbuddy/devbuddy/pkg/test"
+)
+
+func TestFormatDebugInfo(t *testing.T) {
+	defer filet.CleanUp(t)
+
+	text := FormatDebugInfo("versionONE", []string{"SHELL=/bin/bash"}, "")
+	require.Contains(t, text, "`versionONE`")
+	require.Contains(t, text, "SHELL=\"/bin/bash\"\n")
+	require.Contains(t, text, "Project not found")
+
+	tmpdir := filet.TmpDir(t, "")
+
+	text = FormatDebugInfo("", []string{}, tmpdir)
+	require.Contains(t, text, "Failed to read manifest: no manifest at")
+
+	writer := test.Project(tmpdir)
+	writer.Manifest().WriteString(t, "up: [{go: 1.2.3}]")
+
+	text = FormatDebugInfo("", []string{}, tmpdir)
+	require.Contains(t, text, "0. `map[go:1.2.3]`")
+}
+
+func TestNewGithubIssueURL(t *testing.T) {
+	url := NewGithubIssueURL("", []string{}, "")
+	require.Contains(t, url, "https://github.com/devbuddy/devbuddy/issues/new?body=")
+	require.Contains(t, url, "Project+not+found")
+}

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -16,3 +16,14 @@ def test_cmd_init(cmd):
     init = cmd.run('bud --shell-init')
     assert 'bud() {' in init
     assert '__bud_prompt_command' in init
+
+
+def test_debug_info(cmd, project):
+    debug_info = cmd.run('bud --debug-info')
+    assert '**DevBuddy version**' in debug_info
+    assert 'SHELL="/bin/bash"' in debug_info
+    assert 'Project not found' in debug_info
+
+    project.write_devyml("")
+    debug_info = cmd.run('bud --debug-info')
+    assert 'Project path: ' in debug_info

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -19,9 +19,12 @@ def test_cmd_init(cmd):
 
 
 def test_debug_info(cmd, project):
+    pwd = cmd.run('echo -n $PWD')
+    assert pwd
+
     debug_info = cmd.run('bud --debug-info')
     assert '**DevBuddy version**' in debug_info
-    assert 'SHELL="/bin/bash"' in debug_info
+    assert f'PWD="{pwd}"' in debug_info
     assert 'Project not found' in debug_info
 
     project.write_devyml("")


### PR DESCRIPTION
## Why

Debugging issues on someone else's computer is always a challenge.
Helping people provide some debug information should help a lot.

## How

- `bud --report-issue` -> open the issue creation page, prefilled as shown in #311
- `bud --debug-info` -> print the same debug info

