### PR TITLE
Make CI faster by reducing number of jobs to 4 (CircleCI limit)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,10 +62,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - lint:
-          filters:
-            tags:
-              only: /.*/
       - binaries:
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - checkout
       - run: echo 'export PATH="~/.pyenv/bin:~/.pyenv/shims:$PATH"' >> $BASH_ENV
       - run: script/test
+      - run: script/lint
       - run: pip install mypy; mypy --strict script/release.py
 
   tests-bash:
@@ -29,13 +30,6 @@ jobs:
       - run: echo 'export PATH="~/.pyenv/bin:~/.pyenv/shims:$PATH"' >> $BASH_ENV
       - run: pip install -r tests/requirements.txt
       - run: pytest --durations=1 --shell zsh -v tests
-
-  lint:
-    executor: testing
-    steps:
-      - checkout
-      - run: go mod download
-      - run: script/lint
 
   binaries:
     executor: testing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
             tags:
               only: /.*/
       - deploy-release:
-          requires: [tests, tests-bash, tests-zsh, lint]
+          requires: [tests, tests-bash, tests-zsh]
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
## Why

CircleCI offers up to 4 concurrent jobs for open-source projects.
Currently we have 5 jobs, one job gets queued.
This slows down the completion of a CI run by ~30s.

## How

- Runs the tests and the linter in the same job. 
