### PR TITLE
Add support for setting env-vars directly from dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,3 +1,6 @@
+env:
+  SOME_VAR: some_value
+
 up:
   - go:
       version: '1.12'

--- a/pkg/autoenv/features/env.go
+++ b/pkg/autoenv/features/env.go
@@ -1,0 +1,23 @@
+package features
+
+import (
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/manifest"
+)
+
+func init() {
+	register("env", envActivate, nil)
+}
+
+func envActivate(ctx *context.Context, param string) (bool, error) {
+	man, err := manifest.Load(ctx.Project.Path)
+	if err != nil {
+		return false, err
+	}
+
+	for name, value := range man.Env {
+		ctx.Env.Set(name, value)
+	}
+
+	return false, nil
+}

--- a/pkg/manifest/create.go
+++ b/pkg/manifest/create.go
@@ -8,6 +8,9 @@ import (
 
 const defaultManifestContent = `# Created by "bud init"
 
+env:
+  ENV: development
+
 up:
   - go: 1.10.1
   - golang_dep

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -14,6 +14,7 @@ var manifestFilename = "dev.yml"
 
 // Manifest is a representation of the project manifest
 type Manifest struct {
+	Env      map[string]string   `yaml:"env"`
 	Up       []interface{}       `yaml:"up"`
 	Commands map[string]*Command `yaml:"commands"`
 	Open     map[string]string   `yaml:"open"`

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 var manifestContent = `
+env:
+  TESTENV: TESTVALUE
+
 up:
   - task1
   - task2
@@ -32,6 +35,7 @@ func TestLoad(t *testing.T) {
 	require.NoError(t, err, "Load() failed")
 	require.NotEqual(t, nil, man)
 
+	require.Equal(t, map[string]string{"TESTENV": "TESTVALUE"}, man.Env)
 	require.Equal(t, []interface{}{"task1", "task2"}, man.Up)
 	require.Equal(t, map[string]*Command{"cmd1": {Run: "command1", Description: "description1"}}, man.Commands)
 	require.Equal(t, map[string]string{"app": "http://localhost:5000"}, man.Open)

--- a/pkg/tasks/env.go
+++ b/pkg/tasks/env.go
@@ -1,0 +1,19 @@
+package tasks
+
+import (
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/tasks/taskapi"
+)
+
+func init() {
+	taskapi.Register("env", "Env", parseEnv)
+}
+
+func parseEnv(config *taskapi.TaskConfig, task *taskapi.Task) error {
+	check := func(ctx *context.Context) error {
+		return nil
+	}
+	task.AddActionWithBuilder("", check).SetFeature("env", "")
+
+	return nil
+}

--- a/pkg/tasks/taskapi/task_list.go
+++ b/pkg/tasks/taskapi/task_list.go
@@ -17,6 +17,14 @@ func GetTasksFromProject(proj *project.Project) (taskList []*Task, err error) {
 		return nil, err
 	}
 
+	if len(manifest.Env) != 0 {
+		task, err = NewTaskFromDefinition("env")
+		if err != nil {
+			return nil, err
+		}
+		taskList = append(taskList, task)
+	}
+
 	for _, taskdef := range manifest.Up {
 		task, err = NewTaskFromDefinition(taskdef)
 		if err != nil {

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,12 @@
+
+def test_set_env(cmd, project):
+    project.write_devyml("""
+        env:
+          TESTVAR: TESTVALUE
+        up: []
+    """)
+
+    cmd.run("true")
+
+    output = cmd.run("echo $TESTVAR")
+    assert "TESTVALUE" in output


### PR DESCRIPTION
## Why

To improve the compatibility with Dev, this PR introduces the support for setting env-vars declared in `dev.yml`.

## How

- Add a special task `env` that is automatically prepended if the `env` key is defined. 

