### PR TITLE
Run commands with a pseudo-terminal only when needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,6 @@ require (
 	github.com/spf13/cobra v0.0.0-20181127133106-d2d81d9a96e2
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,13 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
+golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -41,7 +41,7 @@ func customCommandRun(cmd *cobra.Command, args []string) error {
 
 	ui.CommandHeader(cmdline)
 
-	return executor.NewShell(cmdline).SetCwd(proj.Path).Run().Error
+	return executor.NewShell(cmdline).SetPTY(true).SetCwd(proj.Path).Run().Error
 }
 
 func buildCustomCommands() {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -6,6 +6,7 @@ type Executor interface {
 	SetEnv(env []string) Executor
 	SetEnvVar(name, value string) Executor
 	SetOutputPrefix(prefix string) Executor
+	SetPTY(enabled bool) Executor
 	AddOutputFilter(substring string) Executor
 	Run() *Result
 	Capture() *Result

--- a/pkg/executor/run.go
+++ b/pkg/executor/run.go
@@ -1,0 +1,52 @@
+package executor
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+
+	"github.com/kr/pty"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func runWithPTY(cmd *exec.Cmd, outputWriter io.Writer) error {
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = ptmx.Close()
+	}()
+
+	// Handle pty size
+	chResize := make(chan os.Signal, 1)
+	signal.Notify(chResize, syscall.SIGWINCH)
+	go func() {
+		for range chResize {
+			_ = pty.InheritSize(os.Stdin, ptmx)
+		}
+	}()
+	chResize <- syscall.SIGWINCH // Initial resize.
+	defer func() {
+		signal.Stop(chResize)
+		close(chResize)
+	}()
+
+	// Set Stdin in raw mode
+	oldState, err := terminal.MakeRaw(int(os.Stdin.Fd()))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = terminal.Restore(int(os.Stdin.Fd()), oldState)
+	}()
+
+	go func() {
+		_, _ = io.Copy(ptmx, os.Stdin)
+	}()
+	_, _ = io.Copy(outputWriter, ptmx)
+
+	return cmd.Wait()
+}


### PR DESCRIPTION
## Why

The initial attempt at running commands had a major issue: it was not setting stdin in raw mode.

## How

- Change the executor so that it would only run the command with a PTY if explicitly enabled.
- Set stdin in raw mode. 
- Disable output filtering (and prefixing) with a PTY, it's either tricky or impossible.

