### PR TITLE
[FEATURE] Add basic auto-completion support for ZSH

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -45,11 +45,8 @@ func rootRun(cmd *cobra.Command, args []string) {
 	var err error
 
 	if GetFlagBool(cmd, "shell-init") {
-		if GetFlagBool(cmd, "with-completion") {
-			err = cmd.GenBashCompletion(os.Stdout)
-			checkError(err)
-		}
-		integration.Print()
+		withCompletion := GetFlagBool(cmd, "with-completion")
+		integration.Print(withCompletion, cmd)
 		os.Exit(0)
 	}
 

--- a/pkg/integration/shells.go
+++ b/pkg/integration/shells.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	ps "github.com/mitchellh/go-ps"
+)
+
+type ShellIdentity string
+
+var (
+	BASH ShellIdentity = "bash"
+	ZSH  ShellIdentity = "zsh"
+)
+
+func DetectShell() (ShellIdentity, error) {
+	proc, err := ps.FindProcess(os.Getppid())
+	if err != nil {
+		return "", fmt.Errorf("failed to get parent process info: %s", err)
+	}
+	parentProcessPath := proc.Executable()
+
+	switch {
+	case strings.HasSuffix(parentProcessPath, "bash"):
+		return BASH, nil
+	case strings.HasSuffix(parentProcessPath, "zsh"):
+		return ZSH, nil
+	}
+
+	return "", fmt.Errorf("parent process is not a supported shell: %s", parentProcessPath)
+}


### PR DESCRIPTION
## Context

The auto-completion feature only support Bash, and fails with other shells. 

## Changes

Detect the shell and runs the Cobra helper accordingly.
