### PR TITLE
[Improvement] Allow overriding destination and sudo command in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ Uninstall it:
 $ sudo rm /usr/local/bin/bud
 ```
 
+To choose another destination:
+```bash
+$ SUDO= DEST=~/bin bash -c "$(curl -sL https://raw.githubusercontent.com/devbuddy/devbuddy/master/install.sh)"
+```
+
 ### Manual
 
 Older releases are available on [Github releases](https://github.com/devbuddy/devbuddy/releases).

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,8 @@
 set -eu
 
 VERSION="v0.9.2"
-DEST="/usr/local/bin"
+DEST=${DEST:-"/usr/local/bin"}
+SUDO=${SUDO-sudo} # keep the empty string
 SHELL_LINE='eval "$(bud --shell-init --with-completion)"'
 
 YELLOW="\033[1;33m"
@@ -69,7 +70,7 @@ main() {
     shasum -c "${BINARY}.sha256"
 
     header "Installing to ${DEST}"
-    sudo install "${BINARY}" "${DEST}/bud"
+    ${SUDO} install "${BINARY}" "${DEST}/bud"
 
     instructions
 }


### PR DESCRIPTION
## Why

Fix #349 

## How

- Let the user override `DEST`
- Let the user override `SUDO` and an keep empty string to disable sudo'ing completely  

Ping @merwok  