### PR TITLE
[Code] Make the install script fetch the latest version from Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Older releases are available on [Github releases](https://github.com/devbuddy/de
 
 #### Linux
 
-- ```curl -L https://github.com/devbuddy/devbuddy/releases/download/v0.9.2/bud-linux-amd64 > /tmp/bud```
+- ```curl -L https://github.com/devbuddy/devbuddy/releases/download/v0.11.0/bud-linux-amd64 > /tmp/bud```
 - ```sudo install /tmp/bud /usr/local/bin/bud```
 
 #### MacOs
 
-- ```curl -L https://github.com/devbuddy/devbuddy/releases/download/v0.9.2/bud-darwin-amd64 > /tmp/bud```
+- ```curl -L https://github.com/devbuddy/devbuddy/releases/download/v0.11.0/bud-darwin-amd64 > /tmp/bud```
 - ```sudo install /tmp/bud /usr/local/bin/bud```
 
 ## Setup

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-VERSION="v0.9.2"
 DEST="/usr/local/bin"
 SHELL_LINE='eval "$(bud --shell-init --with-completion)"'
 
@@ -11,6 +10,10 @@ WHITE="\033[1;37m"
 CODE="\033[44m\033[1;37m"
 LINK="\033[4m\033[1;34m"
 RESET="\033[0m"
+
+find_latest_version() {
+    curl -Ls -o /dev/null -w %{url_effective} "https://github.com/devbuddy/devbuddy/releases/latest" | grep -oE "[^/]+$"
+}
 
 make_variant() {
     ARCH=$(uname -m)
@@ -59,16 +62,19 @@ main() {
 
     VARIANT=$(make_variant)
 
-    header "Downloading DevBuddy version ${VERSION} for ${VARIANT} from Github"
+    header "Fetching the version of the latest release..."
+    VERSION=$(find_latest_version)
+
+    header "Downloading DevBuddy version ${VERSION} for ${VARIANT} from Github..."
     BINARY="bud-${VARIANT}"
     URL="https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/${BINARY}"
     curl -L -# --fail "${URL}" -o "${BINARY}"
     curl -L -# --fail "${URL}.sha256" -o "${BINARY}.sha256"
 
-    header "Verify SHA256 checksum"
+    header "Verify SHA256 checksum..."
     shasum -c "${BINARY}.sha256"
 
-    header "Installing to ${DEST}"
+    header "Installing to ${DEST}..."
     sudo install "${BINARY}" "${DEST}/bud"
 
     instructions


### PR DESCRIPTION
## Why

The `install.sh` script contains a variable defining the version to fetch from Github.
This should be updated after each release... 

## How

Fetch the version using the redirect from `https://github.com/devbuddy/devbuddy/releases/latest`.

Curl trick from:  https://github.com/helm/helm/blob/master/scripts/get#L87


