### PR TITLE
Replace filet with t.Tmpdir() and some testing helpers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.37
+          version: v1.43
 
   tests:
     name: go test
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.16.x"
+          go-version: "1.17.x"
       - run: go test -timeout 10s -cover ./pkg/...
 
   tests-bash:
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.16.x"
+          go-version: "1.17.x"
       - run: docker pull $TEST_DOCKER_IMAGE
       - run: TEST_SHELL=bash go test -cover -v ./tests
 
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.16.x"
+          go-version: "1.17.x"
       - run: docker pull $TEST_DOCKER_IMAGE
       - run: TEST_SHELL=zsh go test -cover -v ./tests
 
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.16.x"
+          go-version: "1.17.x"
       - run: script/buildall
       - run: ls -l dist
       - run: grep . dist/*.sha256

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ env:
 
 up:
   - go:
-      version: '1.16'
+      version: '1.17.3'
       modules: true
   - homebrew:
     - curl
@@ -15,7 +15,7 @@ up:
   - custom:
       name: Install golangci-lint
       met?: which golangci-lint
-      meet: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.19.1
+      meet: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
 
 commands:
   test:

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,12 @@
 module github.com/devbuddy/devbuddy
 
-go 1.15
+go 1.17
 
 require (
 	github.com/creack/pty v1.1.17
 	github.com/devbuddy/expect v0.0.0-20210723163049-dbaeb92456c7
 	github.com/dnaeon/go-vcr v1.2.0
 	github.com/joho/godotenv v1.4.0
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/sahilm/fuzzy v0.1.0
@@ -15,4 +14,14 @@ require (
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/devbuddy/devbuddy
 go 1.15
 
 require (
-	github.com/Flaque/filet v0.0.0-20201012163910-45f684403088
 	github.com/creack/pty v1.1.17
 	github.com/devbuddy/expect v0.0.0-20210723163049-dbaeb92456c7
 	github.com/dnaeon/go-vcr v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,6 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Flaque/filet v0.0.0-20201012163910-45f684403088 h1:PnnQln5IGbhLeJOi6hVs+lCeF+B1dRfFKPGXUAez0Ww=
-github.com/Flaque/filet v0.0.0-20201012163910-45f684403088/go.mod h1:TK+jB3mBs+8ZMWhU5BqZKnZWJ1MrLo8etNVg51ueTBo=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -224,7 +222,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
@@ -413,7 +410,6 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.5 h1:i6eZZ+zk0SOf0xgBpEpPD18qWcJda6q1sxt3S0kzyUQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/pkg/helpers/debug/debug_test.go
+++ b/pkg/helpers/debug/debug_test.go
@@ -3,21 +3,18 @@ package debug
 import (
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/devbuddy/devbuddy/pkg/test"
 )
 
 func TestFormatDebugInfo(t *testing.T) {
-	defer filet.CleanUp(t)
-
 	text := FormatDebugInfo("versionONE", []string{"SHELL=/bin/bash"}, "")
 	require.Contains(t, text, "`versionONE`")
 	require.Contains(t, text, "SHELL=\"/bin/bash\"\n")
 	require.Contains(t, text, "Project not found")
 
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 
 	text = FormatDebugInfo("", []string{}, tmpdir)
 	require.Contains(t, text, "Failed to read manifest: no manifest at")

--- a/pkg/helpers/downloader_test.go
+++ b/pkg/helpers/downloader_test.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"testing"
 
-	filet "github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,12 +27,10 @@ func (h *TestHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestData(t *testing.T) {
-	defer filet.CleanUp(t)
-
 	server := httptest.NewServer(&TestHandler{})
 	defer server.Close()
 
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 	testfile := path.Join(tmpdir, "testfile")
 
 	err := NewDownloader(server.URL + "/download").DownloadToFile(testfile)
@@ -46,12 +43,10 @@ func TestData(t *testing.T) {
 }
 
 func TestStatus(t *testing.T) {
-	defer filet.CleanUp(t)
-
 	server := httptest.NewServer(&TestHandler{})
 	defer server.Close()
 
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 	testfile := path.Join(tmpdir, "testfile")
 
 	err := NewDownloader(server.URL + "/notfound").DownloadToFile(testfile)
@@ -59,12 +54,10 @@ func TestStatus(t *testing.T) {
 }
 
 func TestRedirect(t *testing.T) {
-	defer filet.CleanUp(t)
-
 	server := httptest.NewServer(&TestHandler{})
 	defer server.Close()
 
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 	testfile := path.Join(tmpdir, "testfile")
 
 	err := NewDownloader(server.URL + "/redirect").DownloadToFile(testfile)
@@ -77,12 +70,10 @@ func TestRedirect(t *testing.T) {
 }
 
 func TestRedirectLimit(t *testing.T) {
-	defer filet.CleanUp(t)
-
 	server := httptest.NewServer(&TestHandler{})
 	defer server.Close()
 
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 	testfile := path.Join(tmpdir, "testfile")
 
 	err := NewDownloader(server.URL + "/loop").DownloadToFile(testfile)

--- a/pkg/helpers/envfile_test.go
+++ b/pkg/helpers/envfile_test.go
@@ -5,33 +5,30 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/Flaque/filet"
-
 	"github.com/devbuddy/devbuddy/pkg/env"
 	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/devbuddy/devbuddy/pkg/test"
 )
 
 func TestLoadEnvfile(t *testing.T) {
-	defer filet.CleanUp(t)
-	envfilePath := filet.File(t, ".env", "\nPOIPOI=fromEnvFile")
+	_, tmpfile := test.CreateFile(t, ".env", []byte("\nPOIPOI=fromEnvFile"))
 
 	env := env.New([]string{})
 	env.Set("EXISTING", "XXX")
 	env.Set("POIPOI", "XXX")
 
-	err := helpers.LoadEnvfile(env, envfilePath.Name())
+	err := helpers.LoadEnvfile(env, tmpfile)
 	require.Nil(t, err)
 	require.Equal(t, "fromEnvFile", env.Get("POIPOI"))
 	require.Equal(t, "XXX", env.Get("EXISTING"))
 }
 
 func TestLoadEnvfileNoFile(t *testing.T) {
-	defer filet.CleanUp(t)
-	envfilePath := filet.File(t, "whatever", "")
+	tmpdir := t.TempDir()
 
 	env := env.New([]string{})
 
-	err := helpers.LoadEnvfile(env, envfilePath.Name()+"nope")
+	err := helpers.LoadEnvfile(env, tmpdir+"/nope")
 	require.NotNil(t, err)
 	require.Zero(t, len(env.Environ()))
 }

--- a/pkg/helpers/git_test.go
+++ b/pkg/helpers/git_test.go
@@ -3,15 +3,13 @@ package helpers
 import (
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/devbuddy/devbuddy/pkg/test"
 )
 
 func TestGitGithubProjectURL(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 	writer.CreateGitRepo(t)
 
@@ -22,8 +20,7 @@ func TestGitGithubProjectURL(t *testing.T) {
 }
 
 func TestGitGithubPullrequestURL(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 	writer.CreateGitRepo(t)
 

--- a/pkg/helpers/open/open_test.go
+++ b/pkg/helpers/open/open_test.go
@@ -3,7 +3,6 @@ package open
 import (
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/devbuddy/devbuddy/pkg/project"
@@ -11,8 +10,7 @@ import (
 )
 
 func TestFindLink(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 	writer.Manifest().WriteString(t, "open: {doc: http://doc.com, logs: http://logs}")
 
@@ -30,8 +28,7 @@ func TestFindLink(t *testing.T) {
 }
 
 func TestFindLinkDefault(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 	writer.Manifest().WriteString(t, "open: {doc: http://doc.com}")
 
@@ -43,8 +40,7 @@ func TestFindLinkDefault(t *testing.T) {
 }
 
 func TestFindLinkGithub(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 	writer.CreateGitRepo(t)
 	writer.Manifest().Empty(t)
@@ -65,8 +61,7 @@ func TestFindLinkGithub(t *testing.T) {
 }
 
 func TestPrintLinks(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 
 	proj := project.NewFromPath(tmpdir)

--- a/pkg/helpers/projectmetadata/projectmetadata_test.go
+++ b/pkg/helpers/projectmetadata/projectmetadata_test.go
@@ -4,22 +4,21 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 
 	"github.com/devbuddy/devbuddy/pkg/helpers/projectmetadata"
+	"github.com/devbuddy/devbuddy/pkg/test"
 )
 
 func Test(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir, gitignorePath := test.File(t, ".devbuddy/.gitignore")
 
 	path, err := projectmetadata.New(tmpdir).Path()
 	require.NoError(t, err)
+
 	require.Equal(t, filepath.Join(tmpdir, ".devbuddy"), path)
 	require.DirExists(t, path)
 
-	gitignorePath := filepath.Join(path, ".gitignore")
-	require.FileExists(t, gitignorePath)
-	require.True(t, filet.FileSays(t, gitignorePath, []byte("*")))
+	data := test.ReadFile(gitignorePath)
+	require.Equal(t, data, []byte("*"))
 }

--- a/pkg/helpers/store/store_test.go
+++ b/pkg/helpers/store/store_test.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/Flaque/filet"
 )
 
 func open(path string) *Store {
@@ -18,8 +16,7 @@ func open(path string) *Store {
 }
 
 func TestSetGetString(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 
 	testValues := []string{"DUMMY", "", "   "}
 
@@ -34,8 +31,7 @@ func TestSetGetString(t *testing.T) {
 }
 
 func TestKeyEmpty(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 
 	_, err := open(tmpdir).GetString("")
 	require.EqualError(t, err, "empty string is not a valid key")
@@ -45,8 +41,7 @@ func TestKeyEmpty(t *testing.T) {
 }
 
 func TestGetStringNotFound(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir := t.TempDir()
 
 	val, err := open(tmpdir).GetString("doesnotexist")
 	require.NoError(t, err)

--- a/pkg/helpers/upgrader_test.go
+++ b/pkg/helpers/upgrader_test.go
@@ -1,22 +1,20 @@
 package helpers
 
 import (
-	"io/ioutil"
 	"log"
 	"net/http"
-	"os"
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/stretchr/testify/require"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
 	"github.com/devbuddy/devbuddy/pkg/termui"
+	"github.com/devbuddy/devbuddy/pkg/test"
 )
 
 func TestUpgraderLatestRelease(t *testing.T) {
-	defer filet.CleanUp(t)
+	_, tmpfile := test.File(t, "blob")
 
 	r, err := recorder.New("fixtures/upgrader")
 	require.NoError(t, err, "recorder.New() failed")
@@ -28,25 +26,14 @@ func TestUpgraderLatestRelease(t *testing.T) {
 		}
 	}()
 
-	target := filet.TmpFile(t, "", "")
-
-	defer func() {
-		err = os.Remove(target.Name())
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
-
 	client := &http.Client{Transport: r}
 
 	u := NewUpgraderWithHTTPClient(client, false)
 
 	ui := termui.New(config.NewTestConfig())
-	err = u.Perform(ui, target.Name(), "https://github.com/devbuddy/devbuddy/releases/download/v0.1.0/bud-darwin-amd64")
+	err = u.Perform(ui, tmpfile, "https://github.com/devbuddy/devbuddy/releases/download/v0.1.0/bud-darwin-amd64")
 	require.NoError(t, err, "upgrader.Perform() failed")
 
-	result, err := ioutil.ReadFile(target.Name())
-	require.NoError(t, err, "ioutil.ReadFile() failed")
-
+	result := test.ReadFile(tmpfile)
 	require.Equal(t, string(result), "Original data was too big")
 }

--- a/pkg/manifest/manifest_test.go
+++ b/pkg/manifest/manifest_test.go
@@ -3,7 +3,6 @@ package manifest
 import (
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/devbuddy/devbuddy/pkg/test"
 	"github.com/stretchr/testify/require"
 )
@@ -29,8 +28,8 @@ open:
 `
 
 func TestLoad(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
+
 	writer := test.Project(tmpdir)
 	writer.Manifest().WriteString(t, manifestContent)
 

--- a/pkg/project/current_test.go
+++ b/pkg/project/current_test.go
@@ -5,14 +5,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/devbuddy/devbuddy/pkg/test"
 	"github.com/stretchr/testify/require"
 )
 
 func TestFindByPath(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
+
 	writer := test.Project(tmpdir)
 	writer.Manifest().Empty(t)
 
@@ -23,8 +22,8 @@ func TestFindByPath(t *testing.T) {
 }
 
 func TestFindByPathNested(t *testing.T) {
-	tmpdir := filet.TmpDir(t, "")
-	defer filet.CleanUp(t)
+	tmpdir := t.TempDir()
+
 	writer := test.Project(tmpdir)
 	writer.Manifest().Empty(t)
 

--- a/pkg/project/search_test.go
+++ b/pkg/project/search_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/devbuddy/devbuddy/pkg/config"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,8 +26,7 @@ func runFind(t *testing.T, dir, input, defaultOrg string) string {
 }
 
 func TestMatches(t *testing.T) {
-	defer filet.CleanUp(t)
-	dir := filet.TmpDir(t, "")
+	dir := t.TempDir()
 	populateProjects(t, dir, "pior", []string{"george", "caravan", "pyramid_bugsnag"})
 	populateProjects(t, dir, "george", []string{"carpe", "dorade", "gardon", "marlin", "caravan"})
 
@@ -76,8 +74,7 @@ func TestMatches(t *testing.T) {
 }
 
 func TestNoMatch(t *testing.T) {
-	defer filet.CleanUp(t)
-	dir := filet.TmpDir(t, "")
+	dir := t.TempDir()
 
 	populateProjects(t, dir, "pior", []string{"whatever"})
 
@@ -88,8 +85,7 @@ func TestNoMatch(t *testing.T) {
 }
 
 func TestSearchingWithNoProject(t *testing.T) {
-	defer filet.CleanUp(t)
-	dir := filet.TmpDir(t, "")
+	dir := t.TempDir()
 
 	cfg := &config.Config{SourceDir: dir}
 	_, err := FindBestMatch("nope", cfg)

--- a/pkg/tasks/taskapi/task_action_generic_test.go
+++ b/pkg/tasks/taskapi/task_action_generic_test.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/project"
+	"github.com/devbuddy/devbuddy/pkg/test"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -135,8 +135,7 @@ func TestTaskActionGenericOnFunc(t *testing.T) {
 }
 
 func TestTaskActionGenericFileChange(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	tmpdir, tmpfile := test.File(t, "testfile")
 
 	ctx := &context.Context{
 		Project: project.NewFromPath(tmpdir),
@@ -160,7 +159,7 @@ func TestTaskActionGenericFileChange(t *testing.T) {
 
 	// With a new file
 
-	filet.File(t, tmpdir+"/testfile", "content-A")
+	test.WriteFile(tmpfile, []byte("content-A"))
 
 	action = newBuilder("", runFunc).OnFileChange("testfile").genericTaskAction
 
@@ -185,7 +184,7 @@ func TestTaskActionGenericFileChange(t *testing.T) {
 
 	// The file changed
 
-	filet.File(t, tmpdir+"/testfile", "content-B")
+	test.WriteFile(tmpfile, []byte("content-B"))
 
 	action = newBuilder("", runFunc).OnFileChange("testfile").genericTaskAction
 
@@ -193,5 +192,4 @@ func TestTaskActionGenericFileChange(t *testing.T) {
 	require.NoError(t, result.Error)
 	require.True(t, result.Needed)
 	require.Equal(t, "file testfile has changed", result.Reason)
-
 }

--- a/pkg/test/file.go
+++ b/pkg/test/file.go
@@ -1,0 +1,43 @@
+package test
+
+import (
+	"os"
+	"path"
+	"testing"
+)
+
+// File creates a temporary directory and returns the full path of the file. Panic on error.
+func File(t testing.TB, filename string) (tmpdir, tmpfile string) {
+	tmpdir = t.TempDir()
+	tmpfile = path.Join(tmpdir, filename)
+	return
+}
+
+// CreateFile creates a temporary directory, writes a file and returns the full path of the file. Panic on error.
+func CreateFile(t testing.TB, filename string, content []byte) (tmpdir, tmpfile string) {
+	tmpdir, tmpfile = File(t, filename)
+
+	err := os.WriteFile(tmpfile, content, 0600)
+	if err != nil {
+		panic("failed to write to " + tmpfile + ": " + err.Error())
+	}
+
+	return
+}
+
+// WriteFile writes, or overwrites a file. Panic on error.
+func WriteFile(fullpath string, content []byte) {
+	err := os.WriteFile(fullpath, content, 0600)
+	if err != nil {
+		panic("failed to write to " + fullpath + ": " + err.Error())
+	}
+}
+
+// ReadFile returns the content of an existing file. Panic on error.
+func ReadFile(fullpath string) []byte {
+	content, err := os.ReadFile(fullpath)
+	if err != nil {
+		panic("failed to read from " + fullpath + ": " + err.Error())
+	}
+	return content
+}

--- a/pkg/test/project.go
+++ b/pkg/test/project.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/Flaque/filet"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,9 +51,9 @@ func (p *projectWriter) Manifest() *manifestWriter {
 }
 
 func (m *manifestWriter) Empty(t *testing.T) {
-	filet.File(t, m.path, "")
+	WriteFile(m.path, []byte(""))
 }
 
 func (m *manifestWriter) WriteString(t *testing.T, value string) {
-	filet.File(t, m.path, value)
+	WriteFile(m.path, []byte(value))
 }

--- a/pkg/utils/file_test.go
+++ b/pkg/utils/file_test.go
@@ -1,47 +1,36 @@
 package utils
 
 import (
-	"io/ioutil"
-	"path"
 	"testing"
 
+	"github.com/devbuddy/devbuddy/pkg/test"
 	"github.com/stretchr/testify/require"
-
-	"github.com/Flaque/filet"
 )
 
 func Test_AppendOnlyFile(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
+	_, tmpfile := test.File(t, "testfile")
 
-	nofile := path.Join(tmpdir, "testfile")
-
-	err := AppendOnlyFile(nofile, []byte(""))
+	err := AppendOnlyFile(tmpfile, []byte(""))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no such file or directory")
 
-	tmpfile := filet.TmpFile(t, tmpdir, "one").Name()
+	test.WriteFile(tmpfile, []byte("one"))
 
 	err = AppendOnlyFile(tmpfile, []byte("two"))
 	require.NoError(t, err)
 
-	buffer, err := ioutil.ReadFile(tmpfile)
-	require.NoError(t, err)
+	buffer := test.ReadFile(tmpfile)
 	require.Equal(t, "onetwo", string(buffer))
 }
 
 func Test_WriteNewFile(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
-
-	tmpfile := path.Join(tmpdir, "testfile")
+	_, tmpfile := test.File(t, "testfile")
 
 	err := WriteNewFile(tmpfile, []byte("one"), 0664)
 	require.NoError(t, err)
 
-	buffer, err := ioutil.ReadFile(tmpfile)
-	require.NoError(t, err)
-	require.Equal(t, "one", string(buffer))
+	content := test.ReadFile(tmpfile)
+	require.Equal(t, "one", string(content))
 
 	err = WriteNewFile(tmpfile, []byte("onetwo"), 0664)
 	require.Error(t, err)
@@ -49,22 +38,17 @@ func Test_WriteNewFile(t *testing.T) {
 }
 
 func Test_WriteFile(t *testing.T) {
-	defer filet.CleanUp(t)
-	tmpdir := filet.TmpDir(t, "")
-
-	tmpfile := path.Join(tmpdir, "testfile")
+	_, tmpfile := test.File(t, "testfile")
 
 	err := WriteFile(tmpfile, []byte("one"), 0664)
 	require.NoError(t, err)
 
-	buffer, err := ioutil.ReadFile(tmpfile)
-	require.NoError(t, err)
-	require.Equal(t, "one", string(buffer))
+	content := test.ReadFile(tmpfile)
+	require.Equal(t, "one", string(content))
 
 	err = WriteFile(tmpfile, []byte("onetwo"), 0664)
 	require.NoError(t, err)
 
-	buffer, err = ioutil.ReadFile(tmpfile)
-	require.NoError(t, err)
-	require.Equal(t, "onetwo", string(buffer))
+	content = test.ReadFile(tmpfile)
+	require.Equal(t, "onetwo", string(content))
 }


### PR DESCRIPTION
## Why

Filet was a nice testing helper when [T.Tempdir()](https://pkg.go.dev/testing#T.TempDir) did not exist.
We should drop it now, and just use the stdlib.

## How


