### PR TITLE
Run the custom commands with the envvars from manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,5 +1,6 @@
 env:
   SOME_VAR: some_value
+  TEST_DOCKER_IMAGE: ghcr.io/devbuddy/docker-testing:sha-f11e362
 
 up:
   - go:
@@ -25,14 +26,12 @@ commands:
   integration:
     desc: Run the integration tests with Bash
     run: |
-      export TEST_DOCKER_IMAGE=ghcr.io/devbuddy/docker-testing:sha-f11e362 
       docker pull $TEST_DOCKER_IMAGE
       TEST_SHELL=bash go test -v ./tests
 
   integration-zsh:
     desc: Run the integration tests with Zsh
     run: |
-      export TEST_DOCKER_IMAGE=ghcr.io/devbuddy/docker-testing:sha-f11e362 
       docker pull $TEST_DOCKER_IMAGE
       TEST_SHELL=zsh go test -v ./tests
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,6 +1,6 @@
 env:
   SOME_VAR: some_value
-  TEST_DOCKER_IMAGE: ghcr.io/devbuddy/docker-testing:sha-f11e362
+  TEST_DOCKER_IMAGE: ghcr.io/devbuddy/docker-testing:sha-7fd13f4
 
 up:
   - go:

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/env"
 	"github.com/devbuddy/devbuddy/pkg/executor"
 	"github.com/devbuddy/devbuddy/pkg/manifest"
 	"github.com/devbuddy/devbuddy/pkg/project"
@@ -41,7 +42,17 @@ func customCommandRun(cmd *cobra.Command, args []string) error {
 
 	ui.CommandHeader(cmdline)
 
-	return executor.NewShell(cmdline).SetPTY(true).SetCwd(proj.Path).Run().Error
+	exec := executor.NewShell(cmdline).SetPTY(true).SetCwd(proj.Path)
+
+	envs := env.NewFromOS()
+	for name, value := range man.Env {
+		if !envs.Has(name) {
+			envs.Set(name, value)
+		}
+	}
+	exec.SetEnv(envs.Environ())
+
+	return exec.Run().Error
 }
 
 func buildCustomCommands(rootCmd *cobra.Command) {

--- a/tests/cmd_custom_test.go
+++ b/tests/cmd_custom_test.go
@@ -41,6 +41,21 @@ func Test_Cmd_Custom_Short_Syntax(t *testing.T) {
 	OutputEqual(t, lines, "🐼  running touch somefile")
 }
 
+func Test_Cmd_Custom_Envs_Are_Applied(t *testing.T) {
+	c := CreateContextAndInit(t)
+
+	project := CreateProject(c, "project",
+		`env:`,
+		`  MYVAR: poipoi`,
+		`commands:`,
+		`  mycmd: "echo __${MYVAR}__ > result"`,
+	)
+	c.Cd(project.Path)
+
+	c.Run("bud mycmd")
+	c.AssertContains("result", "__poipoi__")
+}
+
 func Test_Cmd_Custom_Always_Run_In_Project_Root(t *testing.T) {
 	c := CreateContextAndInit(t)
 

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -186,6 +186,11 @@ func (e *TestContext) AssertExist(path string) {
 	require.NoError(e.t, err, "expected file %s to exist", quotedPath)
 }
 
+func (e *TestContext) AssertContains(path, expected string) {
+	value := e.Cat(path)
+	require.Equal(e.t, expected, value, "expected file %s to contain %s", strconv.Quote(path), strconv.Quote(expected))
+}
+
 func (e *TestContext) GetEnv(name string) string {
 	lines, err := e.shell.Run("echo ${" + name + "}")
 	require.NoError(e.t, err)

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -1,6 +1,7 @@
 package context
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"strconv"
@@ -101,39 +102,39 @@ func (c *TestContext) Debug() {
 	c.expect.Debug = true
 }
 
-func (e *TestContext) Close() error {
-	return e.expect.Stop()
+func (c *TestContext) Close() error {
+	return c.expect.Stop()
 }
 
-func (e *TestContext) Run(cmd string, optFns ...runOptionsFn) []string {
-	lines, err := e.run(cmd, optFns...)
-	require.NoError(e.t, err, "running command: %q", cmd)
+func (c *TestContext) Run(cmd string, optFns ...runOptionsFn) []string {
+	lines, err := c.run(cmd, optFns...)
+	require.NoError(c.t, err, "running command: %q", cmd)
 	return lines
 }
 
-func (e *TestContext) run(cmd string, optFns ...runOptionsFn) ([]string, error) {
+func (c *TestContext) run(cmd string, optFns ...runOptionsFn) ([]string, error) {
 	opt := buildRunOptions(optFns)
 
-	e.debugLine("Running command %q", cmd)
-	e.debugLine("Options: %+v", opt)
+	c.debugLine("Running command %q", cmd)
+	c.debugLine("Options: %+v", opt)
 
 	var lines []string
 	var err error
 
 	done := make(chan bool)
 	go func() {
-		lines, err = e.shell.Run(cmd)
+		lines, err = c.shell.Run(cmd)
 		close(done)
 	}()
 
 	select {
 	case <-done:
-		e.debugLine("command completed")
+		c.debugLine("command completed")
 	case <-time.After(opt.timeout):
 		return nil, fmt.Errorf("timed out after %s", opt.timeout)
 	}
 
-	codeLines, err := e.shell.Run("echo $?")
+	codeLines, err := c.shell.Run("echo $?")
 	if err != nil {
 		return nil, fmt.Errorf("getting exit code: %w", err)
 	}
@@ -156,55 +157,56 @@ func (e *TestContext) run(cmd string, optFns ...runOptionsFn) ([]string, error) 
 	return StripAnsiSlice(lines), nil
 }
 
-func (e *TestContext) Write(path, content string) {
-	_, err := e.shell.Run(fmt.Sprintf("echo -e %q > %q", content, path))
-	require.NoError(e.t, err)
+func (c *TestContext) Write(path, content string) {
+	b64content := base64.StdEncoding.EncodeToString([]byte(content))
+	_, err := c.shell.Run(fmt.Sprintf("echo %s | base64 --decode > %q", b64content, path))
+	require.NoError(c.t, err)
 }
 
-func (e *TestContext) Cwd() string {
-	lines, err := e.shell.Run("pwd")
-	require.NoError(e.t, err)
-	require.Len(e.t, lines, 1, "unexpected output for 'pwd'")
+func (c *TestContext) Cwd() string {
+	lines, err := c.shell.Run("pwd")
+	require.NoError(c.t, err)
+	require.Len(c.t, lines, 1, "unexpected output for 'pwd'")
 	return lines[0]
 }
 
-func (e *TestContext) Cat(path string) string {
-	lines, err := e.shell.Run("cat " + strconv.Quote(path))
-	require.NoError(e.t, err)
+func (c *TestContext) Cat(path string) string {
+	lines, err := c.shell.Run("cat " + strconv.Quote(path))
+	require.NoError(c.t, err)
 	return strings.Join(lines, "\n")
 }
 
-func (e *TestContext) Ls(path string) []string {
-	lines, err := e.shell.Run("ls -1 " + strconv.Quote(path))
-	require.NoError(e.t, err)
+func (c *TestContext) Ls(path string) []string {
+	lines, err := c.shell.Run("ls -1 " + strconv.Quote(path))
+	require.NoError(c.t, err)
 	return lines
 }
 
-func (e *TestContext) AssertExist(path string) {
+func (c *TestContext) AssertExist(path string) {
 	quotedPath := strconv.Quote(path)
-	_, err := e.shell.Run("test -e " + strconv.Quote(quotedPath))
-	require.NoError(e.t, err, "expected file %s to exist", quotedPath)
+	_, err := c.shell.Run("test -e " + strconv.Quote(quotedPath))
+	require.NoError(c.t, err, "expected file %s to exist", quotedPath)
 }
 
-func (e *TestContext) AssertContains(path, expected string) {
-	value := e.Cat(path)
-	require.Equal(e.t, expected, value, "expected file %s to contain %s", strconv.Quote(path), strconv.Quote(expected))
+func (c *TestContext) AssertContains(path, expected string) {
+	value := c.Cat(path)
+	require.Equal(c.t, expected, value, "expected file %s to contain %s", strconv.Quote(path), strconv.Quote(expected))
 }
 
-func (e *TestContext) GetEnv(name string) string {
-	lines, err := e.shell.Run("echo ${" + name + "}")
-	require.NoError(e.t, err)
-	require.Len(e.t, lines, 1)
+func (c *TestContext) GetEnv(name string) string {
+	lines, err := c.shell.Run("echo ${" + name + "}")
+	require.NoError(c.t, err)
+	require.Len(c.t, lines, 1)
 	return lines[0]
 }
 
-func (e *TestContext) Cd(path string) {
-	_, err := e.shell.Run("cd " + strconv.Quote(path))
-	require.NoError(e.t, err)
+func (c *TestContext) Cd(path string) {
+	_, err := c.shell.Run("cd " + strconv.Quote(path))
+	require.NoError(c.t, err)
 }
 
-func (e *TestContext) debugLine(format string, a ...interface{}) {
-	if e.debug {
+func (c *TestContext) debugLine(format string, a ...interface{}) {
+	if c.debug {
 		format = strings.TrimSuffix(format, "\n") + "\n"
 		fmt.Printf(format, a...)
 	}

--- a/tests/task_pipfile_test.go
+++ b/tests/task_pipfile_test.go
@@ -16,7 +16,7 @@ func Test_Task_Pipfile(t *testing.T) {
 		`- pipfile`,
 	)
 
-	c.Write("Pipfile", `[packages]\n"pyreleaser" = "==0.5.2"\n`)
+	c.Write("Pipfile", "[packages]\n\"pyreleaser\" = \"==0.5.2\"\n")
 
 	c.Run("bud up", context.Timeout(2*time.Minute))
 


### PR DESCRIPTION
## Why

The custom commands are run with the environment variables inherited from the shell, ignoring the `env` section of the manifest.
Usually, the user would run `bud up` when the manifest is changed to _apply_ the change.
But it's easy to miss this step, and be puzzled why the command does not work.

Injecting the envvars declared in the manifest in the custom command environment make sense until #406 is fixed and https://github.com/devbuddy/devbuddy/issues/30 is implemented.

## How

If the envvar already exists in the shell environment, the envvar is not overridden.
