### PR TITLE
Go: refactor the support of Modules and GOPATH modes

### DIFF
--- a/pkg/autoenv/features/golang.go
+++ b/pkg/autoenv/features/golang.go
@@ -11,8 +11,13 @@ func init() {
 	register("golang", golangActivate, nil)
 }
 
+const (
+	GolangSuffixMod    = "+mod"
+	GolangSuffixGopath = "+gopath"
+)
+
 func golangActivate(ctx *context.Context, version string) (bool, error) {
-	golang := helpers.NewGolang(ctx.Cfg, golangExtractVersion(version))
+	golang := helpers.NewGolang(ctx.Cfg, strings.Split(version, "+")[0])
 
 	if !golang.Exists() {
 		return true, nil
@@ -22,19 +27,12 @@ func golangActivate(ctx *context.Context, version string) (bool, error) {
 
 	ctx.Env.Set("GOROOT", golang.Path())
 
-	if golangVersionWithModules(version) {
+	switch {
+	case strings.HasSuffix(version, GolangSuffixMod):
 		ctx.Env.Set("GO111MODULE", "on")
+	case strings.HasSuffix(version, GolangSuffixGopath):
+		ctx.Env.Set("GO111MODULE", "off")
 	}
 
 	return false, nil
-}
-
-const golangModulesSuffix = "+mod"
-
-func golangExtractVersion(version string) string {
-	return strings.TrimSuffix(version, golangModulesSuffix)
-}
-
-func golangVersionWithModules(version string) bool {
-	return strings.HasSuffix(version, golangModulesSuffix)
 }

--- a/pkg/tasks/api/task_config.go
+++ b/pkg/tasks/api/task_config.go
@@ -124,18 +124,24 @@ func (c *TaskConfig) GetStringPropertyDefault(name string, defaultValue string) 
 	return str, nil
 }
 
-// GetBooleanPropertyDefault expects the payload to be a hash, returns the value as a boolean for the name specified.
-// Or returns the default value specified if the payload is nil.
+// GetBooleanProperty expects the payload to be a hash, returns the value as a boolean for the name specified.
 //
 // YAML Example:
 //   - TASKNAME:
 //     PROPERTYNAME: on
-func (c *TaskConfig) GetBooleanPropertyDefault(name string, defaultValue bool) (bool, error) {
-	value, err := c.getPropertyDefault(name, defaultValue)
-	if err != nil {
-		return false, err
+func (c *TaskConfig) GetBooleanProperty(name string) (value bool, present bool, err error) {
+	propValue, err := c.getProperty(name)
+	if err == nil {
+		b, err := asBool(propValue)
+		if err != nil {
+			return false, false, err
+		}
+		return b, true, nil
 	}
-	return asBool(value)
+	if _, ok := err.(propertyNotFoundError); ok {
+		return false, false, nil
+	}
+	return false, false, err
 }
 
 func (c *TaskConfig) getProperty(name string) (interface{}, error) {

--- a/pkg/tasks/api/task_config_test.go
+++ b/pkg/tasks/api/task_config_test.go
@@ -54,12 +54,14 @@ func TestTaskConfigGetBooleanPropertyDefault(t *testing.T) {
 	payload := map[interface{}]interface{}{"flag": true}
 	config := &TaskConfig{name: "test", payload: payload}
 
-	val, err := config.GetBooleanPropertyDefault("flag", false)
+	val, present, err := config.GetBooleanProperty("flag")
 	require.NoError(t, err)
+	require.Equal(t, present, true)
 	require.Equal(t, val, true)
 
-	val, err = config.GetBooleanPropertyDefault("nope", false)
+	val, present, err = config.GetBooleanProperty("nope")
 	require.NoError(t, err)
+	require.Equal(t, present, false)
 	require.Equal(t, val, false)
 }
 

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -100,7 +100,12 @@ func (c *TestContext) Debug() {
 }
 
 func (c *TestContext) Close() error {
-	return c.expect.Stop()
+	c.debugLine("Stopping docker container")
+	err := c.expect.Stop()
+	if err != nil {
+		c.debugLine("ERROR when stopping docker: %s", err)
+	}
+	return err
 }
 
 func (c *TestContext) Run(t *testing.T, cmd string, optFns ...runOptionsFn) []string {
@@ -160,6 +165,11 @@ func (c *TestContext) Write(t *testing.T, path, content string) {
 	b64content := base64.StdEncoding.EncodeToString([]byte(content))
 	_, err := c.shell.Run(fmt.Sprintf("echo %s | base64 --decode > %q", b64content, path))
 	require.NoError(t, err)
+}
+
+func (c *TestContext) WriteLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	c.Write(t, path, strings.Join(lines, "\n"))
 }
 
 func (c *TestContext) Cwd(t *testing.T) string {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -74,7 +74,7 @@ func CreateProject(t *testing.T, c *context.TestContext, name string, devYmlLine
 
 	path := projectPath + "/dev.yml"
 	c.Write(t, path, strings.Join(devYmlLines, "\n"))
-	c.Run(t, "bud cd "+name)
+	c.Cd(t, projectPath)
 
 	return Project{name, projectPath}
 }


### PR DESCRIPTION
## Why

1. GOPATH is not required for Go +1.16 with Modules, DevBuddy should not enforce it
2. The `go.modules` setting should disable GO111MODULE when set to `false`, to support legacy GOPATH projects

## How

- The Go task does not fail if GOPATH is missing
- The Go autoenv feature sets GO111MODULE to `off` when `modules` is set to `false`
