### PR TITLE
Update code to Go 1.21, skip unsupported NodeJS tests, simplify CreateProject

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: go test -timeout 10s -cover ./pkg/...
 
   tests-bash:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: docker pull $TEST_DOCKER_IMAGE
       - run: TEST_SHELL=bash go test -cover -v ./tests
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: docker pull $TEST_DOCKER_IMAGE
       - run: TEST_SHELL=zsh go test -cover -v ./tests
 
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v1
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - run: script/buildall
 
       - run: ls -l dist

--- a/dev.yml
+++ b/dev.yml
@@ -9,13 +9,12 @@ up:
   - homebrew:
     - curl
     - shellcheck
-    - golangci/tap/golangci-lint
   - apt:
     - curl
     - shellcheck
   - custom:
       name: Install golangci-lint
-      met?: which golangci-lint
+      met?: which golangci-lint && golangci-lint --version | grep -q '1.55.2'
       meet: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
 
 commands:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devbuddy/devbuddy
 
-go 1.17
+go 1.21
 
 require (
 	github.com/creack/pty v1.1.21

--- a/pkg/helpers/downloader.go
+++ b/pkg/helpers/downloader.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -34,7 +33,7 @@ func (d *downloader) DownloadToFile(file string) error {
 	}()
 
 	// Create a temp file
-	tmpFile, err := ioutil.TempFile(os.TempDir(), "devbuddy-")
+	tmpFile, err := os.CreateTemp(os.TempDir(), "devbuddy-")
 	if err != nil {
 		return err
 	}

--- a/pkg/helpers/github.go
+++ b/pkg/helpers/github.go
@@ -3,7 +3,7 @@ package helpers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 )
@@ -35,7 +35,7 @@ func (g *Github) listReleases() (releases *GithubReleaseList, err error) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return
 	}
@@ -81,7 +81,7 @@ func (g *Github) Get(url string) (data []byte, err error) {
 		return
 	}
 
-	data, err = ioutil.ReadAll(response.Body)
+	data, err = io.ReadAll(response.Body)
 
 	if err != nil {
 		return

--- a/pkg/helpers/node.go
+++ b/pkg/helpers/node.go
@@ -41,8 +41,12 @@ func (n *Node) Which(program string) string {
 	return path.Join(n.path, "bin", program)
 }
 
+func NodeJSIsSupportedOnThisPlatform() bool {
+	return runtime.GOARCH == "amd64"
+}
+
 func (n *Node) Install() error {
-	if runtime.GOARCH != "amd64" {
+	if !NodeJSIsSupportedOnThisPlatform() {
 		return fmt.Errorf("NodeJS installation is only supported on %s by DevBuddy", runtime.GOARCH)
 	}
 

--- a/pkg/helpers/projectmetadata/projectmetadata.go
+++ b/pkg/helpers/projectmetadata/projectmetadata.go
@@ -2,7 +2,6 @@ package projectmetadata
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -47,7 +46,7 @@ func (p *ProjectMetadata) prepare() error {
 
 	gitignore := filepath.Join(p.path, ".gitignore")
 	if !utils.PathExists(gitignore) {
-		err := ioutil.WriteFile(gitignore, []byte("*"), 0644)
+		err := os.WriteFile(gitignore, []byte("*"), 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/helpers/store/store.go
+++ b/pkg/helpers/store/store.go
@@ -3,7 +3,7 @@ package store
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/devbuddy/devbuddy/pkg/helpers/projectmetadata"
@@ -33,7 +33,7 @@ func (s *Store) read() (*fileData, error) {
 	data := &fileData{Entries: make(map[string]string)}
 
 	if utils.PathExists(s.path) {
-		serialized, err := ioutil.ReadFile(s.path)
+		serialized, err := os.ReadFile(s.path)
 		if err != nil {
 			return nil, err
 		}
@@ -52,7 +52,7 @@ func (s *Store) write(data *fileData) error {
 		return err
 	}
 
-	return ioutil.WriteFile(s.path, serialized, 0644)
+	return os.WriteFile(s.path, serialized, 0644)
 }
 
 // SetString stores a string for a key

--- a/pkg/helpers/upgrader.go
+++ b/pkg/helpers/upgrader.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -41,7 +40,7 @@ func (u *Upgrader) Perform(ui *termui.UI, destinationPath string, sourceURL stri
 		return
 	}
 
-	tmpFile, err := ioutil.TempFile("", "bud-")
+	tmpFile, err := os.CreateTemp("", "bud-")
 	if err != nil {
 		return
 	}

--- a/pkg/manifest/manifest.go
+++ b/pkg/manifest/manifest.go
@@ -2,7 +2,7 @@ package manifest
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -72,7 +72,7 @@ func Load(path string) (*Manifest, error) {
 		return nil, fmt.Errorf("no manifest at %s", manifestPath)
 	}
 
-	file, err := ioutil.ReadFile(manifestPath)
+	file, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/search.go
+++ b/pkg/project/search.go
@@ -2,7 +2,7 @@ package project
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/sahilm/fuzzy"
@@ -113,7 +113,7 @@ func getAllProjects(sourceDir string) ([]*Project, error) {
 }
 
 func listChildDir(path string) (paths []string, err error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		err = fmt.Errorf("error listing files in %s: %w", path, err)
 		return

--- a/pkg/utils/file.go
+++ b/pkg/utils/file.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"fmt"
 	"hash/adler32"
-	"io/ioutil"
 	"os"
 	"time"
 )
@@ -31,7 +30,7 @@ func Touch(path string, atime, mtime time.Time) error {
 
 // FileChecksum reads a file and return the Adler32 checksum of its data as a string
 func FileChecksum(path string) (string, error) {
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}

--- a/tests/cmd_custom_test.go
+++ b/tests/cmd_custom_test.go
@@ -21,7 +21,7 @@ commands:
 func Test_Cmd_Custom(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	project := CreateProject(t, c, "project", devYmlMyCmd)
+	project := CreateProject(t, c, devYmlMyCmd)
 	c.Cd(t, project.Path)
 
 	lines := c.Run(t, "bud mycmd")
@@ -34,7 +34,7 @@ func Test_Cmd_Custom(t *testing.T) {
 func Test_Cmd_Custom_Short_Syntax(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	project := CreateProject(t, c, "project", devYmlMyCmdShort)
+	project := CreateProject(t, c, devYmlMyCmdShort)
 	c.Cd(t, project.Path)
 
 	lines := c.Run(t, "bud mycmd")
@@ -44,7 +44,7 @@ func Test_Cmd_Custom_Short_Syntax(t *testing.T) {
 func Test_Cmd_Custom_Envs_Are_Applied(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	project := CreateProject(t, c, "project",
+	project := CreateProject(t, c,
 		`env:`,
 		`  MYVAR: poipoi`,
 		`commands:`,
@@ -59,7 +59,7 @@ func Test_Cmd_Custom_Envs_Are_Applied(t *testing.T) {
 func Test_Cmd_Custom_Always_Run_In_Project_Root(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	project := CreateProject(t, c, "project", devYmlMyCmd)
+	project := CreateProject(t, c, devYmlMyCmd)
 	c.Cd(t, project.Path)
 	c.Run(t, "mkdir foobar")
 	c.Cd(t, "foobar")

--- a/tests/cmd_inspect_test.go
+++ b/tests/cmd_inspect_test.go
@@ -9,7 +9,7 @@ import (
 func Test_Cmd_Inspect(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project",
+	project := CreateProject(t, c,
 		`up:`,
 		`- node: '10.15.0'`,
 		`- pip: [requirements.txt]`,
@@ -17,7 +17,7 @@ func Test_Cmd_Inspect(t *testing.T) {
 
 	lines := c.Run(t, "bud inspect")
 	OutputEqual(t, lines[0:3],
-		"Found project at /home/tester/src/github.com/orgname/project",
+		"Found project at "+project.Path,
 		"- Task NodeJS (10.15.0) feature=node:10.15.0 actions=2",
 		"- Task Pip (requirements.txt) required_task=python actions=1",
 	)

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -152,7 +152,7 @@ func (c *TestContext) run(cmd string, optFns ...runOptionsFn) ([]string, error) 
 	if exitCode != opt.exitCode {
 		exert := "no output"
 		if len(lines) > 0 {
-			exert = lines[0]
+			exert = strings.Join(lines[:min(5, len(lines))], "\n")
 		}
 		return nil, fmt.Errorf("exit code %d. first output line: %s", exitCode, exert)
 	}

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"crypto/rand"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -68,15 +70,19 @@ type Project struct {
 	Path string
 }
 
-func CreateProject(t *testing.T, c *context.TestContext, name string, devYmlLines ...string) Project {
-	projectPath := "/home/tester/src/github.com/orgname/" + name
+func CreateProject(t *testing.T, c *context.TestContext, devYmlLines ...string) Project {
+	rnd := make([]byte, 4)
+	rand.Read(rnd)
+	projectName := fmt.Sprintf("project-%x", rnd)
+
+	projectPath := "/home/tester/src/github.com/orgname/" + projectName
 	c.Run(t, "mkdir -p "+projectPath)
 
 	path := projectPath + "/dev.yml"
 	c.Write(t, path, strings.Join(devYmlLines, "\n"))
 	c.Cd(t, projectPath)
 
-	return Project{name, projectPath}
+	return Project{projectName, projectPath}
 }
 
 func (p *Project) UpdateDevYml(t *testing.T, c *context.TestContext, devYmlLines ...string) {

--- a/tests/task_custom_test.go
+++ b/tests/task_custom_test.go
@@ -19,7 +19,7 @@ up:
 func Test_Task_Custom(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project", customTaskDevYml)
+	CreateProject(t, c, customTaskDevYml)
 
 	// file does not exist -> task must run
 	c.Run(t, "bud up")
@@ -35,7 +35,7 @@ func Test_Task_Custom(t *testing.T) {
 func Test_Task_Custom_Subdir(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project", customTaskDevYml)
+	CreateProject(t, c, customTaskDevYml)
 
 	// The command must work in a sub-dir, but run in the project root
 	c.Run(t, "mkdir subdir")
@@ -50,7 +50,7 @@ func Test_Task_Custom_Subdir(t *testing.T) {
 func Test_Task_Custom_Fails(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project", `
+	CreateProject(t, c, `
 up:
 - custom:
     name: TestCustom
@@ -67,7 +67,7 @@ func Test_Task_Custom_With_Env_From_Shell(t *testing.T) {
 
 	c.Run(t, "export MYVAR=poipoi")
 
-	CreateProject(t, c, "project",
+	CreateProject(t, c,
 		`env:`,
 		`  MYVAR: poipoi`,
 		`up:`,
@@ -86,7 +86,7 @@ func Test_Task_Custom_With_Env_At_First_Run(t *testing.T) {
 	t.Skip("Fixme: env vars not set before tasks?")
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project",
+	CreateProject(t, c,
 		`env:`,
 		`  MYVAR: poipoi`,
 		`up:`,
@@ -107,7 +107,7 @@ func Test_Task_Custom_With_Env_Previously_Set_By_DevBuddy(t *testing.T) {
 
 	c.Run(t, "export MYVAR=poipoi")
 
-	p := CreateProject(t, c, "project",
+	p := CreateProject(t, c,
 		`env:`,
 		`  MYVAR: poipoi`,
 	)

--- a/tests/task_go_test.go
+++ b/tests/task_go_test.go
@@ -30,7 +30,7 @@ func Test_Task_Go(t *testing.T) {
 
 		c.Run(t, "export GOPATH=~")
 
-		CreateProject(t, c, "project",
+		CreateProject(t, c,
 			`up:`,
 			`- go:`,
 			`    version: "1.20"`,
@@ -58,7 +58,7 @@ func Test_Task_Go(t *testing.T) {
 
 		c.Run(t, "unset GOPATH")
 
-		CreateProject(t, c, "project2",
+		CreateProject(t, c,
 			`up:`,
 			`- go:`,
 			`    version: "1.20"`,
@@ -87,7 +87,7 @@ func Test_Task_Go(t *testing.T) {
 
 		c.Run(t, "export GOPATH=~")
 
-		CreateProject(t, c, "project3",
+		CreateProject(t, c,
 			`up:`,
 			`- go:`,
 			`    version: "1.20"`,

--- a/tests/task_node_test.go
+++ b/tests/task_node_test.go
@@ -10,7 +10,7 @@ import (
 func Test_Task_Node(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project",
+	CreateProject(t, c,
 		`up:`,
 		`- node: '10.15.0'`,
 	)
@@ -26,7 +26,7 @@ func Test_Task_Node(t *testing.T) {
 func Test_Task_Node_Npm_Install(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project",
+	CreateProject(t, c,
 		`up:`,
 		`- node: '10.15.0'`,
 	)

--- a/tests/task_node_test.go
+++ b/tests/task_node_test.go
@@ -4,10 +4,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/devbuddy/devbuddy/pkg/helpers"
 	"github.com/devbuddy/devbuddy/tests/context"
 )
 
 func Test_Task_Node(t *testing.T) {
+	if !helpers.NodeJSIsSupportedOnThisPlatform() {
+		t.Skip("NodeJS is not supported on this platform")
+	}
+
 	c := CreateContextAndInit(t)
 
 	CreateProject(t, c,
@@ -24,6 +29,10 @@ func Test_Task_Node(t *testing.T) {
 }
 
 func Test_Task_Node_Npm_Install(t *testing.T) {
+	if !helpers.NodeJSIsSupportedOnThisPlatform() {
+		t.Skip("NodeJS is not supported on this platform")
+	}
+
 	c := CreateContextAndInit(t)
 
 	CreateProject(t, c,

--- a/tests/task_pip_test.go
+++ b/tests/task_pip_test.go
@@ -10,7 +10,7 @@ import (
 func Test_Task_Pip(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project",
+	CreateProject(t, c,
 		`up:`,
 		`- python: 3.9.0`,
 		`- pip : [requirements.txt]`,

--- a/tests/task_pipfile_test.go
+++ b/tests/task_pipfile_test.go
@@ -10,7 +10,7 @@ import (
 func Test_Task_Pipfile(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	CreateProject(t, c, "project",
+	CreateProject(t, c,
 		`up:`,
 		`- python: 3.9.0`,
 		`- pipfile`,

--- a/tests/task_python_develop_test.go
+++ b/tests/task_python_develop_test.go
@@ -11,14 +11,13 @@ import (
 
 func Test_Task_Python_Develop(t *testing.T) {
 	c := CreateContextAndInit(t)
-	c.Debug()
 
 	devYml := `
 up:
 - python: 3.9.0
 - python_develop
 `
-	CreateProject(t, c, "project", devYml)
+	CreateProject(t, c, devYml)
 
 	// Install in develop mode
 
@@ -50,7 +49,7 @@ up:
 - python_develop:
     extras: [test]
 `
-	CreateProject(t, c, "project", devYml)
+	CreateProject(t, c, devYml)
 
 	c.Write(t, "setup.py", generateTestSetupPy(1))
 
@@ -68,7 +67,7 @@ up:
 - python: 3.9.0
 - python_develop:
 `
-	CreateProject(t, c, "project", devYml)
+	CreateProject(t, c, devYml)
 
 	c.Write(t, "setup.py", generateTestSetupPy(1))
 

--- a/tests/task_python_test.go
+++ b/tests/task_python_test.go
@@ -14,7 +14,7 @@ func Test_Env_Python(t *testing.T) {
 up:
 - python: 3.9.0
 `
-	CreateProject(t, c, "project", devYml)
+	CreateProject(t, c, devYml)
 
 	lines := c.Run(t, "bud up", context.Timeout(2*time.Minute))
 	OutputContains(t, lines, "python activated. (3.9.0)")


### PR DESCRIPTION
- Skip NodeJS tests on unsupported platform
- In tests, CreateProject picks a random project name
- Fix deprecated Go code