### PR TITLE
Update the usage string to group commands

### DIFF
--- a/pkg/cmd/cd.go
+++ b/pkg/cmd/cd.go
@@ -10,10 +10,11 @@ import (
 )
 
 var cdCmd = &cobra.Command{
-	Use:   "cd [PROJECT]",
-	Short: "Jump to a local project",
-	Run:   cdRun,
-	Args:  onlyOneArg,
+	Use:     "cd [PROJECT]",
+	Short:   "Jump to a local project",
+	Run:     cdRun,
+	Args:    onlyOneArg,
+	GroupID: "devbuddy",
 }
 
 func cdRun(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/clone.go
+++ b/pkg/cmd/clone.go
@@ -10,10 +10,11 @@ import (
 )
 
 var cloneCmd = &cobra.Command{
-	Use:   "clone [REMOTE]",
-	Short: "Clone a project from github.com",
-	Run:   cloneRun,
-	Args:  onlyOneArg,
+	Use:     "clone [REMOTE]",
+	Short:   "Clone a project from github.com",
+	Run:     cloneRun,
+	Args:    onlyOneArg,
+	GroupID: "devbuddy",
 }
 
 func cloneRun(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/commands.go
+++ b/pkg/cmd/commands.go
@@ -66,24 +66,15 @@ func buildCustomCommands(rootCmd *cobra.Command) {
 		return
 	}
 
-	var cmd *cobra.Command
-
 	for name, spec := range man.GetCommands() {
-		desc := "Custom"
-		if spec.Description != "" {
-			desc = fmt.Sprintf("Custom: %s", spec.Description)
-		}
-
-		useLine := fmt.Sprintf("%s [ARGS...]", name)
-
-		cmd = &cobra.Command{
-			Use:                useLine,
-			Short:              desc,
+		rootCmd.AddCommand(&cobra.Command{
+			Use:                fmt.Sprintf("%s [ARGS...]", name),
+			Short:              spec.Description,
 			RunE:               customCommandRun,
 			Annotations:        map[string]string{"name": name},
 			DisableFlagParsing: true,
 			SilenceUsage:       true,
-		}
-		rootCmd.AddCommand(cmd)
+			GroupID:            "project",
+		})
 	}
 }

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -10,13 +10,14 @@ import (
 )
 
 var createCmd = &cobra.Command{
-	Use:   "create [PROJECT]",
-	Short: "Create a new project",
-	Run:   createRun,
-	Args:  onlyOneArg,
+	Use:     "create [PROJECT]",
+	Short:   "Create a new project",
+	Run:     createRun,
+	Args:    onlyOneArg,
+	GroupID: "devbuddy",
 }
 
-func createRun(cmd *cobra.Command, args []string) {
+func createRun(_ *cobra.Command, args []string) {
 	cfg, err := config.Load()
 	checkError(err)
 

--- a/pkg/cmd/helpers.go
+++ b/pkg/cmd/helpers.go
@@ -17,7 +17,7 @@ func GetFlagBool(cmd *cobra.Command, flag string) bool {
 	return b
 }
 
-func onlyOneArg(cmd *cobra.Command, args []string) error {
+func onlyOneArg(_ *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("expecting one argument")
 	}
@@ -31,7 +31,7 @@ func noArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func zeroOrOneArg(cmd *cobra.Command, args []string) error {
+func zeroOrOneArg(_ *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("expecting zero or one argument")
 	}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -11,10 +11,11 @@ import (
 )
 
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize a project in the current directory",
-	Run:   initRun,
-	Args:  noArgs,
+	Use:     "init",
+	Short:   "Initialize a project in the current directory",
+	Run:     initRun,
+	Args:    noArgs,
+	GroupID: "devbuddy",
 }
 
 func initRun(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -10,13 +10,14 @@ import (
 )
 
 var inspectCmd = &cobra.Command{
-	Use:   "inspect",
-	Short: "Inspect the project and its tasks",
-	Run:   inspectRun,
-	Args:  noArgs,
+	Use:     "inspect",
+	Short:   "Inspect the project and its tasks",
+	Run:     inspectRun,
+	Args:    noArgs,
+	GroupID: "devbuddy",
 }
 
-func inspectRun(cmd *cobra.Command, args []string) {
+func inspectRun(_ *cobra.Command, _ []string) {
 	proj, err := project.FindCurrent()
 	checkError(err)
 

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -10,10 +10,11 @@ import (
 )
 
 var openCmd = &cobra.Command{
-	Use:   "open [github|pullrequest]",
-	Short: "Open a link about your project",
-	Run:   openRun,
-	Args:  zeroOrOneArg,
+	Use:     "open [github|pullrequest]",
+	Short:   "Open a link about your project",
+	Run:     openRun,
+	Args:    zeroOrOneArg,
+	GroupID: "devbuddy",
 }
 
 func init() {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -19,6 +19,13 @@ func build(version string) *cobra.Command {
 		Version: version,
 	}
 
+	rootCmd.AddGroup(
+		&cobra.Group{ID: "devbuddy", Title: "DevBuddy Commands:"},
+		&cobra.Group{ID: "project", Title: "Project Commands:"},
+	)
+	rootCmd.SetHelpCommandGroupID("devbuddy")
+	rootCmd.CompletionOptions.HiddenDefaultCmd = true
+
 	rootCmd.Flags().Bool("shell-init", false, "Shell initialization")
 	rootCmd.Flags().Bool("with-completion", false, "Enable completion during initialization")
 
@@ -41,7 +48,7 @@ func build(version string) *cobra.Command {
 	return rootCmd
 }
 
-func rootRun(cmd *cobra.Command, args []string) {
+func rootRun(cmd *cobra.Command, _ []string) {
 	var err error
 
 	if GetFlagBool(cmd, "shell-init") {

--- a/pkg/cmd/up.go
+++ b/pkg/cmd/up.go
@@ -16,10 +16,11 @@ func init() {
 }
 
 var upCmd = &cobra.Command{
-	Use:   "up",
-	Short: "Ensure the project is up and running",
-	Run:   upRun,
-	Args:  noArgs,
+	Use:     "up",
+	Short:   "Ensure the project is up and running",
+	Run:     upRun,
+	Args:    noArgs,
+	GroupID: "devbuddy",
 }
 
 func upRun(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -13,10 +13,11 @@ import (
 )
 
 var upgradeCmd = &cobra.Command{
-	Use:   "upgrade",
-	Short: "[experimental] Upgrade DevBuddy to the latest available release.",
-	Run:   upgradeRun,
-	Args:  noArgs,
+	Use:     "upgrade",
+	Short:   "[experimental] Upgrade DevBuddy to the latest available release.",
+	Run:     upgradeRun,
+	Args:    noArgs,
+	GroupID: "devbuddy",
 }
 
 func upgradeRun(cmd *cobra.Command, args []string) {

--- a/tests/cmd_test.go
+++ b/tests/cmd_test.go
@@ -10,10 +10,10 @@ func Test_Cmd_Help(t *testing.T) {
 	c := CreateContext(t)
 
 	lines := c.Run(t, "bud")
-	OutputContains(t, lines, "Usage:", "Available Commands:", "Flags:")
+	OutputContains(t, lines, "Usage:", "DevBuddy Commands:", "  cd", "  clone", "  up", "Flags:")
 
 	lines = c.Run(t, "bud --help")
-	OutputContains(t, lines, "Usage:", "Available Commands:", "Flags:")
+	OutputContains(t, lines, "Usage:", "DevBuddy Commands:", "  cd", "  clone", "  up", "Flags:")
 }
 
 func Test_Cmd_Version(t *testing.T) {

--- a/tests/helper_test.go
+++ b/tests/helper_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/devbuddy/devbuddy/tests/context"
 )
 
-var config context.Config // Initialized by TestMain()
-
 func CreateContext(t *testing.T) *context.TestContext {
 	t.Helper()
 

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/devbuddy/devbuddy/tests/context"
 )
 
+var config context.Config
+
 func TestMain(m *testing.M) {
 	// call flag.Parse() here if TestMain uses flags
 


### PR DESCRIPTION
```
$ bud
Usage:
  bud [flags]
  bud [command]

DevBuddy commands
  cd              Jump to a local project
  clone           Clone a project from github.com
  create          Create a new project
  help            Help about any command
  init            Initialize a project in the current directory
  inspect         Inspect the project and its tasks
  open            Open a link about your project
  up              Ensure the project is up and running
  upgrade         [experimental] Upgrade DevBuddy to the latest available release.

Project commands
  build           Build all bud binaries
  ci              Run all tests as CI would do
  godoc
  install         Build and install DevBuddy in ${GOPATH}/bin
  integration     Run the integration tests with Bash
  integration-zsh Run the integration tests with Zsh
  lint            Lint the project
  lint-shell      Lint the shell scripts
  patch           Create a new patch release
  rc              Create a new release-candidate or increment the last release-candidate
  release         Create a new release
  releaselog      Show the commits since the last tag
  test            Run the unittests

Flags:
      --debug-info        Print some debug information
  -h, --help              help for bud
      --report-issue      Create an issue about DevBuddy on Github
      --shell-init        Shell initialization
  -v, --version           version for bud
      --with-completion   Enable completion during initialization

Use "bud [command] --help" for more information about a command.
```