### PR TITLE
Python_develop: remove condition on setup.py / setup.cfg

### DIFF
--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -32,9 +32,7 @@ func parserPythonDevelop(config *api.TaskConfig, task *api.Task) error {
 
 		return nil
 	}
-	task.AddActionBuilder("install python package in develop mode", pipInstall).
-		On(api.FileCondition("setup.py")).
-		On(api.FileCondition("setup.cfg"))
+	task.AddActionBuilder("install python package in develop mode", pipInstall)
 
 	return nil
 }


### PR DESCRIPTION
## Why

The `python_develop` task only runs `pip install -e .` if it detects setup.py and setup.cfg.
Those files are widely replaced by pyproject.toml.

But also, I'm not sure why we would want those conditions: if the user chose to add the task, let's run it.

Fixes #479

## How

- Python_develop: remove condition on setup.py / setup.cfg

