### PR TITLE
Prompt to create dev.yml after bud clone

### DIFF
--- a/pkg/cmd/clone.go
+++ b/pkg/cmd/clone.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/integration"
+	"github.com/devbuddy/devbuddy/pkg/manifest"
 	"github.com/devbuddy/devbuddy/pkg/project"
 )
 
@@ -33,6 +35,18 @@ func cloneRun(_ *cobra.Command, args []string) error {
 	} else {
 		if err := proj.Clone(ctx.Executor); err != nil {
 			return err
+		}
+	}
+
+	if !manifest.ExistsIn(proj.Path) {
+		prompt := promptui.Prompt{
+			Label:     "This project has no dev.yml. Create one",
+			IsConfirm: true,
+		}
+		if _, err := prompt.Run(); err == nil {
+			if err := createManifest(ctx.UI, proj.Path, ""); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- After `bud clone`, if the cloned project has no `dev.yml`, prompt the user (y/N) to create one
- On confirmation, reuses the existing `createManifest()` template selection flow from `bud init`/`bud create`
- No changes needed outside `clone.go` — the shared `createManifest()` function in `init.go` handles everything

Fixes: #162

## Test plan

- [ ] `go build ./...` compiles
- [ ] `script/test` passes
- [ ] `script/lint` passes
- [ ] Manual: `bud clone` a repo without dev.yml → prompted to create one → selecting a template creates dev.yml
- [ ] Manual: `bud clone` a repo with dev.yml → no prompt shown
- [ ] Manual: declining the prompt (N) skips creation and jumps to project normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)