### PR TITLE
Improve docs consistency and clarify bud open behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ integration/bud
 devbuddy
 dist/
 bin/
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,184 @@
+# DevBuddy - Claude Instructions
+
+## Overview
+
+DevBuddy (`bud`) is a development environment manager. It reads a `dev.yml` file in a project root and automates environment setup (language versions, virtualenvs, system packages) and provides custom project commands. It integrates deeply with the user's shell (bash/zsh) via a shell hook that automatically activates/deactivates environments as you `cd` between projects.
+
+## Roadmap
+
+See `ROADMAP.md` for the product and technical direction. Consult it before making architectural changes to ensure they align with the desired direction. Key points:
+- Moving toward a **runtime environment abstraction** (command execution, filesystem, terminal I/O, env vars, state store) with real and testing implementations
+- Near-term: refactor `pkg/executor/` from interface+builder to a plain struct representing a command request
+- Changes should move toward testability without Docker/PTY and away from direct OS calls in business logic
+
+## Project Structure
+
+```
+cmd/bud/main.go          # Entry point. Version set via build flags (-ldflags)
+pkg/
+  cmd/                    # Cobra CLI commands (root, up, cd, clone, open, create, init, inspect, upgrade, commands)
+  config/                 # Global config (debug mode via BUD_DEBUG env var)
+  context/                # Runtime context: loads project, env, UI
+  env/                    # Environment variable mutation tracking (set, prepend, compare)
+  executor/               # Command execution helpers
+  autoenv/                # Feature activation/deactivation state machine
+    feature_info.go       # FeatureInfo (name+param), FeatureSet
+    state.go              # Persisted state of active features (JSON in BUD_AUTO_ENV_FEATURES)
+    runner.go             # Sync() - activates/deactivates features by diffing desired vs current
+  hook/                   # Shell hook logic (called on every prompt via `bud --shell-hook`)
+  integration/            # Shell integration scripts (embedded via //go:embed)
+    common.sh             # bud() wrapper, __bud_prompt_command, finalizers
+    bash.sh               # PROMPT_COMMAND hook
+    zsh.sh                # precmd_functions hook
+    integration.go        # Print(), CompletionScriptProvider, AddFinalizerCd
+  manifest/               # dev.yml parsing
+  project/                # Project discovery (walks up to find dev.yml)
+  tasks/                  # Task implementations
+    api/                  # TaskAction interface, Condition interface (file checksum tracking)
+    taskengine/           # Task execution engine
+    golang.go             # Go version management (installs Go, sets GOROOT/GOPATH/GO111MODULE)
+    python.go             # Python via pyenv
+    python_develop.go     # pip install -e . (tracks setup.py/pyproject.toml changes)
+    pip.go                # pip install -r requirements.txt
+    pipfile.go            # Pipfile support
+    node.go               # Node.js version management
+    homebrew.go           # Homebrew package installation
+    apt.go                # APT package installation
+    custom.go             # Custom tasks (met?/meet pattern)
+    env.go                # Environment variable task
+    envfile.go            # .env file loading
+    golang_dep.go         # Go dep (legacy)
+  helpers/                # Shared helpers
+    debug/                # Debug info collector
+    downloader.go         # HTTP file downloader
+    git.go                # Git operations
+    github.go             # GitHub URL parsing
+    golang.go             # Go installation helper
+    homebrew.go           # Homebrew detection/installation
+    node.go               # Node.js installation
+    pyenv.go              # Pyenv management
+    virtualenv.go         # Python virtualenv creation
+    store/                # Key-value store (.devbuddy/ dir in project)
+    open/                 # URL opener (browser)
+    osidentity/           # OS detection (linux/darwin)
+    projectmetadata/      # Project source path conventions
+    fixtures/             # Test fixtures (VCR cassettes)
+  termui/                 # Terminal UI (colored output, spinners, panda emoji)
+  test/                   # Test utilities
+  utils/                  # File utils, checksums, path helpers
+script/
+  test                    # Run unit tests (./pkg/...)
+  lint                    # Run golangci-lint
+  buildall                # Cross-compile for all platforms
+  release.py              # Release automation (version bump, tag, push)
+  install-dev.sh          # Build and install to GOPATH/bin
+tests/                    # Integration tests (Docker-based)
+  context/                # TestContext: orchestrates Docker container with shell
+  main_test.go            # TestMain: builds Linux binary, loads config
+  helper_test.go          # CreateContext, CreateProject, output assertions
+  cmd_*_test.go           # Command integration tests
+  task_*_test.go          # Task integration tests
+```
+
+## Key Architectural Concepts
+
+### Shell Integration
+The user adds `eval "$(bud --shell-init)"` to their shell config. This:
+1. Defines a `bud()` shell function that wraps the real binary
+2. The wrapper handles "finalizers" (cd, setenv) via a temp file (`BUD_FINALIZER_FILE`)
+3. Installs `__bud_prompt_command` as PROMPT_COMMAND (bash) or precmd (zsh)
+4. On every prompt, `bud --shell-hook` runs and outputs shell commands to stdout
+5. The hook output is `eval`'d to export/unset env vars, activate virtualenvs, etc.
+
+Shell hook guardrails:
+- `__bud_prompt_command` must preserve the previous command exit code (`$?`) so prompt-hook execution never clobbers user-visible status.
+- Changes to shell hooks should include an integration regression test under `tests/` (for both bash and zsh jobs).
+
+### AutoEnv (Feature Activation)
+- Each task can declare a "feature" (e.g., `python=3.6.5`, `golang=1.21`)
+- The hook tracks active features in `BUD_AUTO_ENV_FEATURES` env var (JSON state)
+- `autoenv.Sync()` diffs desired vs active features, activating/deactivating as needed
+- Features mutate the environment (PATH, GOROOT, VIRTUAL_ENV, etc.)
+- When leaving a project, features are deactivated and env vars restored
+
+### Task System
+- Tasks implement `TaskAction` interface: `Description()`, `Needed()`, `Run()`, `Feature()`
+- `Needed()` returns whether the task should run (idempotent check)
+- `Condition` interface supports file-checksum-based change detection
+- Task state stored in `.devbuddy/` directory within the project
+
+### Finalizer Mechanism
+Some commands (like `bud cd`) need to change the shell's working directory. Since a subprocess can't change the parent shell's cwd, DevBuddy writes a "finalizer" to `BUD_FINALIZER_FILE`, and the shell wrapper function processes it after the command exits.
+
+## Development
+
+### Build & Run
+```bash
+bud install              # Build and install to GOPATH/bin
+go build -o bud ./cmd/bud  # Quick local build
+```
+
+### Testing
+```bash
+script/test              # Unit tests only (./pkg/...)
+script/lint              # golangci-lint
+```
+
+### Integration Tests
+Don't use `bud integration` (requires a PTY). Run the go test command directly:
+```bash
+export TEST_DOCKER_IMAGE="ghcr.io/devbuddy/docker-testing:sha-7fd13f4"
+TEST_SHELL=bash go test -v -count=1 ./tests
+TEST_SHELL=zsh go test -v -count=1 ./tests
+```
+- Takes ~1 minute, 34 pass / 5 skipped (Node platform not available, env var fixmes)
+- Use `-count=1` to bypass test cache
+- Requires Docker running locally
+
+### Integration Test Architecture
+Integration tests run inside a Docker container (`ghcr.io/devbuddy/docker-testing`):
+- `TestMain()` cross-compiles a Linux binary, mounts it into the container
+- `TestContext` uses `github.com/devbuddy/expect` (PTY-based shell automation)
+- Tests create projects with dev.yml, run `bud` commands, assert output
+- Controlled by env vars: `TEST_SHELL` (bash/zsh), `TEST_DOCKER_IMAGE`
+- Docker image: Ubuntu 20.04 with pyenv, Python 3.9, build tools, git, zsh
+
+**Note:** `dev.yml` references `TEST_DOCKER_IMAGE: ghcr.io/devbuddy/docker-testing:sha-7fd13f4` but CI uses `sha-f11e362`. These may need syncing.
+
+### CI/CD
+GitHub Actions (`.github/workflows/tests.yml`):
+- golangci-lint, unit tests, bash integration, zsh integration (parallel)
+- Release job on version tags: `script/buildall` + GitHub Releases + Homebrew trigger
+- Go 1.24, golangci-lint v2.1.2
+
+### Release Process
+```bash
+python3 script/release.py release           # Minor bump (0.14.1 -> 0.15.0)
+python3 script/release.py patch             # Patch bump (0.14.1 -> 0.14.2)
+python3 script/release.py release-candidate # RC version
+python3 script/release.py --dryrun release  # Dry run
+```
+The script creates a release commit + annotated tag + pushes to GitHub. CI builds binaries and publishes.
+
+### Distribution
+- macOS: Homebrew (`devbuddy/homebrew-devbuddy`, auto-triggered on release)
+- Linux: GitHub Releases (direct binary download)
+- Platforms: darwin/amd64, darwin/arm64, linux/amd64, linux/arm64
+
+## Dependencies
+- `github.com/spf13/cobra` - CLI framework
+- `github.com/devbuddy/expect` - PTY-based shell automation (custom fork)
+- `github.com/joho/godotenv` - .env file parsing
+- `github.com/logrusorgru/aurora` - Terminal colors
+- `github.com/sahilm/fuzzy` - Fuzzy matching (for `bud cd`)
+- `github.com/mitchellh/go-ps` - Process detection (shell identification)
+- `github.com/dnaeon/go-vcr` - HTTP recording for tests
+- `gopkg.in/yaml.v2` - YAML parsing
+
+## Conventions
+- Version is set at build time via `-ldflags` (not in source)
+- No changelog maintained
+- Panda emoji in UI output
+- `.devbuddy/` directory stores per-project state (checksums, etc.)
+- `BUD_DEBUG=1` enables debug logging in both Go code and shell hooks
+- When creating or updating a pull request description for an issue-driven change, include a closing reference in this exact format: `Fixes: #<ISSUE-NUMBER>`

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ The project is evolving slowly, mostly because DevBuddy covers my current needs.
 
 I would love to help people implement their languages/environments/tools/dev-flow.
 
-## What is this?
+## What is DevBuddy?
 
-**DevBuddy** is an open-source implementation of an amazing internal tool developed at
+**DevBuddy** is an open-source implementation of an internal tool developed at
 [Shopify](https://engineering.shopify.com) called "**Dev**".
 
-The first goal of this tools is to automate the **setup** tasks required to work on a project.
+The first goal of this tool is to automate the **setup** tasks required to work on a project.
 
-With **DevBuddy**, pushing a change on a project you never touched look like this:
+With **DevBuddy**, pushing a change to a project you have never touched looks like this:
 
 - `bud clone devbuddy/devbuddy`
 - `bud up`
@@ -44,7 +44,7 @@ supported. DevBuddy is still useful for languages without native support thanks 
 
 See the project config [documentation](docs/Config.md).
 
-### Tasks:
+### Tasks
 
 Python:
 - Python environment (pyenv + virtualenv)
@@ -71,17 +71,17 @@ Others:
 - Custom (conditional shell command)
 - Docker Compose (manage a docker-compose setup): **planned**
 
-### Features:
+### Features
 
-- Notification when important files (eg: `requirements.txt`) are updated locally
-  (eg: by `git pull`)
+- Notification when important files (e.g. `requirements.txt`) are updated locally
+  (e.g. by `git pull`)
 - A `help` command to guide a new developer based on `dev.yml`
-- A `upgrade` command to auto-upgrade **DevBuddy**
+- An `upgrade` command to auto-upgrade **DevBuddy**
 
-### Code hosting platform:
+### Supported code hosting platforms
 
-- Github
-- Gitlab
+- GitHub
+- GitLab
 - Bitbucket (with Git)
 
 ### Shell integration
@@ -110,7 +110,7 @@ $ brew install --HEAD devbuddy
 
 ### Go install
 
-Note: use this if your your PATH includes the GOBIN path.
+Note: use this if your PATH includes the GOBIN path.
 
 Latest release:
 ```bash
@@ -167,7 +167,7 @@ $ sudo install /tmp/bud /usr/local/bin/bud
 
 ## Setup
 
-★ Install the shell integration (in `~/.bash_profile`, or `~/.zshrc`):
+★ Install shell integration (in `~/.bash_profile` or `~/.zshrc`):
 ```bash
 eval "$(bud --shell-init --with-completion)"
 ```
@@ -179,13 +179,13 @@ type bud > /dev/null 2> /dev/null && eval "$(bud --shell-init --with-completion)
 
 ### Configuration
 
-If you usual work with repos from the same organization (like your personal one), you can set it as a default:
+If you usually work with repos from the same organization (like your personal one), you can set it as a default:
 
 ```
 export BUD_DEFAULT_ORG="google"
 ```
 
-Then you can use it directly to create, clone and jump to those repos:
+Then you can use it directly to create, clone, and jump to those repos:
 ```bash
 $ bud clone pytruth
 ```
@@ -217,7 +217,7 @@ open:
   staging: https://staging.myapp.com
   doc: https://godoc.org/github.com/org/myapp
 ```
-See DevBuddy own [dev.yml](dev.yml)
+See DevBuddy's own [dev.yml](dev.yml).
 
 ```bash
 $ bud

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,67 @@
+# DevBuddy Roadmap
+
+Product and technical direction for the project. Consult this when making changes to ensure they align with the desired direction.
+
+## Product Direction
+
+DevBuddy automates development environment setup. The core value is: `cd` into a project, everything activates; run `bud up`, everything installs. It should work reliably across shells, platforms, and terminal environments (interactive, CI, editors, piped).
+
+## Technical Direction
+
+### Runtime Environment Abstraction
+
+The long-term goal is an **environment service** — a single interface representing the execution environment that all code operates through. This covers:
+
+- **Command execution** — running subprocesses
+- **Filesystem** — reading/writing files, checking paths
+- **Terminal I/O** — stdout, stderr, stdin, isatty detection
+- **Environment variables** — reading, setting, tracking mutations
+- **State store** — per-project state (`.devbuddy/` directory)
+- **Logging / UI** — debug output, user-facing messages
+
+Production code uses a **real implementation** that talks to the actual OS. Tests use a **testing implementation** that can be inspected and controlled without real subprocesses, filesystem writes, or terminal access.
+
+This makes the codebase testable without Docker containers or PTY automation, and eliminates the class of bugs where code assumes a specific execution context (interactive terminal, specific OS, writable filesystem).
+
+### Near-term: Executor Refactor
+
+The first step toward the environment abstraction is refactoring `pkg/executor/`:
+
+**Current state:** an `Executor` interface with 11 methods, a fluent builder pattern, and 3 execution modes (output-filter, PTY, passthrough). Tests need type assertions to access internal fields. Several interface methods are unused.
+
+**Target state:** a plain struct representing a command execution request:
+
+```go
+type ExecTask struct {
+    Command      string
+    Args         []string
+    Shell        bool       // if true, run via sh -c
+    Cwd          string
+    Env          []string
+    Passthrough  bool       // inherit stdin/stdout/stderr directly
+    OutputPrefix string
+}
+
+func (t ExecTask) Run() *Result { ... }
+func (t ExecTask) Capture() *Result { ... }
+```
+
+Benefits:
+- Tests inspect struct fields directly — no mocking, no type assertions
+- Adding a field doesn't break an interface
+- No ambiguity about configuration order or repeated calls
+- Natural stepping stone to injecting a `RunFunc` for testing
+
+**Drop:** `SetPTY` (unused), `AddOutputFilter` (unused), `SetEnvVar` (unused), the `Executor` interface itself.
+
+### Future Steps (not yet planned)
+
+Once the executor is a plain struct, introduce a `Runtime` or `Env` service:
+
+1. Extract terminal I/O from `termui` into the service
+2. Move env var tracking (`pkg/env/`) behind the service
+3. Move state store (`pkg/helpers/store/`) behind the service
+4. Move filesystem operations behind the service
+5. Inject the service into task context, replacing direct OS calls
+
+Each step is independently valuable and shippable.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Install DevBuddy by following the steps in the [README](../README.md#install).
 
 ### Clone the project
 
-This will clone a repository from Github: `github.com/devbuddy/devbuddy`.
+This will clone a repository from GitHub: `github.com/devbuddy/devbuddy`.
 
 The repo will be cloned at `~/src/github.com/devbuddy/devbuddy`.
 
@@ -14,24 +14,23 @@ The repo will be cloned at `~/src/github.com/devbuddy/devbuddy`.
 $ bud clone devbuddy/devbuddy
 ```
 
-### Setup the project with DevBuddy
+### Set up the project with DevBuddy
 
-This is the core feature of DevBuddy, the `up` command is supposed to prepare/install/setup everything needed to
-start developing on the project.
+This is the core feature of DevBuddy: the `up` command prepares everything needed to start developing on the project.
 
 ```shell
 ~/src/github.com/devbuddy/devbuddy $ bud up
 ```
 
 The command will sequentially evaluate the *up* tasks defined in [dev.yml](../dev.yml).
-Some will setup the working environment (`go`, `python`), some will install dependencies (`golang_dep`, `pip`),
+Some will set up the working environment (`go`, `python`), some will install dependencies (`golang_dep`, `pip`),
 some will conditionally execute an arbitrary command for specific situations.
 
 ### Run the tests
 
 Project specific commands can be defined in the `commands` section of the [dev.yml](../dev.yml).
 
-Typical commands are `test`, `lint`, `clean`, `release`
+Typical commands are `test`, `lint`, `clean`, and `release`.
 
 ```shell
 ~/src/github.com/devbuddy/devbuddy $ bud test
@@ -46,8 +45,11 @@ Typical commands are `test`, `lint`, `clean`, `release`
 ### Run the integration tests
 
 ```shell
-~/src/github.com/devbuddy/devbuddy $ bud integration
+~/src/github.com/devbuddy/devbuddy $ TEST_SHELL=bash go test -v -count=1 ./tests
+~/src/github.com/devbuddy/devbuddy $ TEST_SHELL=zsh go test -v -count=1 ./tests
 ```
+
+Make sure Docker is running, and set `TEST_DOCKER_IMAGE` when needed.
 
 ### Install DevBuddy from your branch
 
@@ -69,7 +71,7 @@ Or simply:
 
 ### Debugging
 
-You can enable the debug messages with:
+You can enable debug logging with:
 
 ```bash
 $ bud-enable-debug
@@ -89,7 +91,6 @@ $ bud release
 ```
 
 This command will create a tag and push it to the origin.
-The CI process will build and upload the distributions on Github.
+The CI process will build and upload the distributions on GitHub.
 
-Updating the version defined in the [install.sh](https://github.com/devbuddy/devbuddy/blob/master/install.sh)
-script is probably a good idea.
+If release tooling changes, keep install instructions in [README](../README.md#install) in sync.

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -3,16 +3,16 @@
 ## Example
 
 The file `dev.yml` must be placed at the root directory of your project.
-It should be commited to your repository and shared with everyone working on the project.
+It should be committed to your repository and shared with everyone working on the project.
 
 The `up` section describes the tasks that the `bud up` command will run.
 Some tasks prepare your environment to use a language like `python` or `go`.
-Other tasks ensure your environment is up to date like `pip` or `golang_dep`.
-The special `custom` task let you handle specific case needed for your project. See [Tasks](#tasks).
+Other tasks ensure your environment is up to date, like `pip` or `golang_dep`.
+The special `custom` task lets you handle specific cases needed for your project. See [Tasks](#tasks).
 
 The `commands` section describes the project commands like `bud test`. See [Project Commands](#project-commands).
 
-The `open` section describes the project links available through `bud open <name>`. See [Open Command](#open-command).
+The `open` section describes the project links available through `bud open <pattern>`. See [Open Command](#open-command).
 
 **`dev.yml`**:
 ```yaml
@@ -51,7 +51,7 @@ env:
   MEMCACHE_URL: localhost:11211
 ```
 
-The environment variables will be set as soon as you enter the project, they can be used in `custom` tasks, in
+The environment variables will be set as soon as you enter the project. They can be used in `custom` tasks, in
 the `commands` section and in your shell.
 
 ## Tasks
@@ -80,7 +80,7 @@ up:
 
 ### `python`
 
-This task will install the Python version (with PyEnv, which must be installed), create
+This task will install the Python version (with pyenv, which must be installed), create
 a virtualenv and activate it in your shell.
 
 ```yaml
@@ -105,9 +105,9 @@ up:
 
 This task will install a pip requirements file.
 
-A Python environment must be selected before.
+A Python environment must be selected first.
 
-Currently this task can't detect whether it should run or not. PR welcome!
+Currently this task cannot detect whether it should run. PR welcome!
 
 ```yaml
 up:
@@ -122,9 +122,9 @@ up:
 This task will install a [Pipfile](https://github.com/pypa/pipfile) with
 [Pipenv](https://github.com/pypa/pipenv).
 
-A Python environment must be selected before.
+A Python environment must be selected first.
 
-Currently this task can't detect whether it should run or not. PR welcome!
+Currently this task cannot detect whether it should run. PR welcome!
 
 ```yaml
 up:
@@ -164,7 +164,7 @@ up:
 ### `node`
 
 This task will download the Node distribution from `nodejs.org` and activate it in your shell.
-Optionally, it can also install the NodeJS dependencies.
+Optionally, it can also install the Node.js dependencies.
 
 ```yaml
 up:
@@ -194,7 +194,7 @@ up:
 
 ## Project commands
 
-The project can define custom command in `dev.yml` that can be called with: `bud <command>`. Additional arguments are
+The project can define custom commands in `dev.yml` that can be called with: `bud <command>`. Additional arguments are
 also passed to the command: `bud <command> <arg> <arg>...`.
 
 ```yaml
@@ -207,7 +207,7 @@ commands:
     run: script/run_all_linters
 ```
 
-`bud test` is not much shorter than calling `script/test` for example.
+`bud test` is not much shorter than calling `script/test`, for example.
 The idea is to introduce an indirection that will be easy to document and remember by being consistent across projects
 regardless of the programming language used (`rails test`? `pytest -v`? `npm test`? `go test ./...`?).
 
@@ -219,7 +219,7 @@ pkg/project/current.go:14:2:warning: unused variable or constant someVariable de
 
 ## Open Command
 
-The command `bud open <name>` will open a link about the project with the OS default handler (using `open`/`xdg-open`).
+The command `bud open <pattern>` opens a project link with the OS default handler (using `open`/`xdg-open`).
 
 ### Custom links
 
@@ -230,8 +230,12 @@ open:
   doc: https://godoc.org/github.com/org/myapp
 ```
 
-Tip: `dev open` is enough if there is only one link.
+Tip: `bud open` is enough if there is only one link.
 
-### Github links:
-- `github`/`gh`: open the Github source code page for your checked out branch
-- `pullrequest`/`pr`: open the Github pull-request page for your checked out branch
+Matching for custom links is fuzzy, so `bud open stg` can match `staging`.
+
+### GitHub links:
+- `github`/`gh`: open the GitHub source code page for your checked out branch
+- `pullrequest`/`pr`: open the GitHub pull-request page for your checked out branch
+
+Built-in GitHub link names are exact aliases only (no fuzzy matching).

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Why
 
+Fixes: #<ISSUE-NUMBER>
 
 
 ## How
-
 

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -8,7 +8,7 @@ import (
 )
 
 var openCmd = &cobra.Command{
-	Use:          "open [github|pullrequest]",
+	Use:          "open [pattern]",
 	Short:        "Open a link about your project",
 	RunE:         openRun,
 	Args:         zeroOrOneArg,

--- a/tests/INTEGRATION_TESTS.md
+++ b/tests/INTEGRATION_TESTS.md
@@ -1,0 +1,219 @@
+# Integration Tests
+
+## Goals
+
+The integration tests verify that DevBuddy works correctly as an end-user would experience it:
+running inside a real shell, with real environment mutations, real task execution, and real
+shell integration (hooks, finalizers, autoenv).
+
+This is necessary because DevBuddy's core value is shell integration — it mutates the user's
+shell environment, and unit tests cannot verify that. The integration tests prove that:
+
+1. **Shell integration works**: `eval "$(bud --shell-init)"` installs the wrapper and hooks correctly
+2. **Shell hook works**: entering/leaving a project activates/deactivates features (env vars, PATH)
+3. **Finalizers work**: `bud cd` changes the shell's working directory
+4. **Tasks execute correctly**: `bud up` runs tasks, respects conditions, reports errors
+5. **Custom commands work**: project commands from dev.yml execute with the right environment
+6. **Both bash and zsh work**: the shell integration must work identically in both shells
+
+## Requirements
+
+### Shell coverage
+
+- **Bash and zsh are both essential.** Users use both, and the shell integration code differs
+  between them (PROMPT_COMMAND vs precmd_functions, different quoting edge cases).
+- Every test must pass in both shells.
+
+### Platform coverage
+
+- **Linux**: primary CI platform, tested via Docker containers.
+- **macOS**: needed for macOS-specific tasks (homebrew). Currently not covered by integration
+  tests. This is a gap.
+
+### Isolation
+
+- Each test must start from a clean, predictable state.
+- Tests must not affect each other. A failing test must not cause subsequent tests to fail.
+- The test environment must not depend on the host machine's state beyond Docker being available.
+
+### No network dependency
+
+- Integration tests must not depend on external network calls (downloading Go, Python, Node, etc.).
+- External downloads are a major source of flakiness: slow, rate-limited, or unavailable.
+- **Strategy**: use a local HTTP server serving dummy payloads, or pre-bake tools into the
+  Docker image, or force the HTTP client to target a local server.
+- The tests should prove that DevBuddy correctly orchestrates the installation — not that the
+  upstream download servers are available.
+
+### Robustness
+
+- Tests must be deterministic. Flaky tests erode trust and slow down development.
+- Prompt detection must be reliable. The PTY/expect layer is the most fragile part.
+- Timeouts must be generous enough for slow CI machines but tight enough to catch hangs.
+- CI and local-dev must behave the same way. A test that passes in CI but fails locally
+  (or vice versa) is a bug in the test infrastructure.
+
+### Speed
+
+- Fast feedback is important. Tests that take minutes to run get skipped.
+- Container startup/teardown overhead should be minimized.
+- Tests that don't need network or heavy setup should run fast.
+
+## Current Implementation
+
+### Architecture
+
+```
+Host machine (macOS or Linux CI)
+  │
+  ├─ TestMain (tests/main_test.go)
+  │   ├─ Loads config from env vars (TEST_SHELL, TEST_DOCKER_IMAGE)
+  │   └─ Cross-compiles a static Linux binary: GOOS=linux CGO_ENABLED=0
+  │
+  ├─ Per test function:
+  │   ├─ CreateContext() → starts a Docker container with the compiled binary mounted
+  │   │   ├─ docker run -ti --rm -v bud:/usr/local/bin/bud -e PS1=... IMAGE SHELL
+  │   │   ├─ Wraps with expect.ShellExpect (prompt-based command/response)
+  │   │   ├─ Disables echo: stty -echo
+  │   │   └─ Verifies IN_DOCKER=yes
+  │   │
+  │   ├─ CreateContextAndInit() → also runs: eval "$(bud --shell-init)"
+  │   │
+  │   ├─ CreateProject() → creates a temp directory with a dev.yml inside the container
+  │   │
+  │   └─ c.Run(t, "bud up") → sends command, waits for prompt, checks exit code
+  │
+  └─ Container cleanup via t.Cleanup() → sends SIGKILL to Docker process
+```
+
+### Key components
+
+**tests/main_test.go** — TestMain builds the Linux binary once before all tests run.
+
+**tests/context/** — TestContext wraps the Docker + PTY interaction:
+- `context.go`: New(), Run(), Write(), Cat(), Cd(), GetEnv(), Close()
+- `config.go`: loads TEST_SHELL (default "bash"), TEST_DOCKER_IMAGE (required)
+- `options.go`: Timeout() (default 5s), ExitCode() (default 0)
+- `strip_ansi.go`: strips ANSI escape codes from command output
+
+**tests/helper_test.go** — Test helpers:
+- `CreateContext(t)` / `CreateContextAndInit(t)`: container lifecycle
+- `CreateProject(t, c, devYmlLines...)`: creates a project dir with dev.yml
+- `OutputContains(t, lines, ...)` / `OutputEqual(t, lines, ...)`: output assertions
+
+**github.com/devbuddy/expect** — PTY-based shell automation library (custom fork of etcd's):
+- `ExpectProcess`: low-level PTY process (start, send, read lines, stop)
+- `ShellExpect`: sends commands, waits for prompt string, returns output
+- Prompt detection: reads lines until accumulated output ends with the prompt string
+
+**ghcr.io/devbuddy/docker-testing** — Pre-built Docker image:
+- Base: Ubuntu 20.04
+- Includes: bash, zsh, git, curl, build tools, pyenv, Python 3.9.0
+- User: `tester` (non-root), home: `/home/tester`
+- Published to GitHub Container Registry, pinned by SHA in CI
+
+### How a test runs a command
+
+1. `c.Run(t, "bud up")` calls the internal `run()` method
+2. `run()` calls `c.shell.Run(cmd)` in a goroutine (for timeout)
+3. `ShellExpect.Run()` sends `cmd + "\n"` to the PTY
+4. It reads lines until the accumulated output ends with the prompt string
+5. Back in `run()`, it sends `echo $?` to get the exit code
+6. It parses the exit code and compares with the expected one
+7. Output lines are stripped of ANSI codes and returned
+
+### Test patterns
+
+**Simple command test** (no shell-init needed):
+```go
+func Test_Cmd_Help(t *testing.T) {
+    c := CreateContext(t)
+    lines := c.Run(t, "bud")
+    OutputContains(t, lines, "Usage:", "DevBuddy Commands:")
+}
+```
+
+**Task test** (needs shell-init for hooks):
+```go
+func Test_Task_Custom(t *testing.T) {
+    c := CreateContextAndInit(t)
+    p := CreateProject(t, c, `up:\n- custom:\n    met?: test -e sentinel\n    meet: echo A > sentinel`)
+    c.Cd(t, p.Path)
+    c.Run(t, "bud up")
+    content := c.Cat(t, "sentinel")
+    require.Equal(t, "A", content)
+}
+```
+
+**Shared container via subtests** (avoids redundant downloads):
+```go
+func Test_Task_Go(t *testing.T) {
+    c := CreateContextAndInit(t)
+    t.Run("installs_and_runs_go_modules", func(t *testing.T) { /* reuses container */ })
+    t.Run("modules_false_is_rejected", func(t *testing.T) { /* reuses container */ })
+}
+```
+
+### Environment variables
+
+| Variable | Required | Default | Purpose |
+|----------|----------|---------|---------|
+| `TEST_SHELL` | no | `bash` | Shell to test (bash or zsh) |
+| `TEST_DOCKER_IMAGE` | **yes** | — | Docker image for the container |
+
+### CI configuration
+
+`.github/workflows/tests.yml` runs four parallel jobs:
+1. `golangci-lint` — linting
+2. `go test ./pkg/...` — unit tests
+3. `TEST_SHELL=bash go test -v ./tests` — bash integration
+4. `TEST_SHELL=zsh go test -v ./tests` — zsh integration
+
+The release job depends on all four passing.
+
+## Known Issues
+
+### Prompt detection is fragile
+
+The expect library detects command completion by matching the prompt string
+(`\nPROMPTPROMPTPROMPTPROMPT\n`) at the end of accumulated output. This breaks when:
+- A command's output happens to contain the prompt string
+- The PTY splits the prompt across multiple reads
+- Terminal initialization output interferes (note: `c.Init()` is commented out in context.go)
+
+### One container per test function
+
+Each call to `CreateContext()` starts a new Docker container. This gives good isolation but is
+slow. Container startup typically takes 1-3 seconds. Tests that share a container via subtests
+(like `Test_Task_Go`) work around this but sacrifice isolation — a failing subtest can leave
+the container in a dirty state.
+
+### Timeout handling
+
+The default timeout is 5 seconds. Tasks that download tools (Go, Python, Node) need
+`context.Timeout(2*time.Minute)`. If the timeout is too short, the test fails with a
+confusing "timed out" error rather than the actual command output. There is no way to see
+what the command was doing when it timed out.
+
+### Docker image version mismatch
+
+`dev.yml` pins `TEST_DOCKER_IMAGE: ghcr.io/devbuddy/docker-testing:sha-7fd13f4` but CI uses
+`ghcr.io/devbuddy/docker-testing:sha-f11e362`. This means local `bud integration` and CI may
+use different images.
+
+### No macOS integration tests
+
+Tasks like `homebrew` that are macOS-specific cannot be tested in the Docker-based setup
+(which runs Linux). There is currently no way to run integration tests against macOS.
+
+### Network-dependent tests are slow and flaky
+
+Tests for Go, Python, and Node tasks download real distributions from the internet.
+This makes them slow (~minutes) and vulnerable to network issues or rate limiting.
+
+### Skipped tests
+
+`Test_Task_Custom_With_Env_At_First_Run` is skipped with `t.Skip("Fixme: env vars not set
+before tasks?")`. This indicates a known bug where dev.yml `env:` vars are not available
+during the first `bud up` run (they're only set by the shell hook, which runs on prompt, not
+during `bud up`).


### PR DESCRIPTION
## Summary
- document `bud open <pattern>` and clarify that fuzzy matching applies to custom `open:` links while built-in aliases stay exact
- improve wording and consistency across `README.md`, `docs/Config.md`, and `docs/CONTRIBUTING.md`
- add contributor-facing guidance docs (`CLAUDE.md`, `ROADMAP.md`, `tests/INTEGRATION_TESTS.md`) and add a `Fixes` reminder to the PR template

## Testing
- `go test ./pkg/helpers/open ./pkg/project`

Fixes: #112