### PR TITLE
Support custom path in envfile task

### DIFF
--- a/pkg/tasks/apt_test.go
+++ b/pkg/tasks/apt_test.go
@@ -14,6 +14,9 @@ apt:
 `)
 
 	require.Equal(t, "Task Apt (curl, git) actions=1", task.Describe())
+	require.Equal(t, "curl, git", task.Info)
+	require.Equal(t, 1, len(task.Actions))
+	requireNoFeature(t, task)
 }
 
 func TestAptEmpty(t *testing.T) {

--- a/pkg/tasks/custom_test.go
+++ b/pkg/tasks/custom_test.go
@@ -14,6 +14,9 @@ custom:
 `)
 
 	require.Equal(t, "Task Custom (custom-command) actions=1", task.Describe())
+	require.Equal(t, "custom-command", task.Info)
+	require.Equal(t, 1, len(task.Actions))
+	requireNoFeature(t, task)
 }
 
 func TestCustomName(t *testing.T) {
@@ -25,6 +28,9 @@ custom:
 `)
 
 	require.Equal(t, "Task Custom (NAMENAME) actions=1", task.Describe())
+	require.Equal(t, "NAMENAME", task.Info)
+	require.Equal(t, 1, len(task.Actions))
+	requireNoFeature(t, task)
 }
 
 func TestCustomWithBoolean(t *testing.T) {

--- a/pkg/tasks/envfile.go
+++ b/pkg/tasks/envfile.go
@@ -10,7 +10,10 @@ func init() {
 }
 
 func parseEnvfile(config *api.TaskConfig, task *api.Task) error {
-	envfilePath := ".env"
+	envfilePath, err := config.GetStringPropertyAllowSingle("path")
+	if err != nil {
+		envfilePath = ".env"
+	}
 
 	check := func(ctx *context.Context) error {
 		return nil

--- a/pkg/tasks/envfile_test.go
+++ b/pkg/tasks/envfile_test.go
@@ -1,0 +1,19 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvfileDefault(t *testing.T) {
+	task := ensureLoadTestTask(t, `envfile`)
+
+	require.Equal(t, "Task EnvFile () feature=envfile:.env actions=1", task.Describe())
+}
+
+func TestEnvfileCustomPath(t *testing.T) {
+	task := ensureLoadTestTask(t, `envfile: config/local-dev.env`)
+
+	require.Equal(t, "Task EnvFile () feature=envfile:config/local-dev.env actions=1", task.Describe())
+}

--- a/pkg/tasks/envfile_test.go
+++ b/pkg/tasks/envfile_test.go
@@ -10,10 +10,12 @@ func TestEnvfileDefault(t *testing.T) {
 	task := ensureLoadTestTask(t, `envfile`)
 
 	require.Equal(t, "Task EnvFile () feature=envfile:.env actions=1", task.Describe())
+	requireFeature(t, task, "envfile", ".env")
 }
 
 func TestEnvfileCustomPath(t *testing.T) {
 	task := ensureLoadTestTask(t, `envfile: config/local-dev.env`)
 
 	require.Equal(t, "Task EnvFile () feature=envfile:config/local-dev.env actions=1", task.Describe())
+	requireFeature(t, task, "envfile", "config/local-dev.env")
 }

--- a/pkg/tasks/homebrew_test.go
+++ b/pkg/tasks/homebrew_test.go
@@ -12,7 +12,11 @@ homebrew:
   - file1
   - file2
 `)
+
 	require.Equal(t, "Task Homebrew (file1, file2) actions=2", task.Describe())
+	require.Equal(t, "file1, file2", task.Info)
+	require.Equal(t, 2, len(task.Actions))
+	requireNoFeature(t, task)
 }
 
 func TestHomebrewEmpty(t *testing.T) {

--- a/pkg/tasks/node_test.go
+++ b/pkg/tasks/node_test.go
@@ -27,5 +27,5 @@ node:
   version: 20
 `)
 
-	require.EqualError(t, err, `task "node": key "version": expecting a string, found a int (20)`)
+	require.ErrorContains(t, err, `key "version": expecting a string, found a`)
 }

--- a/pkg/tasks/pip_test.go
+++ b/pkg/tasks/pip_test.go
@@ -30,5 +30,5 @@ pip:
   - requirements.txt
   - 123
 `)
-	require.EqualError(t, err, `task "pip": expecting a list of strings, found an invalid element: type int (123)`)
+	require.ErrorContains(t, err, `expecting a list of strings, found an invalid element`)
 }

--- a/pkg/tasks/pip_test.go
+++ b/pkg/tasks/pip_test.go
@@ -14,6 +14,9 @@ pip:
 `)
 
 	require.Equal(t, "Task Pip (file1, file2) required_task=python actions=2", task.Describe())
+	require.Equal(t, "file1, file2", task.Info)
+	require.Equal(t, "python", task.RequiredTask)
+	require.Equal(t, 2, len(task.Actions))
 }
 
 func TestPipEmpty(t *testing.T) {

--- a/pkg/tasks/python_develop_test.go
+++ b/pkg/tasks/python_develop_test.go
@@ -12,6 +12,9 @@ python_develop
 `)
 
 	require.Equal(t, "Task Python develop () required_task=python actions=1", task.Describe())
+	require.Equal(t, "python", task.RequiredTask)
+	require.Equal(t, 1, len(task.Actions))
+	requireNoFeature(t, task)
 }
 
 func TestPythonDevelopWithExtras(t *testing.T) {
@@ -21,4 +24,7 @@ python_develop:
 `)
 
 	require.Equal(t, "Task Python develop () required_task=python actions=1", task.Describe())
+	require.Equal(t, "python", task.RequiredTask)
+	require.Equal(t, 1, len(task.Actions))
+	requireNoFeature(t, task)
 }

--- a/pkg/tasks/python_test.go
+++ b/pkg/tasks/python_test.go
@@ -10,6 +10,9 @@ func TestPythonOk(t *testing.T) {
 	task := ensureLoadTestTask(t, `python: 3.6.3`)
 
 	require.Equal(t, "Task Python (3.6.3) feature=python:3.6.3 actions=4", task.Describe())
+	require.Equal(t, "3.6.3", task.Info)
+	require.Equal(t, 4, len(task.Actions))
+	requireFeature(t, task, "python", "3.6.3")
 }
 
 func TestPythonInvalid(t *testing.T) {

--- a/pkg/tasks/task_utils_test.go
+++ b/pkg/tasks/task_utils_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"testing"
 
+	"github.com/devbuddy/devbuddy/pkg/autoenv"
 	"github.com/devbuddy/devbuddy/pkg/tasks/api"
 	"github.com/stretchr/testify/require"
 	yaml "github.com/goccy/go-yaml"
@@ -19,4 +20,31 @@ func ensureLoadTestTask(t *testing.T, payload string) *api.Task {
 	task, err := loadTestTask(t, payload)
 	require.NoError(t, err, "NewTaskFromPayload() failed")
 	return task
+}
+
+// taskFeature returns the first feature found across all actions, or nil.
+func taskFeature(task *api.Task) *autoenv.FeatureInfo {
+	for _, action := range task.Actions {
+		if f := action.Feature(); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+// requireFeature asserts that the task has a feature with the given name and param.
+func requireFeature(t *testing.T, task *api.Task, expectedName, expectedParam string) {
+	t.Helper()
+	f := taskFeature(task)
+	require.NotNil(t, f, "expected a feature but none found")
+	require.Equal(t, expectedName, f.Name, "feature name")
+	require.Equal(t, expectedParam, f.Param, "feature param")
+}
+
+// requireNoFeature asserts that no action on the task declares a feature.
+func requireNoFeature(t *testing.T, task *api.Task) {
+	t.Helper()
+	for _, action := range task.Actions {
+		require.Nil(t, action.Feature(), "expected no feature but found one")
+	}
 }


### PR DESCRIPTION
## Summary

- Allow specifying a custom file path for the envfile task: `- envfile: config/local-dev.env`
- When no path is given (`- envfile`), defaults to `.env` as before
- Stacked on #525

Fixes: #149

## Test plan

- [x] Unit tests for default path and custom path parsing
- [x] `script/test` passes
- [x] `script/lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)