### PR TITLE
Fix envfile: deactivate before reactivate on file change

### DIFF
--- a/pkg/autoenv/features/envfile_test.go
+++ b/pkg/autoenv/features/envfile_test.go
@@ -94,6 +94,30 @@ func TestEnvfileDeactivate(t *testing.T) {
 	require.False(t, ctx.Env.Has(envfileTrackedVarsKey))
 }
 
+func TestEnvfileDeactivateThenActivateUnsetsRemovedVars(t *testing.T) {
+	ctx := newTestContext()
+	dir := t.TempDir()
+	path := writeEnvFile(t, dir, "A=1\nB=2\n")
+
+	// First activation: sets A and B
+	_, err := envfile{}.Activate(ctx, path)
+	require.NoError(t, err)
+	require.Equal(t, "1", ctx.Env.Get("A"))
+	require.Equal(t, "2", ctx.Env.Get("B"))
+
+	// Modify .env: remove B
+	writeEnvFile(t, dir, "A=1\n")
+
+	// Deactivate then re-activate (what the runner does on file change)
+	envfile{}.Deactivate(ctx, path)
+	_, err = envfile{}.Activate(ctx, path)
+	require.NoError(t, err)
+
+	require.Equal(t, "1", ctx.Env.Get("A"))
+	require.False(t, ctx.Env.Has("B"))
+	require.Equal(t, "A", ctx.Env.Get(envfileTrackedVarsKey))
+}
+
 func TestEnvfileDeactivateNoopWhenNotActivated(t *testing.T) {
 	ctx := newTestContext()
 

--- a/pkg/autoenv/runner.go
+++ b/pkg/autoenv/runner.go
@@ -183,6 +183,7 @@ func (r *runner) reactivateIfFilesChanged(featureInfo *FeatureInfo) {
 	for _, path := range watcher.WatchedFiles(featureInfo.Param) {
 		if changed, _ := r.fileTracker.HasChanged(path); changed {
 			r.ctx.UI.Debug("watched file changed: %s", path)
+			r.deactivateFeature(featureInfo)
 			r.activateFeature(featureInfo)
 			return
 		}

--- a/pkg/autoenv/runner_test.go
+++ b/pkg/autoenv/runner_test.go
@@ -189,12 +189,12 @@ func TestRunnerFileWatcher(t *testing.T) {
 	r.sync(NewFeatureSet().With(NewFeatureInfo("envfile", envPath)))
 	require.Empty(t, watcher.getCallsAndReset())
 
-	// Modify the watched file → reactivation
+	// Modify the watched file → deactivate then reactivate
 	os.WriteFile(envPath, []byte("VAR=two"), 0644)
 
 	r = newRunner(testEnv, reg)
 	r.sync(NewFeatureSet().With(NewFeatureInfo("envfile", envPath)))
-	require.Equal(t, []string{"activate " + envPath}, watcher.getCallsAndReset())
+	require.Equal(t, []string{"deactivate " + envPath, "activate " + envPath}, watcher.getCallsAndReset())
 
 	// File unchanged again → no reactivation
 	r = newRunner(testEnv, reg)


### PR DESCRIPTION
## Summary

Alternative approach to #525 for fixing #509.

Instead of having `Activate` diff previous vs new variable names internally, this PR makes the **runner** call `deactivateFeature` before `activateFeature` when a watched file changes. This is a cleaner separation:

- **`runner.reactivateIfFilesChanged`**: now calls deactivate → activate (one line change)
- **`envfile.Activate`**: sets vars from .env, records names in `__BUD_ENVFILE_VARS`
- **`envfile.Deactivate`**: unsets all tracked vars (was a no-op)

The deactivate/activate cycle naturally handles removed variables: deactivate clears everything, activate sets only what's currently in the file.

This is a more general pattern — any feature that implements `FileWatcher` gets clean deactivate/activate semantics on file change, not just envfile.

Fixes: #509

## Test plan

- [x] Unit test: activate sets vars and tracks names
- [x] Unit test: deactivate unsets tracked vars
- [x] Unit test: deactivate → activate cycle correctly drops removed vars
- [x] Unit test: runner calls deactivate before activate on file change (updated existing `TestRunnerFileWatcher`)
- [x] `script/test` passes
- [x] `script/lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)