### PR TITLE
Refresh README: remove stale content, modernize examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,207 +3,150 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/devbuddy/devbuddy)](https://goreportcard.com/report/github.com/devbuddy/devbuddy)
 [![tests](https://github.com/devbuddy/devbuddy/workflows/tests/badge.svg)](https://github.com/devbuddy/devbuddy/actions?query=workflow%3Atests)
 [![GitHub Release](https://img.shields.io/github/release/devbuddy/devbuddy.svg)](https://github.com/devbuddy/devbuddy/releases/latest)
-[![GitHub Release Date](https://img.shields.io/github/release-date/devbuddy/devbuddy.svg)](https://github.com/devbuddy/devbuddy/releases/latest)
-[![Gitter](https://img.shields.io/badge/Discussions%20on-Gitter-crimson.svg?logo=gitter&style=flat)](https://gitter.im/devbuddy)
-![GitHub Release](https://img.shields.io/badge/license-MIT-green.svg)
+![License](https://img.shields.io/badge/license-MIT-green.svg)
 
-Contents:
-- [Install DevBuddy](#install)
-- [Usage](#usage)
-- [Tasks](docs/Config.md)
-- [Contributing to DevBuddy](docs/CONTRIBUTING.md)
+**DevBuddy** is a command-line tool that automates development environment setup and provides project-specific commands. Define your project's requirements in a `dev.yml` file and let `bud` handle the rest.
 
-#### Note: contributors are welcome to join the project! 👩‍💻👨‍💻🤖
+With DevBuddy, getting started on a project you've never touched looks like this:
 
-The project is evolving slowly, mostly because DevBuddy covers my current needs.
-
-I would love to help people implement their languages/environments/tools/dev-flow.
-
-## What is DevBuddy?
-
-**DevBuddy** is an open-source implementation of an internal tool developed at
-[Shopify](https://engineering.shopify.com) called "**Dev**".
-
-The first goal of this tool is to automate the **setup** tasks required to work on a project.
-
-With **DevBuddy**, pushing a change to a project you have never touched looks like this:
-
-- `bud clone devbuddy/devbuddy`
-- `bud up`
-- `git commit`
-- `bud test`
-- `git push`
+```bash
+bud clone devbuddy/devbuddy
+bud up
+# hack hack hack
+bud test
+```
 
 <br>
 <p align="center"><img src="/docs/demo.gif?raw=true"/></p>
 
-## Status and progress
+## Supported Tasks
 
-**DevBuddy** is more useful for Python, Go and Node projects. More languages will be natively
-supported. DevBuddy is still useful for languages without native support thanks to the **custom** task.
+DevBuddy manages environments and dependencies through tasks defined in `dev.yml`:
 
-See the project config [documentation](docs/Config.md).
+**Languages:**
+- **Python** — version management (pyenv + virtualenv), pip, Pipfile
+- **Go** — version management, Go modules
+- **Node.js** — version management (including Apple Silicon), npm
 
-### Tasks
+**System & Environment:**
+- **Homebrew** — install macOS packages
+- **Apt** — install Debian/Ubuntu packages
+- **Environment variables** — set project-specific env vars
+- **Env files** — load variables from `.env` files
+- **Custom tasks** — conditional shell commands (met?/meet pattern)
 
-Python:
-- Python environment (pyenv + virtualenv)
-- Pip (requirements file)
-- Pipenv (support for [Pipfile](https://github.com/pypa/pipfile))
+See the full [task documentation](docs/Config.md) for details.
 
-Go:
-- Go environment (with GOPATH)
-- Go modules
-- Dep (support for [Go Dep](https://github.com/golang/dep))
+## Features
 
-Node:
-- Node environment
-- Dependencies with NPM
-- Dependencies with Yarn **planned**
-
-Ruby: **planned**
-
-Rust: **planned**
-
-Others:
-- Homebrew
-- Apt
-- Custom (conditional shell command)
-- Docker Compose (manage a docker-compose setup): **planned**
-
-### Features
-
+- Automatic environment activation/deactivation as you `cd` between projects
 - Notification when important files (e.g. `requirements.txt`) are updated locally
-  (e.g. by `git pull`)
-- A `help` command to guide a new developer based on `dev.yml`
-- An `upgrade` command to auto-upgrade **DevBuddy**
+- Quick links with `bud open <name>` to jump to project URLs
+- `bud clone` / `bud cd` for fast project navigation
+- Shell completion (bash and zsh)
 
-### Supported code hosting platforms
+### Supported platforms
 
-- GitHub
-- GitLab
-- Bitbucket (with Git)
+- macOS (Intel and Apple Silicon)
+- Linux (amd64 and arm64)
 
-### Shell integration
+### Supported shells
 
 - Bash
 - Zsh
 
 ## Install
 
-### Homebrew
+### Homebrew (macOS)
 
-Install the Homebrew tap:
 ```bash
-$ brew install devbuddy/devbuddy/devbuddy
-```
-
-Install the latest release:
-```bash
-$ brew install devbuddy
-```
-
-Install from the master branch:
-```bash
-$ brew install --HEAD devbuddy
+brew install devbuddy/devbuddy/devbuddy
 ```
 
 ### Go install
 
-Note: use this if your PATH includes the GOBIN path.
+Requires Go and `GOPATH/bin` in your PATH:
 
-Latest release:
 ```bash
-$ go install github.com/devbuddy/devbuddy/cmd/bud@latest
+go install github.com/devbuddy/devbuddy/cmd/bud@latest
 ```
 
-Specify a version, like `v0.11.1`:
+Or a specific version:
 ```bash
-$ go install github.com/devbuddy/devbuddy/cmd/bud@v0.11.1
+go install github.com/devbuddy/devbuddy/cmd/bud@v0.15.0
 ```
 
-### Manual
+### Manual download
 
-#### Select the version to download:
+Download the latest binary for your platform:
 
-Latest:
 ```bash
-$ VERSION=$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/devbuddy/devbuddy/releases/latest" | grep -oE "[^/]+$")
+VERSION=$(curl -Ls -o /dev/null -w %{url_effective} "https://github.com/devbuddy/devbuddy/releases/latest" | grep -oE "[^/]+$")
 ```
 
-[Previous releases](https://github.com/devbuddy/devbuddy/releases):
-
+Then download for your platform:
 ```bash
-$ VERSION="v0.12.0"
+# macOS Apple Silicon
+curl -L "https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-darwin-arm64" > /tmp/bud
+
+# macOS Intel
+curl -L "https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-darwin-amd64" > /tmp/bud
+
+# Linux amd64
+curl -L "https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-linux-amd64" > /tmp/bud
+
+# Linux arm64
+curl -L "https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-linux-arm64" > /tmp/bud
 ```
 
-#### Download the binary
-
-Linux Intel:
+Install:
 ```bash
-$ curl -L https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-linux-amd64 > /tmp/bud
-```
-
-Linux ARM:
-```bash
-$ curl -L https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-linux-arm64 > /tmp/bud
-```
-
-macOS Intel:
-```bash
-$ curl -L https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-darwin-amd64 > /tmp/bud
-```
-
-macOS Apple Silicon:
-```bash
-$ curl -L https://github.com/devbuddy/devbuddy/releases/download/${VERSION}/bud-darwin-arm64 > /tmp/bud
-```
-
-#### Install the binary
-
-```bash
-$ sudo install /tmp/bud /usr/local/bin/bud
+sudo install /tmp/bud /usr/local/bin/bud
 ```
 
 ## Setup
 
-★ Install shell integration (in `~/.bash_profile` or `~/.zshrc`):
+Add shell integration to your `~/.bash_profile` or `~/.zshrc`:
+
 ```bash
 eval "$(bud --shell-init --with-completion)"
 ```
 
-A safer version:
+A safer version that only activates if `bud` is installed:
 ```bash
 type bud > /dev/null 2> /dev/null && eval "$(bud --shell-init --with-completion)"
 ```
 
 ### Configuration
 
-If you usually work with repos from the same organization (like your personal one), you can set it as a default:
+If you usually work with repos from the same GitHub organization, set it as a default:
 
-```
-export BUD_DEFAULT_ORG="google"
+```bash
+export BUD_DEFAULT_ORG="myorg"
 ```
 
-Then you can use it directly to create, clone, and jump to those repos:
-```bash
-$ bud clone pytruth
-```
-Rather than:
-```bash
-$ bud clone google/pytruth
-```
+Then `bud clone myrepo` is equivalent to `bud clone myorg/myrepo`.
 
 ## Usage
 
-★ Add a `dev.yml` file in your project:
+Add a `dev.yml` file to your project root:
+
 ```yaml
+env:
+  DATABASE_URL: postgres://localhost:5432/myapp_dev
+
 up:
-  - go: 1.9.2
-  - golang_dep
-  - python: 3.6.4rc1
+  - go:
+      version: '1.22'
+  - python: 3.12.0
   - pip:
     - requirements.txt
+  - homebrew:
+    - curl
+  - custom:
+      name: Download GeoIP db
+      met?: test -e GeoIP.dat
+      meet: curl -sL http://example.com/GeoIP.dat.gz | gunzip > GeoIP.dat
 
 commands:
   test:
@@ -215,34 +158,14 @@ commands:
 
 open:
   staging: https://staging.myapp.com
-  doc: https://godoc.org/github.com/org/myapp
+  ci: https://github.com/org/myapp/actions
 ```
-See DevBuddy's own [dev.yml](dev.yml).
 
-```bash
-$ bud
-Usage:
-  bud [flags]
-  bud [command]
+See DevBuddy's own [dev.yml](dev.yml) for a real-world example.
 
-Available Commands:
-  cd          Jump to a local project
-  clone       Clone a project from github.com
-  create      Create a new project
-  help        Help about any command
-  inspect     Inspect the project and its tasks
-  open        Open a link about your project
-  up          Ensure the project is up and running
-  upgrade     [experimental] Upgrade DevBuddy to the latest available release.
+## Contributing
 
-Flags:
-  -h, --help              help for bud
-      --shell-init        Shell initialization
-      --version           version for bud
-      --with-completion   Enable completion during initialization
-
-Use "bud [command] --help" for more information about a command.
-```
+Contributions are welcome! See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for details.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Remove dead Gitter badge, deprecated Go Dep references, and long-stale "planned" items (Ruby, Rust, Docker Compose, Yarn — open since 2018)
- Update `dev.yml` example to modern Go/Python versions and remove `golang_dep`
- Add env file and environment variable tasks to the feature list
- Streamline install section (consolidate Homebrew, update `go install` version to v0.15.0)
- Rewrite intro to stand on its own instead of framing as "Shopify internal tool clone"
- Tighten overall structure: rename "Status and progress" to "Supported Tasks", trim CLI output block, move contributor note to bottom

## Test plan

- [ ] Verify all links in the README resolve correctly
- [ ] Confirm the demo gif still renders
- [ ] Review that listed features match actual codebase capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)