### PR TITLE
Add shell.defer_init config to avoid P10k instant prompt warnings

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	color "github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 
+	"github.com/devbuddy/devbuddy/pkg/config"
 	"github.com/devbuddy/devbuddy/pkg/helpers/debug"
 	"github.com/devbuddy/devbuddy/pkg/helpers/open"
 	"github.com/devbuddy/devbuddy/pkg/hook"
@@ -60,7 +61,11 @@ func build(version string) *cobra.Command {
 func rootRun(cmd *cobra.Command, _ []string) error {
 	if GetFlagBool(cmd, "shell-init") {
 		withCompletion := GetFlagBool(cmd, "with-completion")
-		integration.Print(withCompletion, cmd)
+		userCfg := config.LoadUserConfig()
+		opts := integration.ShellOptions{
+			DeferInit: userCfg.Shell.DeferInit,
+		}
+		integration.Print(withCompletion, cmd, opts)
 		return nil
 	}
 

--- a/pkg/config/userconfig.go
+++ b/pkg/config/userconfig.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v2"
+)
+
+type UserConfig struct {
+	Shell ShellConfig `yaml:"shell"`
+}
+
+type ShellConfig struct {
+	DeferInit bool `yaml:"defer_init"`
+}
+
+func LoadUserConfig() *UserConfig {
+	path := userConfigPath()
+	if path == "" {
+		return &UserConfig{}
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return &UserConfig{}
+	}
+
+	var cfg UserConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return &UserConfig{}
+	}
+	return &cfg
+}
+
+func userConfigPath() string {
+	dir := os.Getenv("XDG_CONFIG_HOME")
+	if dir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return ""
+		}
+		dir = filepath.Join(home, ".config")
+	}
+	return filepath.Join(dir, "devbuddy", "config.yml")
+}

--- a/pkg/config/userconfig_test.go
+++ b/pkg/config/userconfig_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadUserConfig_MissingFile(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	cfg := LoadUserConfig()
+
+	require.Equal(t, false, cfg.Shell.DeferInit)
+}
+
+func TestLoadUserConfig_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "devbuddy")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, "config.yml"),
+		[]byte("shell:\n  defer_init: true\n"),
+		0o644,
+	))
+
+	cfg := LoadUserConfig()
+
+	require.Equal(t, true, cfg.Shell.DeferInit)
+}
+
+func TestLoadUserConfig_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "devbuddy")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, "config.yml"),
+		[]byte("not: [valid: yaml"),
+		0o644,
+	))
+
+	cfg := LoadUserConfig()
+
+	require.Equal(t, false, cfg.Shell.DeferInit)
+}
+
+func TestLoadUserConfig_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	configDir := filepath.Join(dir, "devbuddy")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configDir, "config.yml"),
+		[]byte(""),
+		0o644,
+	))
+
+	cfg := LoadUserConfig()
+
+	require.Equal(t, false, cfg.Shell.DeferInit)
+}

--- a/pkg/integration/common.sh
+++ b/pkg/integration/common.sh
@@ -35,6 +35,13 @@ bud() {
 __bud_prompt_command() {
     local previous_exit=$?
 
+    # When defer_init is enabled (e.g. for Powerlevel10k instant prompt), skip
+    # the first invocation entirely to avoid console output during shell init.
+    if [[ -n "${__bud_defer_init:-}" && -z "${__bud_hook_initialized:-}" ]]; then
+        __bud_hook_initialized=1
+        return ${previous_exit}
+    fi
+
     # In shell hook mode, the command will use stderr to print in the console
     # and stdout to mutate the shell (like activating a Python virtualenv)
 

--- a/pkg/integration/integration.go
+++ b/pkg/integration/integration.go
@@ -26,20 +26,30 @@ type CompletionScriptProvider interface {
 	GenZshCompletion(w io.Writer) error
 }
 
+type ShellOptions struct {
+	DeferInit bool
+}
+
 // Print prints the integration code for the user's shell
-func Print(withCompletion bool, completionScriptProvider CompletionScriptProvider) {
+func Print(withCompletion bool, completionScriptProvider CompletionScriptProvider, opts ShellOptions) {
 	shell, err := DetectShell()
 	if err != nil {
 		termui.HookShellDetectionError(err)
 		return
 	}
 
-	script := buildCompletionScript(shell, withCompletion, completionScriptProvider)
+	script := buildCompletionScript(shell, withCompletion, completionScriptProvider, opts)
 	fmt.Println(script)
 }
 
-func buildCompletionScript(shell ShellIdentity, withCompletion bool, completionScriptProvider CompletionScriptProvider) string {
-	buffer := bytes.NewBufferString(shellSource)
+func buildCompletionScript(shell ShellIdentity, withCompletion bool, completionScriptProvider CompletionScriptProvider, opts ShellOptions) string {
+	buffer := &bytes.Buffer{}
+
+	if opts.DeferInit {
+		buffer.WriteString("__bud_defer_init=1\n")
+	}
+
+	buffer.WriteString(shellSource)
 
 	switch shell {
 	case BASH:

--- a/tests/cmd_hook_test.go
+++ b/tests/cmd_hook_test.go
@@ -2,6 +2,8 @@ package integration
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Hook_Preserves_Previous_Exit_Code(t *testing.T) {
@@ -14,4 +16,48 @@ func Test_Hook_Preserves_Previous_Exit_Code(t *testing.T) {
 
 	lines := c.Run(t, "false; __bud_prompt_command; echo $?")
 	OutputEqual(t, lines, "1")
+}
+
+func Test_Hook_DeferInit_Skips_First_Invocation(t *testing.T) {
+	c := CreateContext(t)
+
+	// Create a project and cd into it BEFORE shell init.
+	// No PROMPT_COMMAND is set yet, so no hook fires during these steps.
+	p := CreateProject(t, c,
+		`env:`,
+		`  TESTVAR: hello`,
+	)
+	c.Cd(t, p.Path)
+
+	// Source the init but unset PROMPT_COMMAND/precmd so we control hook calls manually.
+	c.Run(t, `__bud_defer_init=1; eval "$(bud --shell-init)"; unset PROMPT_COMMAND; precmd_functions=()`)
+
+	// Call the hook manually for the first time — should be deferred.
+	c.Run(t, `__bud_prompt_command`)
+	value := c.GetEnv(t, "TESTVAR")
+	require.Equal(t, "", value, "TESTVAR should not be set after deferred first hook")
+
+	// Call the hook again — should activate now.
+	c.Run(t, `__bud_prompt_command`)
+	value = c.GetEnv(t, "TESTVAR")
+	require.Equal(t, "hello", value, "TESTVAR should be set after second hook")
+}
+
+func Test_Hook_Without_DeferInit_Activates_Immediately(t *testing.T) {
+	c := CreateContext(t)
+
+	// Create a project and cd into it BEFORE shell init.
+	p := CreateProject(t, c,
+		`env:`,
+		`  TESTVAR: hello`,
+	)
+	c.Cd(t, p.Path)
+
+	// Source the init but unset PROMPT_COMMAND/precmd so we control hook calls.
+	c.Run(t, `eval "$(bud --shell-init)"; unset PROMPT_COMMAND; precmd_functions=()`)
+
+	// First hook call without defer should activate immediately.
+	c.Run(t, `__bud_prompt_command`)
+	value := c.GetEnv(t, "TESTVAR")
+	require.Equal(t, "hello", value, "TESTVAR should be set after first hook")
 }


### PR DESCRIPTION
## Summary

- Add a user config file at `~/.config/devbuddy/config.yml` (respects `XDG_CONFIG_HOME`)
- Add `shell.defer_init` option that skips the first shell hook invocation during init, deferring feature activation to the second prompt
- This avoids triggering Powerlevel10k's instant prompt console output warning when opening a terminal tab in a project directory

### Usage

Create `~/.config/devbuddy/config.yml`:
```yaml
shell:
  defer_init: true
```

Then `exec zsh` or open a new terminal tab.

### Trade-off

With `defer_init: true`, environment activation is delayed by one prompt — the "🐼 activated: ..." message and env changes appear on the second prompt after opening a tab, not the first.

## Test plan

- [x] Unit tests for config parsing (missing file, valid YAML, invalid YAML, empty file)
- [x] Integration test: with `__bud_defer_init`, first hook call is skipped, second activates (bash + zsh)
- [x] Integration test: without `__bud_defer_init`, first hook call activates immediately (bash + zsh)
- [x] Existing hook test (exit code preservation) still passes
- [x] Full integration suite passes for both bash and zsh
- [x] golangci-lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)