### PR TITLE
Improve activation line display format and colors

### DIFF
--- a/pkg/autoenv/feature_info.go
+++ b/pkg/autoenv/feature_info.go
@@ -20,13 +20,16 @@ func (f FeatureInfo) String() string {
 	return fmt.Sprintf("%s:%s", f.Name, f.Param)
 }
 
-// DisplayString returns a human-friendly representation like "python 3.6.5".
+func (f FeatureInfo) FeatureName() string  { return f.Name }
+func (f FeatureInfo) FeatureParam() string { return f.Param }
+
+// DisplayString returns a human-friendly representation like "python[3.6.5]".
 // JSON params (e.g. from the env feature) are omitted.
 func (f FeatureInfo) DisplayString() string {
 	if f.Param == "" || strings.HasPrefix(f.Param, "{") {
 		return f.Name
 	}
-	return f.Name + " " + f.Param
+	return f.Name + "[" + f.Param + "]"
 }
 
 // FeatureSet represents a set of parameterized features

--- a/pkg/autoenv/feature_info_test.go
+++ b/pkg/autoenv/feature_info_test.go
@@ -20,8 +20,8 @@ func TestFeatureInfoDisplayString(t *testing.T) {
 		param string
 		want  string
 	}{
-		{"python", "3.6.5", "python 3.6.5"},
-		{"golang", "1.13.1", "golang 1.13.1"},
+		{"python", "3.6.5", "python[3.6.5]"},
+		{"golang", "1.13.1", "golang[1.13.1]"},
 		{"env", `{"VAR":"val"}`, "env"},
 		{"env", "", "env"},
 	}

--- a/pkg/autoenv/runner.go
+++ b/pkg/autoenv/runner.go
@@ -3,6 +3,7 @@ package autoenv
 import (
 	"github.com/devbuddy/devbuddy/pkg/autoenv/features"
 	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/termui"
 	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
@@ -109,11 +110,11 @@ func (r *runner) sync(featureSet FeatureSet) {
 	}
 
 	if len(r.activated) > 0 {
-		names := make([]string, len(r.activated))
+		displays := make([]termui.Feature, len(r.activated))
 		for i, f := range r.activated {
-			names[i] = f.DisplayString()
+			displays[i] = f
 		}
-		r.ctx.UI.HookFeaturesActivated(names)
+		r.ctx.UI.HookFeaturesActivated(displays)
 	}
 	for _, f := range r.failed {
 		r.ctx.UI.HookFeatureFailure(f.Name, f.Param)

--- a/pkg/autoenv/runner_test.go
+++ b/pkg/autoenv/runner_test.go
@@ -213,7 +213,8 @@ func TestRunnerConsolidatedOutput(t *testing.T) {
 
 		output := r.output.String()
 		require.True(t, strings.Contains(output, "activated:"), "expected consolidated message, got: %s", output)
-		require.True(t, strings.Contains(output, "rust 1.0"), "expected feature name in message, got: %s", output)
+		require.True(t, strings.Contains(output, "rust"), "expected feature name in message, got: %s", output)
+		require.True(t, strings.Contains(output, "1.0"), "expected feature param in message, got: %s", output)
 		// Should be exactly one line (one newline)
 		require.Equal(t, 1, strings.Count(output, "\n"), "expected single line, got: %s", output)
 	})
@@ -228,8 +229,10 @@ func TestRunnerConsolidatedOutput(t *testing.T) {
 		r.sync(NewFeatureSet().With(NewFeatureInfo("rust", "1.0")).With(NewFeatureInfo("elixir", "0.4")))
 
 		output := r.output.String()
-		require.True(t, strings.Contains(output, "rust 1.0"), "got: %s", output)
-		require.True(t, strings.Contains(output, "elixir 0.4"), "got: %s", output)
+		require.True(t, strings.Contains(output, "rust"), "got: %s", output)
+		require.True(t, strings.Contains(output, "1.0"), "got: %s", output)
+		require.True(t, strings.Contains(output, "elixir"), "got: %s", output)
+		require.True(t, strings.Contains(output, "0.4"), "got: %s", output)
 		require.Equal(t, 1, strings.Count(output, "\n"), "expected single line, got: %s", output)
 	})
 

--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -8,8 +8,22 @@ import (
 	color "github.com/logrusorgru/aurora"
 )
 
-func (u *UI) HookFeaturesActivated(features []string) {
-	Fprintf(u.out, "🐼  %s %s\n", color.Cyan("activated:"), color.Blue(strings.Join(features, ", ")))
+type Feature interface {
+	FeatureName() string
+	FeatureParam() string
+}
+
+func (u *UI) HookFeaturesActivated(features []Feature) {
+	parts := make([]string, len(features))
+	for i, f := range features {
+		param := f.FeatureParam()
+		if param == "" || strings.HasPrefix(param, "{") {
+			parts[i] = fmt.Sprintf("%s", color.Blue(f.FeatureName()))
+		} else {
+			parts[i] = fmt.Sprintf("%s%s%s%s", color.Blue(f.FeatureName()), color.Gray(12, "["), color.Cyan(param), color.Gray(12, "]"))
+		}
+	}
+	Fprintf(u.out, "🐼  %s %s\n", color.Cyan("activated:"), strings.Join(parts, color.Gray(12, ", ").String()))
 }
 
 func (u *UI) HookFeatureFailure(name string, param string) {

--- a/tests/docker/task_go_test.go
+++ b/tests/docker/task_go_test.go
@@ -35,7 +35,7 @@ func Test_Task_Go(t *testing.T) {
 
 		lines := c.Run(t, "bud up", context.Timeout(2*time.Minute))
 		OutputContains(t, lines, "Golang (1.23.6)", "install golang distribution")
-		OutputContains(t, lines, "activated: golang 1.23.6")
+		OutputContains(t, lines, "activated: golang[1.23.6]")
 
 		lines = c.Run(t, "go version")
 		OutputContains(t, lines, "go version go1.23.6")

--- a/tests/docker/task_node_test.go
+++ b/tests/docker/task_node_test.go
@@ -18,7 +18,7 @@ func Test_Task_Node(t *testing.T) {
 
 	lines := c.Run(t, "bud up", context.Timeout(2*time.Minute))
 	OutputContains(t, lines, "NodeJS (10.15.0)")
-	OutputContains(t, lines, "activated: node 10.15.0")
+	OutputContains(t, lines, "activated: node[10.15.0]")
 
 	lines = c.Run(t, "node -v")
 	OutputEqual(t, lines, "v10.15.0")

--- a/tests/docker/task_pip_test.go
+++ b/tests/docker/task_pip_test.go
@@ -20,7 +20,7 @@ func Test_Task_Pip(t *testing.T) {
 	c.Write(t, "requirements.txt", "pkginfo==1.9.6\n")
 
 	lines := c.Run(t, "bud up", context.Timeout(2*time.Minute))
-	OutputContains(t, lines, "activated: python 3.9.0")
+	OutputContains(t, lines, "activated: python[3.9.0]")
 
 	lines = c.Run(t, "pip freeze")
 	OutputContains(t, lines, "pkginfo==1.9.6")

--- a/tests/docker/task_python_develop_test.go
+++ b/tests/docker/task_python_develop_test.go
@@ -24,7 +24,7 @@ func Test_Task_Python_Develop(t *testing.T) {
 	c.Write(t, "setup.py", generateTestSetupPy(42))
 
 	lines := c.Run(t, "bud up", context.Timeout(2*time.Minute))
-	OutputContains(t, lines, "activated: python 3.9.0")
+	OutputContains(t, lines, "activated: python[3.9.0]")
 
 	lines = c.Run(t, "pip show devbuddy-test-pkg")
 	OutputContains(t, lines, "Version: 42")

--- a/tests/docker/task_python_test.go
+++ b/tests/docker/task_python_test.go
@@ -17,7 +17,7 @@ func Test_Env_Python(t *testing.T) {
 	c.Cd(t, p.Path)
 
 	lines := c.Run(t, "bud up", context.Timeout(2*time.Minute))
-	OutputContains(t, lines, "activated: python 3.9.0")
+	OutputContains(t, lines, "activated: python[3.9.0]")
 
 	lines = c.Run(t, "python --version")
 	OutputEqual(t, lines, "Python 3.9.0")


### PR DESCRIPTION
## Summary
- Change activation display from `name param` to `name[param]` with per-element coloring: feature names in blue, params in cyan, brackets and commas in gray
- Example: `🐼  activated: env, envfile[.env], golang[1.26.0]`

## Test plan
- [x] Unit tests pass (`script/test`)
- [x] Lint passes (`script/lint`)
- [ ] Integration tests verify new format (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)