### PR TITLE
Make bud open default to GitHub repo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the full [task documentation](docs/Config.md) for details.
 
 - Automatic environment activation/deactivation as you `cd` between projects
 - Notification when important files (e.g. `requirements.txt`) are updated locally
-- Quick links with `bud open <name>` to jump to project URLs
+- `bud open` to jump to the GitHub repo page, or `bud open <name>` for project URLs
 - `bud clone` / `bud cd` for fast project navigation
 - Shell completion (bash and zsh)
 

--- a/pkg/helpers/git.go
+++ b/pkg/helpers/git.go
@@ -46,7 +46,8 @@ var githubRemotePatterns = []*regexp.Regexp{
 	regexp.MustCompile(`^https?://github\.com/([^/]+)/([^/.]+?)(?:\.git)?$`),
 }
 
-func (r *GitRepo) buildGithubURL() (string, error) {
+// BuildGithubURL returns the base GitHub URL (https://github.com/org/repo) from the git remote
+func (r *GitRepo) BuildGithubURL() (string, error) {
 	remoteURL, err := r.GetRemoteURL()
 	if err != nil {
 		return "", err
@@ -62,7 +63,7 @@ func (r *GitRepo) buildGithubURL() (string, error) {
 
 // BuildGithubProjectURL builds the Github page url from the git remote url for a specific branch
 func (r *GitRepo) BuildGithubProjectURL() (string, error) {
-	baseURL, err := r.buildGithubURL()
+	baseURL, err := r.BuildGithubURL()
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +76,7 @@ func (r *GitRepo) BuildGithubProjectURL() (string, error) {
 
 // BuildGithubPullrequestURL builds the Github pullrequest  url from the git remote url for a specific branch
 func (r *GitRepo) BuildGithubPullrequestURL() (string, error) {
-	baseURL, err := r.buildGithubURL()
+	baseURL, err := r.BuildGithubURL()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/helpers/open/open.go
+++ b/pkg/helpers/open/open.go
@@ -34,11 +34,6 @@ func FindLink(ctx *context.Context, linkName string) (url string, err error) {
 	}
 
 	if linkName == "" {
-		if len(man.Open) == 1 {
-			for _, url = range man.Open {
-				return url, nil
-			}
-		}
 		return helpers.NewGitRepo(ctx, ctx.Project.Path).BuildGithubURL()
 	}
 

--- a/pkg/helpers/open/open.go
+++ b/pkg/helpers/open/open.go
@@ -39,7 +39,7 @@ func FindLink(ctx *context.Context, linkName string) (url string, err error) {
 				return url, nil
 			}
 		}
-		return "", fmt.Errorf("which link should I open?")
+		return helpers.NewGitRepo(ctx, ctx.Project.Path).BuildGithubURL()
 	}
 
 	link := project.FindBestLinkMatch(linkName, BuildIndex(man.Open))

--- a/pkg/helpers/open/open_test.go
+++ b/pkg/helpers/open/open_test.go
@@ -54,6 +54,20 @@ func TestFindLinkDefault(t *testing.T) {
 	require.Equal(t, "http://doc.com", url)
 }
 
+func TestFindLinkNoArgOpensGithub(t *testing.T) {
+	tmpdir := t.TempDir()
+	writer := test.Project(tmpdir)
+	writer.CreateGitRepo(t)
+	writer.Manifest().WriteString("open: {doc: http://doc.com, logs: http://logs}")
+
+	proj := project.NewFromPath(tmpdir)
+	ctx := newTestContext(proj)
+
+	url, err := FindLink(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, "https://github.com/org1/repo1", url)
+}
+
 func TestFindLinkGithub(t *testing.T) {
 	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)

--- a/pkg/helpers/open/open_test.go
+++ b/pkg/helpers/open/open_test.go
@@ -41,24 +41,11 @@ func TestFindLink(t *testing.T) {
 	require.Equal(t, "http://doc.com", url)
 }
 
-func TestFindLinkDefault(t *testing.T) {
-	tmpdir := t.TempDir()
-	writer := test.Project(tmpdir)
-	writer.Manifest().WriteString("open: {doc: http://doc.com}")
-
-	proj := project.NewFromPath(tmpdir)
-	ctx := newTestContext(proj)
-
-	url, err := FindLink(ctx, "")
-	require.NoError(t, err)
-	require.Equal(t, "http://doc.com", url)
-}
-
 func TestFindLinkNoArgOpensGithub(t *testing.T) {
 	tmpdir := t.TempDir()
 	writer := test.Project(tmpdir)
 	writer.CreateGitRepo(t)
-	writer.Manifest().WriteString("open: {doc: http://doc.com, logs: http://logs}")
+	writer.Manifest().WriteString("open: {doc: http://doc.com}")
 
 	proj := project.NewFromPath(tmpdir)
 	ctx := newTestContext(proj)

--- a/tests/fast/cmd_open_test.go
+++ b/tests/fast/cmd_open_test.go
@@ -42,24 +42,9 @@ func Test_Cmd_Open_CustomLink_FuzzyMatch(t *testing.T) {
 	OutputEqual(t, []string{openedURL}, "https://staging.example.com")
 }
 
-func Test_Cmd_Open_DefaultWhenSingleLink(t *testing.T) {
+func Test_Cmd_Open_NoArgOpensGithub(t *testing.T) {
 	c, p := CreateContextAndProject(t,
 		`open:`,
-		`  docs: https://docs.example.com`,
-	)
-	installFakeXdgOpen(t, c)
-	c.Cd(t, p.Path)
-
-	c.Run(t, "bud open")
-
-	openedURL := waitAndReadOpenedURL(t, c)
-	OutputEqual(t, []string{openedURL}, "https://docs.example.com")
-}
-
-func Test_Cmd_Open_NoArgFallsBackToGithub(t *testing.T) {
-	c, p := CreateContextAndProject(t,
-		`open:`,
-		`  staging: https://staging.example.com`,
 		`  docs: https://docs.example.com`,
 	)
 	c.Cd(t, p.Path)

--- a/tests/fast/cmd_open_test.go
+++ b/tests/fast/cmd_open_test.go
@@ -56,7 +56,7 @@ func Test_Cmd_Open_DefaultWhenSingleLink(t *testing.T) {
 	OutputEqual(t, []string{openedURL}, "https://docs.example.com")
 }
 
-func Test_Cmd_Open_RequiresNameWhenMultipleLinks(t *testing.T) {
+func Test_Cmd_Open_NoArgFallsBackToGithub(t *testing.T) {
 	c, p := CreateContextAndProject(t,
 		`open:`,
 		`  staging: https://staging.example.com`,
@@ -64,6 +64,7 @@ func Test_Cmd_Open_RequiresNameWhenMultipleLinks(t *testing.T) {
 	)
 	c.Cd(t, p.Path)
 
+	// No git remote configured, so it fails
 	lines := c.Run(t, "bud open", context.ExitCode(1))
-	OutputEqual(t, lines, "Error: which link should I open?")
+	OutputContains(t, lines, "failed to get the origin remote url")
 }


### PR DESCRIPTION
## Summary
- `bud open` (no argument) now opens the GitHub repository page derived from the git remote URL
- `bud open <name>` still opens named links from dev.yml or built-in shortcuts (`gh`, `pr`)
- Removed the old behavior of defaulting to a single dev.yml link — `bud open` always opens the repo page
- Updated README to reflect the new behavior

## Test plan
- [x] Unit tests pass (`script/test`)
- [x] Lint passes (`script/lint`)
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)