### PR TITLE
Add Ruby support via rbenv

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+POIPOI=poipoi2
+POIPOIPOI=poipoipoipoipoipoii

--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-POIPOI=poipoi2
-POIPOIPOI=poipoipoipoipoipoii

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -183,12 +183,42 @@ up:
 
 This task will install the Ruby version (with rbenv, which is installed automatically via
 Homebrew if missing) and activate it in your shell. If a `Gemfile` is present, gems will
-be installed with `bundle install`.
+be installed with `bundle install`. Both `Gemfile` and `Gemfile.lock` are watched, so
+either changing will re-trigger the install.
+
+The Ruby version can be set explicitly in `dev.yml`, or omitted to read it from a
+`.ruby-version` file at the project root (an optional `ruby-` engine prefix is stripped):
 
 ```yaml
 up:
   - ruby: 3.3.0
 ```
+
+```yaml
+up:
+  - ruby  # reads .ruby-version
+```
+
+#### Tradeoffs and limitations
+
+- **macOS-first install path.** Bootstrapping rbenv is done via `brew install rbenv`.
+  On Linux, install rbenv yourself before running `bud up`; the task will detect it
+  and proceed.
+- **Native build dependencies are not installed.** `rbenv install` compiles Ruby from
+  source and needs system headers (`libssl-dev`, `libyaml-dev`, `libffi-dev`, etc. on
+  Linux; the Xcode command-line tools on macOS). If they're missing, `rbenv install`
+  will fail with its own error and you'll need to install them manually. Tracked in
+  [#547](https://github.com/devbuddy/devbuddy/issues/547).
+- **No shims, no `GEM_HOME`/`RUBYOPT`.** The autoenv feature simply prepends the
+  selected version's `bin/` directory to `PATH`, which is enough for `ruby`, `gem`,
+  `bundle`, and gem-installed executables. Tools that rely on rbenv shims or that
+  read `GEM_HOME`/`GEM_PATH` directly will not see a version-specific environment.
+- **Bundler is assumed to ship with Ruby.** Ruby 2.6 and later bundle Bundler in the
+  stdlib, so the task does not install it explicitly. Older Ruby versions are not
+  supported.
+- **Gems install into the rbenv version directory** rather than a per-project
+  `vendor/bundle`. If you want isolation, run `bundle config set --local path vendor/bundle`
+  in the project before `bud up`.
 
 ### `custom`
 

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -199,6 +199,10 @@ up:
   - ruby  # reads .ruby-version
 ```
 
+If both an explicit version in `dev.yml` and a `.ruby-version` file are present and
+they disagree, DevBuddy warns on `bud up` and on shell activation, then proceeds with
+the `dev.yml` version. Remove one to silence the warning.
+
 #### Tradeoffs and limitations
 
 - **macOS-first install path.** Bootstrapping rbenv is done via `brew install rbenv`.

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -179,6 +179,17 @@ up:
       npm: true
 ```
 
+### `ruby`
+
+This task will install the Ruby version (with rbenv, which is installed automatically via
+Homebrew if missing) and activate it in your shell. If a `Gemfile` is present, gems will
+be installed with `bundle install`.
+
+```yaml
+up:
+  - ruby: 3.3.0
+```
+
 ### `custom`
 
 This task will run a command if a condition is not met.

--- a/pkg/autoenv/features/ruby.go
+++ b/pkg/autoenv/features/ruby.go
@@ -1,6 +1,8 @@
 package features
 
 import (
+	"errors"
+	"os"
 	"path"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
@@ -19,6 +21,8 @@ func (ruby) Name() string {
 }
 
 func (ruby) Activate(ctx *context.Context, param string) (bool, error) {
+	warnRubyVersionMismatch(ctx, param)
+
 	binPath := path.Join(helpers.RbEnvRoot(), "versions", param, "bin")
 	if !utils.PathExists(binPath) {
 		return true, nil
@@ -28,3 +32,28 @@ func (ruby) Activate(ctx *context.Context, param string) (bool, error) {
 }
 
 func (ruby) Deactivate(ctx *context.Context, param string) {}
+
+// WatchedFiles re-activates the feature when .ruby-version changes so the
+// mismatch warning stays in sync with the file's current contents.
+func (ruby) WatchedFiles(param string) []string {
+	return []string{".ruby-version"}
+}
+
+func warnRubyVersionMismatch(ctx *context.Context, activeVersion string) {
+	if ctx.Project == nil {
+		return
+	}
+	fileVersion, err := helpers.ReadRubyVersionFile(ctx.Project.Path)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			ctx.UI.Warningf("ruby: failed to read .ruby-version: %s", err)
+		}
+		return
+	}
+	if fileVersion != activeVersion {
+		ctx.UI.Warningf(
+			"ruby: dev.yml requests %s but .ruby-version says %s. dev.yml wins; remove one to silence this warning.",
+			activeVersion, fileVersion,
+		)
+	}
+}

--- a/pkg/autoenv/features/ruby.go
+++ b/pkg/autoenv/features/ruby.go
@@ -1,6 +1,8 @@
 package features
 
 import (
+	"path"
+
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/helpers"
 	"github.com/devbuddy/devbuddy/pkg/utils"
@@ -17,11 +19,7 @@ func (ruby) Name() string {
 }
 
 func (ruby) Activate(ctx *context.Context, param string) (bool, error) {
-	rbEnv, err := helpers.NewRbEnv(ctx)
-	if err != nil {
-		return true, nil
-	}
-	binPath := rbEnv.BinPath(param)
+	binPath := path.Join(helpers.RbEnvRoot(), "versions", param, "bin")
 	if !utils.PathExists(binPath) {
 		return true, nil
 	}

--- a/pkg/autoenv/features/ruby.go
+++ b/pkg/autoenv/features/ruby.go
@@ -1,0 +1,32 @@
+package features
+
+import (
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/devbuddy/devbuddy/pkg/utils"
+)
+
+func init() {
+	register.Register(ruby{})
+}
+
+type ruby struct{}
+
+func (ruby) Name() string {
+	return "ruby"
+}
+
+func (ruby) Activate(ctx *context.Context, param string) (bool, error) {
+	rbEnv, err := helpers.NewRbEnv(ctx)
+	if err != nil {
+		return true, nil
+	}
+	binPath := rbEnv.BinPath(param)
+	if !utils.PathExists(binPath) {
+		return true, nil
+	}
+	ctx.Env.PrependToPath(binPath)
+	return false, nil
+}
+
+func (ruby) Deactivate(ctx *context.Context, param string) {}

--- a/pkg/autoenv/features/ruby_test.go
+++ b/pkg/autoenv/features/ruby_test.go
@@ -1,0 +1,57 @@
+package features
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devbuddy/devbuddy/pkg/context"
+	envpkg "github.com/devbuddy/devbuddy/pkg/env"
+	"github.com/devbuddy/devbuddy/pkg/project"
+	"github.com/devbuddy/devbuddy/pkg/termui"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newRubyTestContext(t *testing.T, projectPath string) (*context.Context, func() string) {
+	t.Helper()
+	buf, ui := termui.NewTesting(false)
+	ctx := &context.Context{
+		Env:     envpkg.New([]string{}),
+		UI:      ui,
+		Project: project.NewFromPath(projectPath),
+	}
+	return ctx, buf.String
+}
+
+func TestRubyWarnsOnRubyVersionMismatch(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ruby-version"), []byte("3.2.0\n"), 0o600))
+
+	ctx, output := newRubyTestContext(t, dir)
+	_, _ = ruby{}.Activate(ctx, "3.3.0")
+
+	require.Contains(t, output(), "dev.yml requests 3.3.0 but .ruby-version says 3.2.0")
+}
+
+func TestRubySilentWhenRubyVersionMatches(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ruby-version"), []byte("3.3.0\n"), 0o600))
+
+	ctx, output := newRubyTestContext(t, dir)
+	_, _ = ruby{}.Activate(ctx, "3.3.0")
+
+	require.NotContains(t, output(), ".ruby-version")
+}
+
+func TestRubySilentWhenRubyVersionAbsent(t *testing.T) {
+	dir := t.TempDir()
+	ctx, output := newRubyTestContext(t, dir)
+	_, _ = ruby{}.Activate(ctx, "3.3.0")
+
+	require.NotContains(t, output(), ".ruby-version")
+}
+
+func TestRubyWatchesRubyVersionFile(t *testing.T) {
+	require.Equal(t, []string{".ruby-version"}, ruby{}.WatchedFiles("any"))
+}

--- a/pkg/helpers/rbenv.go
+++ b/pkg/helpers/rbenv.go
@@ -1,0 +1,52 @@
+package helpers
+
+import (
+	"fmt"
+	"path"
+	"slices"
+	"strings"
+
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+)
+
+type RbEnv struct {
+	ctx  *context.Context
+	root string
+}
+
+func NewRbEnv(ctx *context.Context) (*RbEnv, error) {
+	result := ctx.Executor.CaptureAndTrim(executor.New("rbenv", "root"))
+	if result.Error != nil {
+		return nil, fmt.Errorf("Command 'rbenv root' failed: %w", result.Error)
+	}
+	return &RbEnv{ctx: ctx, root: result.Output}, nil
+}
+
+func (r *RbEnv) VersionInstalled(version string) (bool, error) {
+	versions, err := r.listVersions()
+	if err != nil {
+		return false, err
+	}
+	return slices.Contains(versions, version), nil
+}
+
+func (r *RbEnv) listVersions() ([]string, error) {
+	result := r.ctx.Executor.Capture(executor.New("rbenv", "versions", "--bare", "--skip-aliases"))
+	if result.Error != nil {
+		return nil, fmt.Errorf("failed to run rbenv versions: %w", result.Error)
+	}
+	return strings.Split(strings.TrimSpace(result.Output), "\n"), nil
+}
+
+func (r *RbEnv) VersionPath(version string) string {
+	return path.Join(r.root, "versions", version)
+}
+
+func (r *RbEnv) BinPath(version string) string {
+	return path.Join(r.VersionPath(version), "bin")
+}
+
+func (r *RbEnv) Which(version string, command string) string {
+	return path.Join(r.BinPath(version), command)
+}

--- a/pkg/helpers/rbenv.go
+++ b/pkg/helpers/rbenv.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"slices"
 	"strings"
@@ -13,6 +14,16 @@ import (
 type RbEnv struct {
 	ctx  *context.Context
 	root string
+}
+
+// RbEnvRoot returns the rbenv root directory using the same resolution as
+// rbenv itself: $RBENV_ROOT if set, otherwise $HOME/.rbenv. This avoids
+// shelling out to `rbenv root` for hot paths like shell-hook activation.
+func RbEnvRoot() string {
+	if root := os.Getenv("RBENV_ROOT"); root != "" {
+		return root
+	}
+	return path.Join(os.Getenv("HOME"), ".rbenv")
 }
 
 func NewRbEnv(ctx *context.Context) (*RbEnv, error) {

--- a/pkg/helpers/rbenv.go
+++ b/pkg/helpers/rbenv.go
@@ -4,12 +4,29 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"slices"
 	"strings"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
 )
+
+// ReadRubyVersionFile reads a `.ruby-version` file and returns the version
+// string with any leading `ruby-` engine prefix stripped. Returns os.ErrNotExist
+// when the file is absent so callers can decide whether to treat that as fatal.
+func ReadRubyVersionFile(projectPath string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(projectPath, ".ruby-version"))
+	if err != nil {
+		return "", err
+	}
+	version := strings.TrimSpace(string(data))
+	version = strings.TrimPrefix(version, "ruby-")
+	if version == "" {
+		return "", fmt.Errorf(".ruby-version is empty")
+	}
+	return version, nil
+}
 
 type RbEnv struct {
 	ctx  *context.Context

--- a/pkg/tasks/api/task_config.go
+++ b/pkg/tasks/api/task_config.go
@@ -15,8 +15,9 @@ func (e propertyNotFoundError) Error() string {
 
 // TaskConfig represents a task as defined in dev.yml
 type TaskConfig struct {
-	name    string
-	payload any
+	name        string
+	payload     any
+	ProjectPath string // root directory of the project. May be empty in tests.
 }
 
 func NewTaskConfig(definition any) (*TaskConfig, error) {

--- a/pkg/tasks/api/task_list.go
+++ b/pkg/tasks/api/task_list.go
@@ -27,7 +27,7 @@ func GetTasksFromProject(proj *project.Project) (taskList []*Task, err error) {
 	}
 
 	for _, payload := range manifest.Up {
-		task, err = NewTaskFromPayload(payload)
+		task, err = newTaskFromPayloadInProject(payload, proj.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -38,10 +38,15 @@ func GetTasksFromProject(proj *project.Project) (taskList []*Task, err error) {
 }
 
 func NewTaskFromPayload(payload any) (*Task, error) {
+	return newTaskFromPayloadInProject(payload, "")
+}
+
+func newTaskFromPayloadInProject(payload any, projectPath string) (*Task, error) {
 	taskConfig, err := NewTaskConfig(payload)
 	if err != nil {
 		return nil, fmt.Errorf("parsing task: %w", err)
 	}
+	taskConfig.ProjectPath = projectPath
 
 	taskDef := GetDefinitionOrUnknown(taskConfig.name)
 

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devbuddy/devbuddy/pkg/executor"
 	"github.com/devbuddy/devbuddy/pkg/helpers"
 	"github.com/devbuddy/devbuddy/pkg/tasks/api"
-	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
 const rubyTaskName = "ruby"
@@ -78,21 +77,11 @@ func parserRubyInstallRubyVersion(task *api.Task, version string) {
 
 func parserRubyBundleInstall(task *api.Task, version string) {
 	run := func(ctx *context.Context) error {
-		if !utils.PathExists("Gemfile") {
-			return nil
-		}
 		rbEnv, err := helpers.NewRbEnv(ctx)
 		if err != nil {
 			return err
 		}
 		bundle := rbEnv.Which(version, "bundle")
-		if !utils.PathExists(bundle) {
-			ctx.UI.TaskCommand(rbEnv.Which(version, "gem"), "install", "bundler")
-			result := ctx.Executor.Run(executor.New(rbEnv.Which(version, "gem"), "install", "bundler"))
-			if result.Error != nil {
-				return fmt.Errorf("failed to install bundler: %w", result.Error)
-			}
-		}
 		ctx.UI.TaskCommand("bundle", "install")
 		result := ctx.Executor.Run(executor.New(bundle, "install"))
 		if result.Error != nil {

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -1,7 +1,11 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
@@ -16,7 +20,7 @@ func init() {
 }
 
 func parserRuby(config *api.TaskConfig, task *api.Task) error {
-	version, err := config.GetStringPropertyAllowSingle("version")
+	version, err := resolveRubyVersion(config)
 	if err != nil {
 		return err
 	}
@@ -26,6 +30,41 @@ func parserRuby(config *api.TaskConfig, task *api.Task) error {
 	parserRubyInstallRubyVersion(task, version)
 	parserRubyBundleInstall(task, version)
 	return nil
+}
+
+// resolveRubyVersion returns the requested Ruby version. It accepts the version
+// from the dev.yml payload (string form or `version:` property) and falls back
+// to a `.ruby-version` file at the project root when neither is provided.
+func resolveRubyVersion(config *api.TaskConfig) (string, error) {
+	version, err := config.GetStringPropertyAllowSingle("version")
+	if err == nil {
+		return version, nil
+	}
+
+	if config.ProjectPath != "" {
+		v, readErr := readRubyVersionFile(filepath.Join(config.ProjectPath, ".ruby-version"))
+		if readErr == nil {
+			return v, nil
+		}
+		if !errors.Is(readErr, os.ErrNotExist) {
+			return "", fmt.Errorf("reading .ruby-version: %w", readErr)
+		}
+	}
+	return "", err
+}
+
+func readRubyVersionFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	version := strings.TrimSpace(string(data))
+	// Strip an optional engine prefix such as `ruby-3.3.0` written by some tools.
+	version = strings.TrimPrefix(version, "ruby-")
+	if version == "" {
+		return "", fmt.Errorf(".ruby-version is empty")
+	}
+	return version, nil
 }
 
 func parserRubyInstallRbenv(task *api.Task) {
@@ -89,6 +128,9 @@ func parserRubyBundleInstall(task *api.Task, version string) {
 		}
 		return nil
 	}
+	// Either file changing should trigger a re-run: Gemfile when deps are
+	// added/removed, Gemfile.lock when versions are bumped (e.g. `bundle update`).
 	task.AddActionBuilder("install gems with bundler", run).
-		On(api.FileCondition("Gemfile"))
+		On(api.FileCondition("Gemfile")).
+		On(api.FileCondition("Gemfile.lock"))
 }

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
@@ -42,7 +40,7 @@ func resolveRubyVersion(config *api.TaskConfig) (string, error) {
 	}
 
 	if config.ProjectPath != "" {
-		v, readErr := readRubyVersionFile(filepath.Join(config.ProjectPath, ".ruby-version"))
+		v, readErr := helpers.ReadRubyVersionFile(config.ProjectPath)
 		if readErr == nil {
 			return v, nil
 		}
@@ -51,20 +49,6 @@ func resolveRubyVersion(config *api.TaskConfig) (string, error) {
 		}
 	}
 	return "", err
-}
-
-func readRubyVersionFile(path string) (string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-	version := strings.TrimSpace(string(data))
-	// Strip an optional engine prefix such as `ruby-3.3.0` written by some tools.
-	version = strings.TrimPrefix(version, "ruby-")
-	if version == "" {
-		return "", fmt.Errorf(".ruby-version is empty")
-	}
-	return version, nil
 }
 
 func parserRubyInstallRbenv(task *api.Task) {

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -1,0 +1,105 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/devbuddy/devbuddy/pkg/tasks/api"
+	"github.com/devbuddy/devbuddy/pkg/utils"
+)
+
+const rubyTaskName = "ruby"
+
+func init() {
+	api.Register(rubyTaskName, "Ruby", parserRuby)
+}
+
+func parserRuby(config *api.TaskConfig, task *api.Task) error {
+	version, err := config.GetStringPropertyAllowSingle("version")
+	if err != nil {
+		return err
+	}
+	task.Info = version
+
+	parserRubyInstallRbenv(task)
+	parserRubyInstallRubyVersion(task, version)
+	parserRubyBundleInstall(task, version)
+	return nil
+}
+
+func parserRubyInstallRbenv(task *api.Task) {
+	needed := func(ctx *context.Context) *api.ActionResult {
+		_, err := helpers.NewRbEnv(ctx)
+		if err != nil {
+			return api.Needed("rbenv is not installed: %s", err)
+		}
+		return api.NotNeeded()
+	}
+	run := func(ctx *context.Context) error {
+		ctx.UI.TaskCommand("brew", "install", "rbenv")
+		result := ctx.Executor.Run(executor.New("brew", "install", "rbenv").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
+		if result.Error != nil {
+			return fmt.Errorf("failed to install rbenv: %w", result.Error)
+		}
+		return nil
+	}
+	task.AddActionBuilder("install rbenv", run).On(api.FuncCondition(needed))
+}
+
+func parserRubyInstallRubyVersion(task *api.Task, version string) {
+	needed := func(ctx *context.Context) *api.ActionResult {
+		rbEnv, err := helpers.NewRbEnv(ctx)
+		if err != nil {
+			return api.Failed("cannot use rbenv: %s", err)
+		}
+		installed, err := rbEnv.VersionInstalled(version)
+		if err != nil {
+			return api.Failed("failed to check if ruby version is installed: %s", err)
+		}
+		if !installed {
+			return api.Needed("ruby version is not installed")
+		}
+		return api.NotNeeded()
+	}
+	run := func(ctx *context.Context) error {
+		ctx.UI.TaskCommand("rbenv", "install", version)
+		result := ctx.Executor.Run(executor.New("rbenv", "install", version))
+		if result.Error != nil {
+			return fmt.Errorf("failed to install the required ruby version: %w", result.Error)
+		}
+		return nil
+	}
+	task.AddActionBuilder("install Ruby version with rbenv", run).
+		On(api.FuncCondition(needed)).
+		SetFeature("ruby", version)
+}
+
+func parserRubyBundleInstall(task *api.Task, version string) {
+	run := func(ctx *context.Context) error {
+		if !utils.PathExists("Gemfile") {
+			return nil
+		}
+		rbEnv, err := helpers.NewRbEnv(ctx)
+		if err != nil {
+			return err
+		}
+		bundle := rbEnv.Which(version, "bundle")
+		if !utils.PathExists(bundle) {
+			ctx.UI.TaskCommand(rbEnv.Which(version, "gem"), "install", "bundler")
+			result := ctx.Executor.Run(executor.New(rbEnv.Which(version, "gem"), "install", "bundler"))
+			if result.Error != nil {
+				return fmt.Errorf("failed to install bundler: %w", result.Error)
+			}
+		}
+		ctx.UI.TaskCommand("bundle", "install")
+		result := ctx.Executor.Run(executor.New(bundle, "install"))
+		if result.Error != nil {
+			return fmt.Errorf("bundle install failed: %w", result.Error)
+		}
+		return nil
+	}
+	task.AddActionBuilder("install gems with bundler", run).
+		On(api.FileCondition("Gemfile"))
+}

--- a/pkg/tasks/ruby_test.go
+++ b/pkg/tasks/ruby_test.go
@@ -1,0 +1,22 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRubyOk(t *testing.T) {
+	task := ensureLoadTestTask(t, `ruby: 3.3.0`)
+
+	require.Equal(t, "Task Ruby (3.3.0) feature=ruby:3.3.0 actions=3", task.Describe())
+	require.Equal(t, "3.3.0", task.Info)
+	require.Equal(t, 3, len(task.Actions))
+	requireFeature(t, task, "ruby", "3.3.0")
+}
+
+func TestRubyInvalid(t *testing.T) {
+	_, err := loadTestTask(t, `ruby: 3`)
+
+	require.Error(t, err, "buildFromDefinition() should have failed")
+}

--- a/pkg/tasks/ruby_test.go
+++ b/pkg/tasks/ruby_test.go
@@ -1,9 +1,13 @@
 package tasks
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/devbuddy/devbuddy/pkg/tasks/api"
 	"github.com/stretchr/testify/require"
+	yaml "github.com/goccy/go-yaml"
 )
 
 func TestRubyOk(t *testing.T) {
@@ -13,6 +17,55 @@ func TestRubyOk(t *testing.T) {
 	require.Equal(t, "3.3.0", task.Info)
 	require.Equal(t, 3, len(task.Actions))
 	requireFeature(t, task, "ruby", "3.3.0")
+}
+
+func TestRubyMissingVersionNoFile(t *testing.T) {
+	_, err := loadTestTask(t, `ruby:`)
+
+	require.Error(t, err, "buildFromDefinition() should have failed without a version")
+}
+
+// loadRubyTaskInDir parses a task payload with TaskConfig.ProjectPath set, so
+// the parser can consult a .ruby-version file in that directory.
+func loadRubyTaskInDir(t *testing.T, payload, projectPath string) (*api.Task, error) {
+	t.Helper()
+	var data any
+	require.NoError(t, yaml.Unmarshal([]byte(payload), &data))
+
+	taskConfig, err := api.NewTaskConfig(data)
+	require.NoError(t, err)
+	taskConfig.ProjectPath = projectPath
+
+	task := &api.Task{TaskDefinition: api.GetDefinitionOrUnknown("ruby")}
+	return task, task.TaskDefinition.Parser(taskConfig, task)
+}
+
+func TestRubyVersionFromFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ruby-version"), []byte("3.3.0\n"), 0o600))
+
+	task, err := loadRubyTaskInDir(t, `ruby:`, dir)
+	require.NoError(t, err)
+	require.Equal(t, "3.3.0", task.Info)
+	requireFeature(t, task, "ruby", "3.3.0")
+}
+
+func TestRubyVersionFromFileStripsEnginePrefix(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ruby-version"), []byte("ruby-3.3.4\n"), 0o600))
+
+	task, err := loadRubyTaskInDir(t, `ruby:`, dir)
+	require.NoError(t, err)
+	require.Equal(t, "3.3.4", task.Info)
+}
+
+func TestRubyExplicitVersionWinsOverFile(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".ruby-version"), []byte("3.0.0\n"), 0o600))
+
+	task, err := loadRubyTaskInDir(t, `ruby: 3.3.0`, dir)
+	require.NoError(t, err)
+	require.Equal(t, "3.3.0", task.Info)
 }
 
 func TestRubyInvalid(t *testing.T) {


### PR DESCRIPTION
## Summary
- New `ruby: <version>` task that installs rbenv (via Homebrew if missing), installs the requested Ruby version, and runs `bundle install` when a `Gemfile` is present.
- New `ruby` autoenv feature that prepends the version's `bin` to `PATH` so the Ruby interpreter and installed gem executables are available without rbenv shims.
- Modeled after the existing `python` task / pyenv pattern for consistency.

Modern Ruby projects generally use rbenv (or asdf/mise) for version management. rbenv mirrors pyenv closely both in CLI and in directory layout, so it's the natural choice here.

## Test plan
- [x] `script/test` passes
- [x] `script/lint` passes
- [ ] Manually try `bud up` against a sample dev.yml with `- ruby: 3.3.0` and a `Gemfile`

Fixes: #90