### PR TITLE
Mount integration test workspaces

### DIFF
--- a/tests/context/config.go
+++ b/tests/context/config.go
@@ -7,9 +7,11 @@ import (
 )
 
 type Config struct {
-	ShellName   string
-	BinaryPath  string
-	DockerImage string
+	ShellName              string
+	BinaryPath             string
+	DockerImage            string
+	WorkspaceHostPath      string
+	WorkspaceContainerPath string
 }
 
 func LoadConfig() (Config, error) {

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -213,8 +213,8 @@ func (c *TestContext) Cwd(t *testing.T) string {
 	t.Helper()
 	lines, err := c.shell.Run("pwd")
 	require.NoError(t, err)
-	require.Len(t, lines, 1, "unexpected output for 'pwd'")
-	return lines[0]
+	require.NotEmpty(t, lines, "unexpected output for 'pwd'")
+	return lines[len(lines)-1]
 }
 
 func (c *TestContext) Cat(t *testing.T, path string) string {

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -186,6 +186,8 @@ func (c *TestContext) Write(t *testing.T, path, content string) {
 	if hostPath, ok := c.hostPath(t, path); ok {
 		err := os.MkdirAll(filepath.Dir(hostPath), 0755)
 		require.NoError(t, err)
+		err = os.Chmod(filepath.Dir(hostPath), 0777)
+		require.NoError(t, err)
 
 		err = os.WriteFile(hostPath, []byte(content), 0644)
 		require.NoError(t, err)

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -4,7 +4,10 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -20,7 +23,9 @@ type TestContext struct {
 	shell  interface {
 		Run(string) ([]string, error)
 	}
-	debug bool
+	workspaceHostPath      string
+	workspaceContainerPath string
+	debug                  bool
 }
 
 func New(config Config) (*TestContext, error) {
@@ -56,9 +61,11 @@ func New(config Config) (*TestContext, error) {
 		"-e", "PS1=##\n",
 		"-e", "IN_DOCKER=yes",
 		"--rm",
-		"--entrypoint", shellPath,
-		config.DockerImage,
 	}
+	if config.WorkspaceHostPath != "" && config.WorkspaceContainerPath != "" {
+		dockerCommand = append(dockerCommand, "-v", config.WorkspaceHostPath+":"+config.WorkspaceContainerPath)
+	}
+	dockerCommand = append(dockerCommand, "--entrypoint", shellPath, config.DockerImage)
 	dockerCommand = append(dockerCommand, args...)
 
 	e := expect.NewExpect(dockerCommand[0], dockerCommand[1:]...)
@@ -75,9 +82,10 @@ func New(config Config) (*TestContext, error) {
 	}
 
 	tc := &TestContext{
-		expect: e,
-		shell:  c,
-		// t:      t,
+		expect:                 e,
+		shell:                  c,
+		workspaceHostPath:      config.WorkspaceHostPath,
+		workspaceContainerPath: config.WorkspaceContainerPath,
 	}
 	tc.debugLine("Expect command: %q", dockerCommand)
 
@@ -174,6 +182,16 @@ func (c *TestContext) run(cmd string, optFns ...runOptionsFn) ([]string, error) 
 
 func (c *TestContext) Write(t *testing.T, path, content string) {
 	t.Helper()
+
+	if hostPath, ok := c.hostPath(t, path); ok {
+		err := os.MkdirAll(filepath.Dir(hostPath), 0755)
+		require.NoError(t, err)
+
+		err = os.WriteFile(hostPath, []byte(content), 0644)
+		require.NoError(t, err)
+		return
+	}
+
 	b64content := base64.StdEncoding.EncodeToString([]byte(content))
 	_, err := c.shell.Run(fmt.Sprintf("echo %s | base64 --decode > %q", b64content, path))
 	require.NoError(t, err)
@@ -231,6 +249,31 @@ func (c *TestContext) Cd(t *testing.T, path string) []string {
 	lines, err := c.shell.Run("cd " + strconv.Quote(path))
 	require.NoError(t, err)
 	return lines
+}
+
+func (c *TestContext) hostPath(t *testing.T, containerPath string) (string, bool) {
+	t.Helper()
+
+	if c.workspaceHostPath == "" || c.workspaceContainerPath == "" {
+		return "", false
+	}
+
+	absolutePath := containerPath
+	if !path.IsAbs(absolutePath) {
+		absolutePath = path.Join(c.Cwd(t), absolutePath)
+	}
+	absolutePath = path.Clean(absolutePath)
+
+	workspaceRoot := path.Clean(c.workspaceContainerPath)
+	if absolutePath != workspaceRoot && !strings.HasPrefix(absolutePath, workspaceRoot+"/") {
+		return "", false
+	}
+
+	relPath := "."
+	if absolutePath != workspaceRoot {
+		relPath = strings.TrimPrefix(absolutePath, workspaceRoot+"/")
+	}
+	return filepath.Join(c.workspaceHostPath, filepath.FromSlash(relPath)), true
 }
 
 func (c *TestContext) debugLine(format string, a ...any) {

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -94,6 +94,11 @@ func New(config Config) (*TestContext, error) {
 		return nil, fmt.Errorf("disabling echo mode: %w", err)
 	}
 
+	_, err = tc.run("umask 000")
+	if err != nil {
+		return nil, fmt.Errorf("configuring test shell umask: %w", err)
+	}
+
 	output, err := tc.run("echo $IN_DOCKER")
 	if err != nil {
 		return nil, err

--- a/tests/internal/harness/helper.go
+++ b/tests/internal/harness/helper.go
@@ -3,6 +3,7 @@ package harness
 import (
 	"fmt"
 	"math/rand/v2"
+	"os"
 	"strings"
 	"testing"
 
@@ -16,7 +17,9 @@ func CreateContext(t *testing.T) *context.TestContext {
 
 	testConfig := config
 	testConfig.WorkspaceHostPath = t.TempDir()
-	testConfig.WorkspaceContainerPath = "/home/tester/src/github.com/orgname"
+	err := os.Chmod(testConfig.WorkspaceHostPath, 0777)
+	require.NoError(t, err)
+	testConfig.WorkspaceContainerPath = "/home/tester/src/github.com"
 
 	c, err := context.New(testConfig)
 	require.NoError(t, err)

--- a/tests/internal/harness/helper.go
+++ b/tests/internal/harness/helper.go
@@ -25,6 +25,7 @@ func CreateContext(t *testing.T) *context.TestContext {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
+		c.Run(t, "chmod -R a+rwX "+testConfig.WorkspaceContainerPath)
 		err := c.Close()
 		require.NoError(t, err)
 	})

--- a/tests/internal/harness/helper.go
+++ b/tests/internal/harness/helper.go
@@ -25,7 +25,6 @@ func CreateContext(t *testing.T) *context.TestContext {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		c.Run(t, "chmod -R a+rwX "+testConfig.WorkspaceContainerPath)
 		err := c.Close()
 		require.NoError(t, err)
 	})

--- a/tests/internal/harness/helper.go
+++ b/tests/internal/harness/helper.go
@@ -16,8 +16,13 @@ func CreateContext(t *testing.T) *context.TestContext {
 	t.Helper()
 
 	testConfig := config
-	testConfig.WorkspaceHostPath = t.TempDir()
-	err := os.Chmod(testConfig.WorkspaceHostPath, 0777)
+	var err error
+	testConfig.WorkspaceHostPath, err = os.MkdirTemp("", "devbuddy-test-workspace-*")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = os.RemoveAll(testConfig.WorkspaceHostPath)
+	})
+	err = os.Chmod(testConfig.WorkspaceHostPath, 0777)
 	require.NoError(t, err)
 	testConfig.WorkspaceContainerPath = "/home/tester/src/github.com"
 

--- a/tests/internal/harness/helper.go
+++ b/tests/internal/harness/helper.go
@@ -14,7 +14,11 @@ import (
 func CreateContext(t *testing.T) *context.TestContext {
 	t.Helper()
 
-	c, err := context.New(config)
+	testConfig := config
+	testConfig.WorkspaceHostPath = t.TempDir()
+	testConfig.WorkspaceContainerPath = "/home/tester/src/github.com/orgname"
+
+	c, err := context.New(testConfig)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -87,8 +91,6 @@ func CreateProject(t *testing.T, c *context.TestContext, devYmlLines ...string) 
 		c:    c,
 		Path: "/home/tester/src/github.com/orgname/" + name,
 	}
-
-	c.Run(t, "mkdir -p "+p.Path)
 
 	p.WriteDevYml(t, devYmlLines...)
 


### PR DESCRIPTION
## Summary
- mount a per-test host temp directory into the Docker integration container
- write project files directly through the mounted workspace when possible
- keep the existing base64 shell upload path as a fallback for files outside the workspace

## Verification
- env GOCACHE=/private/tmp/devbuddy-go-cache go test ./tests/context ./tests/internal/expect ./tests/internal/harness
- env GOCACHE=/private/tmp/devbuddy-go-cache TEST_DOCKER_IMAGE=dummy go test -run '^$' ./tests/...
- go test ./pkg/...
- bud lint