### PR TITLE
Add fast CLI test harness

### DIFF
--- a/tests/fast/cmd_custom_test.go
+++ b/tests/fast/cmd_custom_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/devbuddy/devbuddy/tests/context"
 )
 
 const (
@@ -91,7 +89,7 @@ func Test_Cmd_Custom_Exit_Code(t *testing.T) {
 	c.Cd(t, project.Path)
 
 	// bud reports the failure but normalizes the exit code to 1
-	lines := c.Run(t, "bud fail", context.ExitCode(1))
+	lines := c.Run(t, "bud fail", ExitCode(1))
 	OutputContains(t, lines, "command failed with exit code 42")
 }
 

--- a/tests/fast/cmd_inspect_test.go
+++ b/tests/fast/cmd_inspect_test.go
@@ -1,10 +1,6 @@
 package integration
 
-import (
-	"testing"
-
-	"github.com/devbuddy/devbuddy/tests/context"
-)
+import "testing"
 
 func Test_Cmd_Inspect(t *testing.T) {
 	c := CreateContextAndInit(t)
@@ -27,6 +23,6 @@ func Test_Cmd_Inspect(t *testing.T) {
 func Test_Cmd_Inspect_No_Manifest(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	lines := c.Run(t, "bud inspect", context.ExitCode(1))
+	lines := c.Run(t, "bud inspect", ExitCode(1))
 	OutputEqual(t, lines, "Error: project not found")
 }

--- a/tests/fast/cmd_open_test.go
+++ b/tests/fast/cmd_open_test.go
@@ -1,30 +1,44 @@
 package integration
 
 import (
+	"os"
 	"testing"
 	"time"
 
-	"github.com/devbuddy/devbuddy/tests/context"
 	"github.com/stretchr/testify/require"
 )
 
-func installFakeXdgOpen(t *testing.T, c *context.TestContext) {
+func installFakeXdgOpen(t *testing.T, c *Context) string {
 	t.Helper()
 
-	c.Run(t, "mkdir -p /tmp/devbuddy-test-bin")
-	c.Write(t, "/tmp/devbuddy-test-bin/xdg-open", `#!/bin/sh
-printf "%s\n" "$1" > /tmp/devbuddy-open-url
-`)
-	c.Run(t, "chmod +x /tmp/devbuddy-test-bin/xdg-open")
-	c.Run(t, `export PATH="/tmp/devbuddy-test-bin:${PATH}"`)
+	binDir := c.Path("bin")
+	outputPath := c.Path("devbuddy-open-url")
+	script := `#!/bin/sh
+printf "%s\n" "$1" > ` + outputPath + `
+`
+	c.Write(t, binDir+"/xdg-open", script)
+	c.Write(t, binDir+"/open", script)
+	c.Run(t, "chmod +x "+binDir+"/xdg-open")
+	c.Run(t, "chmod +x "+binDir+"/open")
+	c.PrependPath(binDir)
+
+	return outputPath
 }
 
-func waitAndReadOpenedURL(t *testing.T, c *context.TestContext) string {
+func waitAndReadOpenedURL(t *testing.T, c *Context, path string) string {
 	t.Helper()
 
-	lines := c.Run(t, "cat /tmp/devbuddy-open-url", context.Timeout(15*time.Second))
-	require.Len(t, lines, 1)
-	return lines[0]
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		_, err := os.ReadFile(path)
+		if err == nil {
+			return c.Run(t, "cat "+path)[0]
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	require.Failf(t, "opened URL was not recorded", "expected %s to be written", path)
+	return ""
 }
 
 func Test_Cmd_Open_CustomLink_FuzzyMatch(t *testing.T) {
@@ -33,12 +47,12 @@ func Test_Cmd_Open_CustomLink_FuzzyMatch(t *testing.T) {
 		`  staging: https://staging.example.com`,
 		`  docs: https://docs.example.com`,
 	)
-	installFakeXdgOpen(t, c)
+	outputPath := installFakeXdgOpen(t, c)
 	c.Cd(t, p.Path)
 
 	c.Run(t, "bud open stg")
 
-	openedURL := waitAndReadOpenedURL(t, c)
+	openedURL := waitAndReadOpenedURL(t, c, outputPath)
 	OutputEqual(t, []string{openedURL}, "https://staging.example.com")
 }
 
@@ -50,6 +64,6 @@ func Test_Cmd_Open_NoArgOpensGithub(t *testing.T) {
 	c.Cd(t, p.Path)
 
 	// No git remote configured, so it fails
-	lines := c.Run(t, "bud open", context.ExitCode(1))
+	lines := c.Run(t, "bud open", ExitCode(1))
 	OutputContains(t, lines, "failed to get the origin remote url")
 }

--- a/tests/fast/cmd_test.go
+++ b/tests/fast/cmd_test.go
@@ -39,5 +39,5 @@ func Test_Cmd_DebugInfo_Project(t *testing.T) {
 	c.Run(t, "touch dev.yml")
 
 	lines := c.Run(t, "bud --debug-info")
-	OutputContains(t, lines, "Project path: `/home/tester/poipoi`")
+	OutputContains(t, lines, "Project path: `"+c.Cwd(t)+"`")
 }

--- a/tests/fast/harness_test.go
+++ b/tests/fast/harness_test.go
@@ -2,41 +2,51 @@ package integration
 
 import (
 	"testing"
+	"time"
 
-	"github.com/devbuddy/devbuddy/tests/context"
-	"github.com/devbuddy/devbuddy/tests/internal/harness"
+	"github.com/devbuddy/devbuddy/tests/internal/cliharness"
 )
 
-type Project = harness.Project
+type Context = cliharness.Context
+type Project = cliharness.Project
+type RunOption = cliharness.RunOption
 
 func TestMain(m *testing.M) {
-	harness.TestMain(m)
+	cliharness.TestMain(m)
 }
 
-func CreateContext(t *testing.T) *context.TestContext {
-	return harness.CreateContext(t)
+func CreateContext(t *testing.T) *cliharness.Context {
+	return cliharness.CreateContext(t)
 }
 
-func CreateContextAndInit(t *testing.T) *context.TestContext {
-	return harness.CreateContextAndInit(t)
+func CreateContextAndInit(t *testing.T) *cliharness.Context {
+	return cliharness.CreateContextAndInit(t)
 }
 
-func CreateContextAndProject(t *testing.T, devYmlLines ...string) (*context.TestContext, Project) {
-	return harness.CreateContextAndProject(t, devYmlLines...)
+func CreateContextAndProject(t *testing.T, devYmlLines ...string) (*cliharness.Context, Project) {
+	return cliharness.CreateContextAndProject(t, devYmlLines...)
 }
 
-func CreateProject(t *testing.T, c *context.TestContext, devYmlLines ...string) Project {
-	return harness.CreateProject(t, c, devYmlLines...)
+func CreateProject(t *testing.T, c *cliharness.Context, devYmlLines ...string) Project {
+	return cliharness.CreateProject(t, c, devYmlLines...)
+}
+
+func ExitCode(code int) RunOption {
+	return cliharness.ExitCode(code)
+}
+
+func Timeout(timeout time.Duration) RunOption {
+	return cliharness.Timeout(timeout)
 }
 
 func OutputContains(t *testing.T, lines []string, subStrings ...string) {
-	harness.OutputContains(t, lines, subStrings...)
+	cliharness.OutputContains(t, lines, subStrings...)
 }
 
 func OutputNotContains(t *testing.T, lines []string, subStrings ...string) {
-	harness.OutputNotContains(t, lines, subStrings...)
+	cliharness.OutputNotContains(t, lines, subStrings...)
 }
 
 func OutputEqual(t *testing.T, lines []string, expectedLines ...string) {
-	harness.OutputEqual(t, lines, expectedLines...)
+	cliharness.OutputEqual(t, lines, expectedLines...)
 }

--- a/tests/fast/task_custom_test.go
+++ b/tests/fast/task_custom_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/devbuddy/devbuddy/tests/context"
 )
 
 var customTaskDevYml = `
@@ -35,9 +33,9 @@ func Test_Task_Custom_Subdir(t *testing.T) {
 
 	// The command must work in a sub-dir, but run in the project root
 	c.Run(t, "mkdir subdir")
-	c.Run(t, "cd subdir")
+	c.Cd(t, "subdir")
 	c.Run(t, "bud up")
-	c.Run(t, "cd ..")
+	c.Cd(t, "..")
 
 	content := c.Cat(t, "sentinel")
 	require.Equal(t, "A", content)
@@ -52,14 +50,14 @@ func Test_Task_Custom_Fails(t *testing.T) {
 		`    meet: exit 1`,
 	)
 
-	lines := c.Run(t, "bud up", context.ExitCode(1))
+	lines := c.Run(t, "bud up", ExitCode(1))
 	OutputContains(t, lines, "Running: exit 1", `action "": failed to run: command failed with exit code 1`)
 }
 
 func Test_Task_Custom_With_Env_From_Shell(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	c.Run(t, "export MYVAR=poipoi")
+	c.Setenv("MYVAR", "poipoi")
 
 	p := CreateProject(t, c,
 		`env:`,
@@ -98,7 +96,7 @@ func Test_Task_Custom_With_Env_At_First_Run(t *testing.T) {
 func Test_Task_Custom_With_Env_Previously_Set_By_DevBuddy(t *testing.T) {
 	c := CreateContextAndInit(t)
 
-	c.Run(t, "export MYVAR=poipoi")
+	c.Setenv("MYVAR", "poipoi")
 
 	p := CreateProject(t, c,
 		`env:`,

--- a/tests/fast/task_error_test.go
+++ b/tests/fast/task_error_test.go
@@ -1,17 +1,13 @@
 package integration
 
-import (
-	"testing"
-
-	"github.com/devbuddy/devbuddy/tests/context"
-)
+import "testing"
 
 func Test_Task_Error_NotAList(t *testing.T) {
 	c := CreateContextAndInit(t)
 
 	c.Write(t, "dev.yml", `up: somestring`)
 
-	lines := c.Run(t, "bud up", context.ExitCode(1))
+	lines := c.Run(t, "bud up", ExitCode(1))
 	OutputContains(t, lines, "string was used where sequence is expected")
 }
 
@@ -20,7 +16,7 @@ func Test_Task_Error_InvalidType(t *testing.T) {
 
 	c.Write(t, "dev.yml", `up: [true]`)
 
-	lines := c.Run(t, "bud up", context.ExitCode(1))
+	lines := c.Run(t, "bud up", ExitCode(1))
 	OutputEqual(t, lines, `Error: parsing task: invalid task: "true"`)
 }
 
@@ -29,7 +25,7 @@ func Test_Task_Error_UnknownTask(t *testing.T) {
 
 	c.Write(t, "dev.yml", `up: [notatask]`)
 
-	lines := c.Run(t, "bud up", context.ExitCode(1))
+	lines := c.Run(t, "bud up", ExitCode(1))
 	OutputContains(t, lines, `unknown task: "notatask"`)
 }
 
@@ -38,7 +34,7 @@ func Test_Task_Error_Invalid_Hash_Type(t *testing.T) {
 
 	c.Write(t, "dev.yml", `up: [ { go: {version: 1.16} } ]`)
 
-	lines := c.Run(t, "bud up", context.ExitCode(1))
+	lines := c.Run(t, "bud up", ExitCode(1))
 	OutputEqual(t, lines,
 		`Error: task "go": key "version": expecting a string, found a float64 (1.16)`,
 	)
@@ -49,7 +45,7 @@ func Test_Task_Error_Invalid_List(t *testing.T) {
 
 	c.Write(t, "dev.yml", `up: [ { homebrew: {} } ]`)
 
-	lines := c.Run(t, "bud up", context.ExitCode(1))
+	lines := c.Run(t, "bud up", ExitCode(1))
 	OutputEqual(t, lines,
 		`Error: task "homebrew": expecting a list of strings, found a map[string]interface {} (map[])`,
 	)

--- a/tests/internal/cliharness/helper.go
+++ b/tests/internal/cliharness/helper.go
@@ -1,0 +1,272 @@
+package cliharness
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	testcontext "github.com/devbuddy/devbuddy/tests/context"
+)
+
+type Context struct {
+	workDir string
+	homeDir string
+	env     []string
+}
+
+type RunOptions struct {
+	ExitCode int
+	Timeout  time.Duration
+}
+
+type RunOption func(*RunOptions)
+
+func ExitCode(code int) RunOption {
+	return func(o *RunOptions) {
+		o.ExitCode = code
+	}
+}
+
+func Timeout(timeout time.Duration) RunOption {
+	return func(o *RunOptions) {
+		o.Timeout = timeout
+	}
+}
+
+func NewContext(t *testing.T) *Context {
+	t.Helper()
+
+	workDir := canonicalTempDir(t)
+	homeDir := canonicalTempDir(t)
+
+	pathValue := filepath.Dir(binaryPath) + string(os.PathListSeparator) + os.Getenv("PATH")
+	env := append(os.Environ(),
+		"HOME="+homeDir,
+		"PATH="+pathValue,
+	)
+
+	return &Context{
+		workDir: workDir,
+		homeDir: homeDir,
+		env:     env,
+	}
+}
+
+func (c *Context) Run(t *testing.T, command string, optFns ...RunOption) []string {
+	t.Helper()
+
+	opt := RunOptions{
+		ExitCode: 0,
+		Timeout:  10 * time.Second,
+	}
+	for _, fn := range optFns {
+		fn(&opt)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), opt.Timeout)
+	defer cancel()
+
+	finalizerFile := filepath.Join(t.TempDir(), "bud-finalizer")
+	cmd := exec.CommandContext(ctx, "sh", "-c", command)
+	cmd.Dir = c.workDir
+	cmd.Env = append(append([]string{}, c.env...), "BUD_FINALIZER_FILE="+finalizerFile)
+
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		require.Failf(t, "command timed out", "timed out after %s running %q. output:\n%s", opt.Timeout, command, string(output))
+	}
+
+	exitCode := 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			require.NoError(t, err, "running command: %q", command)
+		}
+	}
+	require.Equal(t, opt.ExitCode, exitCode, "running command %q. output:\n%s", command, string(output))
+
+	return lines(output)
+}
+
+func (c *Context) Write(t *testing.T, path, content string) {
+	t.Helper()
+	hostPath := c.resolvePath(path)
+	err := os.MkdirAll(filepath.Dir(hostPath), 0755)
+	require.NoError(t, err)
+	err = os.WriteFile(hostPath, []byte(content), 0644)
+	require.NoError(t, err)
+}
+
+func (c *Context) WriteLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	c.Write(t, path, strings.Join(lines, "\n"))
+}
+
+func (c *Context) Cwd(t *testing.T) string {
+	t.Helper()
+	return c.workDir
+}
+
+func (c *Context) Cd(t *testing.T, path string) []string {
+	t.Helper()
+	c.workDir = c.resolvePath(path)
+	err := os.MkdirAll(c.workDir, 0755)
+	require.NoError(t, err)
+	return nil
+}
+
+func (c *Context) Setenv(name, value string) {
+	c.setenv(name, value)
+}
+
+func (c *Context) PrependPath(path string) {
+	c.setenv("PATH", path+string(os.PathListSeparator)+c.getenv("PATH"))
+}
+
+func (c *Context) Cat(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(c.resolvePath(path))
+	require.NoError(t, err)
+	return strings.TrimSuffix(string(content), "\n")
+}
+
+func (c *Context) Ls(t *testing.T, path string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(c.resolvePath(path))
+	require.NoError(t, err)
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func (c *Context) AssertContains(t *testing.T, path, expected string) {
+	t.Helper()
+	require.Equal(t, expected, c.Cat(t, path), "expected file %q to contain %q", path, expected)
+}
+
+func (c *Context) Path(path string) string {
+	return c.resolvePath(path)
+}
+
+func (c *Context) resolvePath(path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(c.workDir, path)
+}
+
+func (c *Context) getenv(name string) string {
+	prefix := name + "="
+	for i := len(c.env) - 1; i >= 0; i-- {
+		if strings.HasPrefix(c.env[i], prefix) {
+			return strings.TrimPrefix(c.env[i], prefix)
+		}
+	}
+	return ""
+}
+
+func (c *Context) setenv(name, value string) {
+	prefix := name + "="
+	filtered := c.env[:0]
+	for _, entry := range c.env {
+		if !strings.HasPrefix(entry, prefix) {
+			filtered = append(filtered, entry)
+		}
+	}
+	c.env = filtered
+	c.env = append(c.env, prefix+value)
+}
+
+type Project struct {
+	c    *Context
+	Path string
+}
+
+func CreateContext(t *testing.T) *Context {
+	t.Helper()
+	return NewContext(t)
+}
+
+func CreateContextAndInit(t *testing.T) *Context {
+	t.Helper()
+	return CreateContext(t)
+}
+
+func CreateContextAndProject(t *testing.T, devYmlLines ...string) (*Context, Project) {
+	t.Helper()
+
+	c := CreateContext(t)
+	p := CreateProject(t, c, devYmlLines...)
+	c.Cd(t, p.Path)
+	return c, p
+}
+
+func CreateProject(t *testing.T, c *Context, devYmlLines ...string) Project {
+	t.Helper()
+
+	name := fmt.Sprintf("project-%x", rand.Int32())
+	p := Project{
+		c:    c,
+		Path: filepath.Join(c.homeDir, "src", "github.com", "orgname", name),
+	}
+
+	p.WriteDevYml(t, devYmlLines...)
+	return p
+}
+
+func (p *Project) WriteDevYml(t *testing.T, devYmlLines ...string) {
+	t.Helper()
+	p.c.Write(t, filepath.Join(p.Path, "dev.yml"), strings.Join(devYmlLines, "\n"))
+}
+
+func OutputContains(t *testing.T, output []string, subStrings ...string) {
+	t.Helper()
+
+	text := testcontext.StripAnsi(strings.Join(output, "\n"))
+	for _, subString := range subStrings {
+		require.Contains(t, text, subString)
+	}
+}
+
+func OutputNotContains(t *testing.T, output []string, subStrings ...string) {
+	t.Helper()
+
+	text := testcontext.StripAnsi(strings.Join(output, "\n"))
+	for _, subString := range subStrings {
+		require.NotContains(t, text, subString)
+	}
+}
+
+func OutputEqual(t *testing.T, output []string, expectedLines ...string) {
+	t.Helper()
+	require.Equal(t, expectedLines, output)
+}
+
+func lines(output []byte) []string {
+	text := strings.ReplaceAll(string(output), "\r", "")
+	text = strings.TrimSuffix(text, "\n")
+	if text == "" {
+		return nil
+	}
+	return strings.Split(testcontext.StripAnsi(text), "\n")
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+	return dir
+}

--- a/tests/internal/cliharness/main.go
+++ b/tests/internal/cliharness/main.go
@@ -1,0 +1,56 @@
+package cliharness
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+var binaryPath string
+
+func TestMain(m *testing.M) {
+	start := time.Now()
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		fmt.Printf("Error finding repo root: %s\n", err)
+		os.Exit(1)
+	}
+
+	binaryPath = filepath.Join(os.TempDir(), fmt.Sprintf("bud-test-%d", os.Getpid()), "bud")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0755); err != nil {
+		fmt.Printf("Error creating binary directory: %s\n", err)
+		os.Exit(1)
+	}
+	cmd := exec.Command("go", "build", "-ldflags", "-X main.Version=devel", "-o", binaryPath, "./cmd/bud")
+	cmd.Dir = repoRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error when building binary: %s\n%s\n", err.Error(), string(output))
+		os.Exit(1)
+	}
+
+	fmt.Printf("Built host binary in %s\n", time.Since(start))
+	os.Exit(m.Run())
+}
+
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s", dir)
+		}
+		dir = parent
+	}
+}


### PR DESCRIPTION
## Summary
- add a host-side CLI harness that builds a local bud binary once and runs it without Docker or PTY
- switch the fast test package to the direct binary harness
- adapt fast tests that previously depended on persistent shell process state

## Verification
- env GOCACHE=/private/tmp/devbuddy-go-cache go test ./tests/fast
- env GOCACHE=/private/tmp/devbuddy-go-cache TEST_DOCKER_IMAGE=dummy go test -run '^$' ./tests/...
- env GOCACHE=/private/tmp/devbuddy-go-cache go test ./pkg/...
- bud lint