### PR TITLE
Run focused integration test jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,16 @@ jobs:
           go-version: "1.26"
       - run: go test -timeout 10s -cover ./pkg/...
 
+  tests-fast:
+    name: fast CLI tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - run: go test -cover -v ./tests/fast
+
   tests-bash:
     name: bash tests
     runs-on: ubuntu-latest
@@ -45,7 +55,7 @@ jobs:
         with:
           go-version: "1.26"
       - run: docker pull $TEST_DOCKER_IMAGE
-      - run: TEST_SHELL=bash go test -cover -v ./tests/...
+      - run: TEST_SHELL=bash go test -cover -v ./tests/shell
 
   tests-zsh:
     name: zsh tests
@@ -56,7 +66,18 @@ jobs:
         with:
           go-version: "1.26"
       - run: docker pull $TEST_DOCKER_IMAGE
-      - run: TEST_SHELL=zsh go test -cover -v ./tests/...
+      - run: TEST_SHELL=zsh go test -cover -v ./tests/shell
+
+  tests-docker:
+    name: Docker runtime tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - run: docker pull $TEST_DOCKER_IMAGE
+      - run: TEST_SHELL=bash go test -cover -v ./tests/docker
 
   # TODO: enable after next release (released binary needs the ioctl fix)
   # install-script:
@@ -98,7 +119,7 @@ jobs:
 
   release:
     name: release
-    needs: [linters, tests, tests-bash, tests-zsh]
+    needs: [linters, tests, tests-fast, tests-bash, tests-zsh, tests-docker]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- add a dedicated fast CLI test job
- limit bash and zsh jobs to the focused shell package
- add a separate Docker runtime package job

## Verification
- env GOCACHE=/private/tmp/devbuddy-go-cache go test ./tests/fast
- env GOCACHE=/private/tmp/devbuddy-go-cache TEST_DOCKER_IMAGE=dummy go test -run '^$' ./tests/shell ./tests/docker
- bud lint