### PR TITLE
Add real-network runtime test switch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,17 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
+    inputs:
+      real_network:
+        description: Run Docker runtime tests against real upstream servers
+        required: true
+        type: boolean
+        default: false
 
 env:
   TEST_DOCKER_IMAGE: ghcr.io/devbuddy/docker-testing:sha-7fd13f4
+  BUD_TEST_REAL_NETWORK: "0"
 
 jobs:
   linters:
@@ -77,7 +85,19 @@ jobs:
         with:
           go-version: "1.26"
       - run: docker pull $TEST_DOCKER_IMAGE
-      - run: TEST_SHELL=bash go test -cover -v ./tests/docker
+      - run: TEST_SHELL=bash BUD_TEST_REAL_NETWORK=0 go test -cover -v ./tests/docker
+
+  tests-docker-real-network:
+    name: Docker runtime tests (real network)
+    if: github.event_name == 'workflow_dispatch' && inputs.real_network
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+      - run: docker pull $TEST_DOCKER_IMAGE
+      - run: TEST_SHELL=bash BUD_TEST_REAL_NETWORK=1 go test -cover -v ./tests/docker
 
   # TODO: enable after next release (released binary needs the ioctl fix)
   # install-script:

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -19,6 +19,10 @@ All tests in `tests/` currently run through the Docker + PTY harness. The
 `BUD_TEST_REAL_NETWORK=1` is set, the same runtime tests may call real upstream
 destinations instead of fixture or preseeded artifacts.
 
+GitHub Actions exposes this as a manual workflow option named
+`real_network`. Pull request CI sets `BUD_TEST_REAL_NETWORK=0`; the manual
+`Docker runtime tests (real network)` job sets it to `1`.
+
 ## Current Test Inventory
 
 | File | Current focus | Target label |


### PR DESCRIPTION
## Summary
- add a manual GitHub Actions input for running Docker runtime tests against real upstream servers
- keep pull request Docker runtime tests explicit about BUD_TEST_REAL_NETWORK=0
- document the CI control in the coverage labels

## Verification
- env GOCACHE=/private/tmp/devbuddy-go-cache TEST_DOCKER_IMAGE=dummy go test -run '^$' ./tests/docker
- git diff --check
- bud lint