### PR TITLE
Add worktree UX and tree commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ bud tree cd feature-a
 bud tree switch
 ```
 
+`bud tree new` creates the worktree and jumps into it. `bud tree prune` cleans stale Git worktree metadata and asks whether to delete each existing worktree that has not been touched for more than one week.
+
 `bud tree switch` opens an interactive selector with up/down keys and enter. Regular `bud cd` also understands managed worktree branches, so `bud cd feature-a` can jump to a worktree even when its directory is named for a different agent or task.
 
 If a branch is already checked out in another worktree, DevBuddy shows the existing path and a command to jump there instead of leaving you with Git's raw error.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See the full [task documentation](docs/Config.md) for details.
 - Notification when important files (e.g. `requirements.txt`) are updated locally
 - `bud open` to jump to the GitHub repo page, or `bud open <name>` for project URLs
 - `bud clone` / `bud cd` for fast project navigation
+- `bud tree` to create, navigate, and clean up Git worktrees
 - Shell completion (bash and zsh)
 
 ### Supported platforms
@@ -166,6 +167,27 @@ open:
 ```
 
 See DevBuddy's own [dev.yml](dev.yml) for a real-world example.
+
+## Git worktrees
+
+DevBuddy can manage Git worktrees beside your existing checkout. The normal clone remains the main worktree:
+
+```text
+~/src/github.com/org/repo
+~/src/github.com/org/repo--feature-a
+```
+
+Create and jump between worktrees from any checkout in the repository:
+
+```bash
+bud tree new feature-a
+bud tree cd feature-a
+bud tree switch
+```
+
+`bud tree switch` opens an interactive selector with up/down keys and enter. Regular `bud cd` also understands managed worktree branches, so `bud cd feature-a` can jump to a worktree even when its directory is named for a different agent or task.
+
+If a branch is already checked out in another worktree, DevBuddy shows the existing path and a command to jump there instead of leaving you with Git's raw error.
 
 ## Contributing
 

--- a/docs/plans/worktree-ux.md
+++ b/docs/plans/worktree-ux.md
@@ -15,13 +15,14 @@ The existing clone path remains the main/default worktree. Additional worktrees 
 
 ## Key UX Changes
 
-- Add `bud wt` as the primary command group, with `bud worktree` as an alias.
+- Add `bud tree` as the primary command group, with `bud wt` and `bud worktree` as aliases.
 - Keep `bud clone` unchanged by default. It still clones to the canonical repo path and jumps there.
 - Make `bud cd` worktree-aware so fuzzy navigation can jump to either the canonical project or a managed sibling worktree.
-- Add `bud wt list [query]` to show grouped worktrees with path, branch, HEAD short SHA, dirty state, and last modified time.
-- Add `bud wt new <name> [branch]` to create `repo--<name>` from the current project repository.
-- Add `bud wt cd [query]` to select and jump to a worktree, using the existing shell finalizer.
-- Add `bud wt remove [query]` and `bud wt prune` for cleanup.
+- Add `bud tree list [query]` to show grouped worktrees with path, branch, HEAD short SHA, dirty state, and last modified time.
+- Add `bud tree new <name> [branch]` to create `repo--<name>` from the current project repository.
+- Add `bud tree cd <query>` to jump to a worktree by branch, worktree name, or fuzzy match, using the existing shell finalizer.
+- Add `bud tree switch [query]` to show an interactive up/down/enter selector and jump to the selected worktree.
+- Add `bud tree remove [query]` and `bud tree prune` for cleanup.
 
 ## Branch Conflict UX
 
@@ -58,9 +59,10 @@ Non-interactive behavior should fail with a clear message and exact commands to 
 - Unit test sibling path derivation and worktree name sanitization.
 - Unit test branch occupancy detection.
 - Unit test project search with canonical repos and `repo--name` worktrees.
-- Integration test `bud wt new feature-a` creates `repo--feature-a`.
-- Integration test `bud wt cd feature-a` changes shell cwd through the existing finalizer.
-- Integration test `bud cd feature-a` jumps directly to a managed worktree.
+- Integration test `bud tree new feature-a` creates `repo--feature-a`.
+- Integration test `bud tree cd feature-a` changes shell cwd through the existing finalizer.
+- Integration test `bud tree switch` can select a worktree with down-arrow and enter.
+- Integration test `bud cd feature-a` jumps directly to a managed worktree branch, including when the branch name differs from the worktree directory suffix.
 - Integration test branch conflict output for interactive and non-interactive use.
 - Run shell finalizer coverage for both bash and zsh where integration coverage is added.
 
@@ -69,5 +71,5 @@ Non-interactive behavior should fail with a clear message and exact commands to 
 - The sibling layout is the default: `repo--<worktree-name>`.
 - Existing clones require no migration.
 - The current repo path is the default/main worktree.
-- `bud wt` is the preferred short command, and `bud worktree` is an alias.
+- `bud tree` is the preferred command, and `bud wt` plus `bud worktree` are aliases.
 - v1 focuses on local Git worktree creation, navigation, cleanup, and branch-conflict help. It does not include remote PR automation or AI-agent metadata.

--- a/docs/plans/worktree-ux.md
+++ b/docs/plans/worktree-ux.md
@@ -15,7 +15,7 @@ The existing clone path remains the main/default worktree. Additional worktrees 
 
 ## Key UX Changes
 
-- Add `bud tree` as the primary command group, with `bud wt` and `bud worktree` as aliases.
+- Add `bud tree` as the primary command group.
 - Keep `bud clone` unchanged by default. It still clones to the canonical repo path and jumps there.
 - Make `bud cd` worktree-aware so fuzzy navigation can jump to either the canonical project or a managed sibling worktree.
 - Add `bud tree list [query]` to show grouped worktrees with path, branch, HEAD short SHA, dirty state, and last modified time.
@@ -71,5 +71,5 @@ Non-interactive behavior should fail with a clear message and exact commands to 
 - The sibling layout is the default: `repo--<worktree-name>`.
 - Existing clones require no migration.
 - The current repo path is the default/main worktree.
-- `bud tree` is the preferred command, and `bud wt` plus `bud worktree` are aliases.
+- `bud tree` is the command namespace. Short aliases are intentionally out of scope for this PR.
 - v1 focuses on local Git worktree creation, navigation, cleanup, and branch-conflict help. It does not include remote PR automation or AI-agent metadata.

--- a/docs/plans/worktree-ux.md
+++ b/docs/plans/worktree-ux.md
@@ -19,10 +19,10 @@ The existing clone path remains the main/default worktree. Additional worktrees 
 - Keep `bud clone` unchanged by default. It still clones to the canonical repo path and jumps there.
 - Make `bud cd` worktree-aware so fuzzy navigation can jump to either the canonical project or a managed sibling worktree.
 - Add `bud tree list [query]` to show grouped worktrees with path, branch, HEAD short SHA, dirty state, and last modified time.
-- Add `bud tree new <name> [branch]` to create `repo--<name>` from the current project repository.
+- Add `bud tree new <name> [branch]` to create `repo--<name>` from the current project repository and jump into it.
 - Add `bud tree cd <query>` to jump to a worktree by branch, worktree name, or fuzzy match, using the existing shell finalizer.
 - Add `bud tree switch [query]` to show an interactive up/down/enter selector and jump to the selected worktree.
-- Add `bud tree remove [query]` and `bud tree prune` for cleanup.
+- Add `bud tree remove [query]` and `bud tree prune` for cleanup. `prune` should also ask whether to delete each existing worktree that has not been touched for more than one week.
 
 ## Branch Conflict UX
 

--- a/docs/plans/worktree-ux.md
+++ b/docs/plans/worktree-ux.md
@@ -1,0 +1,73 @@
+# Worktree UX Plan
+
+## Summary
+
+DevBuddy should make Git worktrees easy to create, maintain, and navigate for developers working across several branches, including AI-assisted work that often needs parallel checkouts.
+
+The default disk layout is backward compatible:
+
+```text
+~/src/<platform>/<org>/<repo>
+~/src/<platform>/<org>/<repo>--<worktree-name>
+```
+
+The existing clone path remains the main/default worktree. Additional worktrees are managed as sibling directories using the `repo--name` convention. This avoids nesting one Git checkout inside another and lets each worktree continue to behave like a normal DevBuddy project.
+
+## Key UX Changes
+
+- Add `bud wt` as the primary command group, with `bud worktree` as an alias.
+- Keep `bud clone` unchanged by default. It still clones to the canonical repo path and jumps there.
+- Make `bud cd` worktree-aware so fuzzy navigation can jump to either the canonical project or a managed sibling worktree.
+- Add `bud wt list [query]` to show grouped worktrees with path, branch, HEAD short SHA, dirty state, and last modified time.
+- Add `bud wt new <name> [branch]` to create `repo--<name>` from the current project repository.
+- Add `bud wt cd [query]` to select and jump to a worktree, using the existing shell finalizer.
+- Add `bud wt remove [query]` and `bud wt prune` for cleanup.
+
+## Branch Conflict UX
+
+When creating a worktree, DevBuddy should inspect `git worktree list --porcelain` before running `git worktree add`.
+
+If the requested branch is already checked out in another worktree, DevBuddy should show a friendly conflict instead of surfacing Git's raw error:
+
+- branch name
+- existing worktree path
+- dirty state when available
+- suggested next actions
+
+Interactive resolution choices:
+
+- jump to the existing worktree
+- create a new branch from the same commit, defaulting to `<branch>-<name>`
+- create a detached worktree at the branch HEAD
+- cancel
+
+Non-interactive behavior should fail with a clear message and exact commands to resolve.
+
+## Implementation Shape
+
+- Add a `pkg/worktree` package for worktree discovery, parsing, path policy, and Git command construction.
+- Parse `git worktree list --porcelain`; do not depend on ad hoc parsing of human-formatted output.
+- Centralize path derivation so managed worktrees always live beside the canonical repo as `repo--<name>`.
+- Keep Git execution isolated behind small functions so the code can later move behind the planned runtime environment abstraction.
+- Avoid required global metadata in v1. Git worktree metadata and the filesystem layout are the source of truth.
+- Extend project search to include both canonical projects and managed worktrees, while preserving existing fuzzy behavior.
+
+## Test Plan
+
+- Unit test porcelain parsing, including branch, detached HEAD, bare, and missing branch cases.
+- Unit test sibling path derivation and worktree name sanitization.
+- Unit test branch occupancy detection.
+- Unit test project search with canonical repos and `repo--name` worktrees.
+- Integration test `bud wt new feature-a` creates `repo--feature-a`.
+- Integration test `bud wt cd feature-a` changes shell cwd through the existing finalizer.
+- Integration test `bud cd feature-a` jumps directly to a managed worktree.
+- Integration test branch conflict output for interactive and non-interactive use.
+- Run shell finalizer coverage for both bash and zsh where integration coverage is added.
+
+## Assumptions
+
+- The sibling layout is the default: `repo--<worktree-name>`.
+- Existing clones require no migration.
+- The current repo path is the default/main worktree.
+- `bud wt` is the preferred short command, and `bud worktree` is an alias.
+- v1 focuses on local Git worktree creation, navigation, cleanup, and branch-conflict help. It does not include remote PR automation or AI-agent metadata.

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -54,6 +54,7 @@ func build(version string) *cobra.Command {
 	rootCmd.AddCommand(openCmd)
 	rootCmd.AddCommand(upCmd)
 	rootCmd.AddCommand(upgradeCmd)
+	rootCmd.AddCommand(worktreeCmd)
 
 	return rootCmd
 }

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/manifoldco/promptui"
 	"github.com/sahilm/fuzzy"
@@ -149,7 +151,7 @@ func worktreeNewRun(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("🐼  created worktree %s at %s\n", branch, path)
-	return nil
+	return integration.AddFinalizerCd(path)
 }
 
 func worktreeCdRun(_ *cobra.Command, args []string) error {
@@ -238,6 +240,30 @@ func worktreePruneRun(_ *cobra.Command, _ []string) error {
 
 	if err := worktree.Prune(ctx.Executor, ctx.Project.Path); err != nil {
 		return err
+	}
+
+	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	if err != nil {
+		return err
+	}
+
+	for _, wt := range inactiveWorktrees(worktrees, time.Now(), 7*24*time.Hour) {
+		prompt := promptui.Prompt{
+			Label:     fmt.Sprintf("Delete inactive worktree %s at %s", worktreeLabel(wt), wt.Path),
+			IsConfirm: true,
+		}
+
+		if _, err := prompt.Run(); err != nil {
+			if errors.Is(err, promptui.ErrAbort) {
+				continue
+			}
+			return err
+		}
+
+		if err := worktree.Remove(ctx.Executor, ctx.Project.Path, wt.Path); err != nil {
+			return err
+		}
+		fmt.Printf("🐼  removed inactive worktree %s\n", wt.Path)
 	}
 
 	fmt.Println("🐼  pruned stale worktree metadata")
@@ -339,6 +365,31 @@ func mainWorktreePath(worktrees []worktree.Worktree, fallback string) string {
 		}
 	}
 	return fallback
+}
+
+func inactiveWorktrees(worktrees []worktree.Worktree, now time.Time, maxAge time.Duration) []worktree.Worktree {
+	if len(worktrees) == 0 {
+		return nil
+	}
+
+	mainPath := mainWorktreePath(worktrees, "")
+	cutoff := now.Add(-maxAge)
+	var inactive []worktree.Worktree
+	for _, wt := range worktrees {
+		if filepath.Clean(wt.Path) == filepath.Clean(mainPath) {
+			continue
+		}
+
+		info, err := os.Stat(wt.Path)
+		if err != nil {
+			continue
+		}
+
+		if info.ModTime().Before(cutoff) {
+			inactive = append(inactive, wt)
+		}
+	}
+	return inactive
 }
 
 type worktreeRow struct {

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -18,7 +18,6 @@ import (
 
 var worktreeCmd = &cobra.Command{
 	Use:          "tree",
-	Aliases:      []string{"wt", "worktree"},
 	Short:        "Manage git worktrees",
 	GroupID:      "devbuddy",
 	SilenceUsage: true,
@@ -41,11 +40,12 @@ var worktreeNewCmd = &cobra.Command{
 }
 
 var worktreeCdCmd = &cobra.Command{
-	Use:          "cd QUERY",
-	Short:        "Jump to a git worktree",
-	Args:         onlyOneArg,
-	RunE:         worktreeCdRun,
-	SilenceUsage: true,
+	Use:               "cd QUERY",
+	Short:             "Jump to a git worktree",
+	Args:              onlyOneArg,
+	RunE:              worktreeCdRun,
+	ValidArgsFunction: worktreeCdCompletions,
+	SilenceUsage:      true,
 }
 
 var worktreeSwitchCmd = &cobra.Command{
@@ -97,8 +97,9 @@ func worktreeListRun(_ *cobra.Command, args []string) error {
 		query = args[0]
 	}
 
-	for _, wt := range matchWorktrees(worktrees, query) {
-		printWorktree(ctx.Executor, wt)
+	rows := buildWorktreeRows(ctx.Executor, matchWorktrees(worktrees, query))
+	for _, line := range formatWorktreeRows(rows, true) {
+		fmt.Println(line)
 	}
 	return nil
 }
@@ -189,7 +190,7 @@ func worktreeSwitchRun(_ *cobra.Command, args []string) error {
 
 	wt := matches[0]
 	if query == "" && len(matches) > 1 {
-		selected, err := selectWorktree(matches)
+		selected, err := selectWorktree(ctx.Executor, matches)
 		if err != nil {
 			return err
 		}
@@ -268,12 +269,14 @@ type switchItem struct {
 	Worktree worktree.Worktree
 }
 
-func selectWorktree(worktrees []worktree.Worktree) (worktree.Worktree, error) {
-	items := make([]switchItem, 0, len(worktrees))
-	for _, wt := range worktrees {
+func selectWorktree(exec *executor.Executor, worktrees []worktree.Worktree) (worktree.Worktree, error) {
+	rows := buildWorktreeRows(exec, worktrees)
+	labels := formatWorktreeRows(rows, false)
+	items := make([]switchItem, 0, len(rows))
+	for i, row := range rows {
 		items = append(items, switchItem{
-			Label:    fmt.Sprintf("%s  %s", worktreeLabel(wt), wt.Path),
-			Worktree: wt,
+			Label:    labels[i],
+			Worktree: row.Worktree,
 		})
 	}
 
@@ -334,7 +337,24 @@ func mainWorktreePath(worktrees []worktree.Worktree, fallback string) string {
 	return fallback
 }
 
-func printWorktree(exec *executor.Executor, wt worktree.Worktree) {
+type worktreeRow struct {
+	Worktree worktree.Worktree
+	Branch   string
+	Head     string
+	State    string
+	Modified string
+	Path     string
+}
+
+func buildWorktreeRows(exec *executor.Executor, worktrees []worktree.Worktree) []worktreeRow {
+	rows := make([]worktreeRow, 0, len(worktrees))
+	for _, wt := range worktrees {
+		rows = append(rows, buildWorktreeRow(exec, wt))
+	}
+	return rows
+}
+
+func buildWorktreeRow(exec *executor.Executor, wt worktree.Worktree) worktreeRow {
 	head := wt.Head
 	if len(head) > 7 {
 		head = head[:7]
@@ -351,7 +371,93 @@ func printWorktree(exec *executor.Executor, wt worktree.Worktree) {
 		modified = info.ModTime().Format("2006-01-02")
 	}
 
-	fmt.Printf("%s  %s  %s  %s  %s\n", worktreeLabel(wt), head, state, modified, wt.Path)
+	return worktreeRow{
+		Worktree: wt,
+		Branch:   worktreeLabel(wt),
+		Head:     head,
+		State:    state,
+		Modified: modified,
+		Path:     wt.Path,
+	}
+}
+
+func formatWorktreeRows(rows []worktreeRow, includeHeader bool) []string {
+	allRows := rows
+	if includeHeader {
+		allRows = append([]worktreeRow{{
+			Branch:   "BRANCH",
+			Head:     "HEAD",
+			State:    "STATE",
+			Modified: "MODIFIED",
+			Path:     "PATH",
+		}}, rows...)
+	}
+
+	branchWidth := len("BRANCH")
+	headWidth := len("HEAD")
+	stateWidth := len("STATE")
+	modifiedWidth := len("MODIFIED")
+	for _, row := range rows {
+		branchWidth = max(branchWidth, len(row.Branch))
+		headWidth = max(headWidth, len(row.Head))
+		stateWidth = max(stateWidth, len(row.State))
+		modifiedWidth = max(modifiedWidth, len(row.Modified))
+	}
+
+	lines := make([]string, 0, len(allRows))
+	for _, row := range allRows {
+		lines = append(lines, fmt.Sprintf(
+			"%-*s  %-*s  %-*s  %-*s  %s",
+			branchWidth, row.Branch,
+			headWidth, row.Head,
+			stateWidth, row.State,
+			modifiedWidth, row.Modified,
+			row.Path,
+		))
+	}
+	return lines
+}
+
+func worktreeCdCompletions(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	completions := []string{}
+	seen := map[string]bool{}
+	for _, wt := range worktrees {
+		for _, candidate := range worktreeCompletionCandidates(wt) {
+			if seen[candidate] || !strings.HasPrefix(candidate, toComplete) {
+				continue
+			}
+			seen[candidate] = true
+			completions = append(completions, fmt.Sprintf("%s\t%s", candidate, wt.Path))
+		}
+	}
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}
+
+func worktreeCompletionCandidates(wt worktree.Worktree) []string {
+	candidates := []string{}
+	if wt.Branch != "" {
+		candidates = append(candidates, wt.Branch)
+	}
+	base := filepath.Base(wt.Path)
+	candidates = append(candidates, base)
+	if name, ok := strings.CutPrefix(base, strings.Split(base, "--")[0]+"--"); ok {
+		candidates = append(candidates, name)
+	}
+	return candidates
 }
 
 func worktreeLabel(wt worktree.Worktree) string {

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sahilm/fuzzy"
+	"github.com/spf13/cobra"
+
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/integration"
+	"github.com/devbuddy/devbuddy/pkg/worktree"
+)
+
+var worktreeCmd = &cobra.Command{
+	Use:          "wt",
+	Aliases:      []string{"worktree"},
+	Short:        "Manage git worktrees",
+	GroupID:      "devbuddy",
+	SilenceUsage: true,
+}
+
+var worktreeListCmd = &cobra.Command{
+	Use:          "list [QUERY]",
+	Short:        "List git worktrees",
+	Args:         zeroOrOneArg,
+	RunE:         worktreeListRun,
+	SilenceUsage: true,
+}
+
+var worktreeNewCmd = &cobra.Command{
+	Use:          "new NAME [BRANCH]",
+	Short:        "Create a sibling git worktree",
+	Args:         oneOrTwoArgs,
+	RunE:         worktreeNewRun,
+	SilenceUsage: true,
+}
+
+var worktreeCdCmd = &cobra.Command{
+	Use:          "cd QUERY",
+	Short:        "Jump to a git worktree",
+	Args:         onlyOneArg,
+	RunE:         worktreeCdRun,
+	SilenceUsage: true,
+}
+
+var worktreeRemoveCmd = &cobra.Command{
+	Use:          "remove QUERY",
+	Short:        "Remove a git worktree",
+	Args:         onlyOneArg,
+	RunE:         worktreeRemoveRun,
+	SilenceUsage: true,
+}
+
+var worktreePruneCmd = &cobra.Command{
+	Use:          "prune",
+	Short:        "Prune stale git worktree metadata",
+	Args:         noArgs,
+	RunE:         worktreePruneRun,
+	SilenceUsage: true,
+}
+
+func init() {
+	worktreeCmd.AddCommand(worktreeListCmd)
+	worktreeCmd.AddCommand(worktreeNewCmd)
+	worktreeCmd.AddCommand(worktreeCdCmd)
+	worktreeCmd.AddCommand(worktreeRemoveCmd)
+	worktreeCmd.AddCommand(worktreePruneCmd)
+}
+
+func worktreeListRun(_ *cobra.Command, args []string) error {
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return err
+	}
+
+	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	if err != nil {
+		return err
+	}
+
+	query := ""
+	if len(args) == 1 {
+		query = args[0]
+	}
+
+	for _, wt := range matchWorktrees(worktrees, query) {
+		printWorktree(wt)
+	}
+	return nil
+}
+
+func worktreeNewRun(_ *cobra.Command, args []string) error {
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return err
+	}
+
+	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	branch := worktree.Slug(name)
+	if len(args) == 2 {
+		branch = args[1]
+	}
+	if branch == "" {
+		return fmt.Errorf("worktree branch must contain letters or numbers")
+	}
+
+	if conflict := worktree.CheckedOutBranch(worktrees, branch); conflict != nil {
+		return fmt.Errorf("branch %s is already checked out at %s\nRun: bud wt cd %s", branch, conflict.Path, branch)
+	}
+
+	repoPath := mainWorktreePath(worktrees, ctx.Project.Path)
+	path, err := worktree.ManagedPath(repoPath, name)
+	if err != nil {
+		return err
+	}
+
+	branchExists, err := worktree.BranchExists(ctx.Executor, repoPath, branch)
+	if err != nil {
+		return err
+	}
+
+	if branchExists {
+		err = worktree.AddExistingBranch(ctx.Executor, repoPath, path, branch)
+	} else {
+		err = worktree.AddNewBranch(ctx.Executor, repoPath, path, branch)
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("🐼  created worktree %s at %s\n", branch, path)
+	return nil
+}
+
+func worktreeCdRun(_ *cobra.Command, args []string) error {
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return err
+	}
+
+	wt, err := findWorktree(ctx.Executor, ctx.Project.Path, args[0])
+	if err != nil {
+		return err
+	}
+
+	ctx.UI.JumpProject(worktreeLabel(wt))
+	return integration.AddFinalizerCd(wt.Path)
+}
+
+func worktreeRemoveRun(_ *cobra.Command, args []string) error {
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return err
+	}
+
+	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	if err != nil {
+		return err
+	}
+	matches := matchWorktrees(worktrees, args[0])
+	if len(matches) == 0 {
+		return fmt.Errorf("no worktree found for %s", args[0])
+	}
+
+	wt := matches[0]
+	repoPath := mainWorktreePath(worktrees, ctx.Project.Path)
+	if filepath.Clean(wt.Path) == filepath.Clean(repoPath) {
+		return fmt.Errorf("refusing to remove the main worktree: %s", wt.Path)
+	}
+
+	if err := worktree.Remove(ctx.Executor, ctx.Project.Path, wt.Path); err != nil {
+		return err
+	}
+
+	fmt.Printf("🐼  removed worktree %s\n", wt.Path)
+	return nil
+}
+
+func worktreePruneRun(_ *cobra.Command, _ []string) error {
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return err
+	}
+
+	if err := worktree.Prune(ctx.Executor, ctx.Project.Path); err != nil {
+		return err
+	}
+
+	fmt.Println("🐼  pruned stale worktree metadata")
+	return nil
+}
+
+func oneOrTwoArgs(_ *cobra.Command, args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return fmt.Errorf("expecting one or two arguments")
+	}
+	return nil
+}
+
+func findWorktree(exec *executor.Executor, repoPath, query string) (worktree.Worktree, error) {
+	worktrees, err := worktree.List(exec, repoPath)
+	if err != nil {
+		return worktree.Worktree{}, err
+	}
+
+	matches := matchWorktrees(worktrees, query)
+	if len(matches) == 0 {
+		return worktree.Worktree{}, fmt.Errorf("no worktree found for %s", query)
+	}
+	return matches[0], nil
+}
+
+func matchWorktrees(worktrees []worktree.Worktree, query string) []worktree.Worktree {
+	if query == "" {
+		return worktrees
+	}
+
+	for _, wt := range worktrees {
+		if worktreeExactMatch(wt, query) {
+			return []worktree.Worktree{wt}
+		}
+	}
+
+	index := make([]string, 0, len(worktrees))
+	for _, wt := range worktrees {
+		index = append(index, worktreeLabel(wt)+" "+filepath.Base(wt.Path))
+	}
+
+	matches := fuzzy.Find(query, index)
+	found := make([]worktree.Worktree, 0, matches.Len())
+	for _, match := range matches {
+		found = append(found, worktrees[match.Index])
+	}
+	return found
+}
+
+func worktreeExactMatch(wt worktree.Worktree, query string) bool {
+	base := filepath.Base(wt.Path)
+	return wt.Branch == query || base == query || strings.HasSuffix(base, "--"+query)
+}
+
+func mainWorktreePath(worktrees []worktree.Worktree, fallback string) string {
+	for _, wt := range worktrees {
+		if !wt.Bare {
+			return wt.Path
+		}
+	}
+	return fallback
+}
+
+func printWorktree(wt worktree.Worktree) {
+	head := wt.Head
+	if len(head) > 7 {
+		head = head[:7]
+	}
+
+	fmt.Printf("%s  %s  %s\n", worktreeLabel(wt), head, wt.Path)
+}
+
+func worktreeLabel(wt worktree.Worktree) string {
+	if wt.Branch != "" {
+		return wt.Branch
+	}
+	if wt.Detached {
+		return "detached"
+	}
+	return strings.TrimPrefix(filepath.Base(wt.Path), filepath.Base(filepath.Dir(wt.Path))+"--")
+}

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/manifoldco/promptui"
 	"github.com/sahilm/fuzzy"
 	"github.com/spf13/cobra"
 
@@ -15,8 +17,8 @@ import (
 )
 
 var worktreeCmd = &cobra.Command{
-	Use:          "wt",
-	Aliases:      []string{"worktree"},
+	Use:          "tree",
+	Aliases:      []string{"wt", "worktree"},
 	Short:        "Manage git worktrees",
 	GroupID:      "devbuddy",
 	SilenceUsage: true,
@@ -46,6 +48,14 @@ var worktreeCdCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
+var worktreeSwitchCmd = &cobra.Command{
+	Use:          "switch [QUERY]",
+	Short:        "Select and jump to a git worktree",
+	Args:         zeroOrOneArg,
+	RunE:         worktreeSwitchRun,
+	SilenceUsage: true,
+}
+
 var worktreeRemoveCmd = &cobra.Command{
 	Use:          "remove QUERY",
 	Short:        "Remove a git worktree",
@@ -66,6 +76,7 @@ func init() {
 	worktreeCmd.AddCommand(worktreeListCmd)
 	worktreeCmd.AddCommand(worktreeNewCmd)
 	worktreeCmd.AddCommand(worktreeCdCmd)
+	worktreeCmd.AddCommand(worktreeSwitchCmd)
 	worktreeCmd.AddCommand(worktreeRemoveCmd)
 	worktreeCmd.AddCommand(worktreePruneCmd)
 }
@@ -87,7 +98,7 @@ func worktreeListRun(_ *cobra.Command, args []string) error {
 	}
 
 	for _, wt := range matchWorktrees(worktrees, query) {
-		printWorktree(wt)
+		printWorktree(ctx.Executor, wt)
 	}
 	return nil
 }
@@ -113,7 +124,7 @@ func worktreeNewRun(_ *cobra.Command, args []string) error {
 	}
 
 	if conflict := worktree.CheckedOutBranch(worktrees, branch); conflict != nil {
-		return fmt.Errorf("branch %s is already checked out at %s\nRun: bud wt cd %s", branch, conflict.Path, branch)
+		return fmt.Errorf("branch %s is already checked out at %s\nRun: bud tree cd %s", branch, conflict.Path, branch)
 	}
 
 	repoPath := mainWorktreePath(worktrees, ctx.Project.Path)
@@ -149,6 +160,40 @@ func worktreeCdRun(_ *cobra.Command, args []string) error {
 	wt, err := findWorktree(ctx.Executor, ctx.Project.Path, args[0])
 	if err != nil {
 		return err
+	}
+
+	ctx.UI.JumpProject(worktreeLabel(wt))
+	return integration.AddFinalizerCd(wt.Path)
+}
+
+func worktreeSwitchRun(_ *cobra.Command, args []string) error {
+	ctx, err := context.LoadWithProject()
+	if err != nil {
+		return err
+	}
+
+	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	if err != nil {
+		return err
+	}
+
+	query := ""
+	if len(args) == 1 {
+		query = args[0]
+	}
+
+	matches := matchWorktrees(worktrees, query)
+	if len(matches) == 0 {
+		return fmt.Errorf("no worktree found for %s", query)
+	}
+
+	wt := matches[0]
+	if query == "" && len(matches) > 1 {
+		selected, err := selectWorktree(matches)
+		if err != nil {
+			return err
+		}
+		wt = selected
 	}
 
 	ctx.UI.JumpProject(worktreeLabel(wt))
@@ -218,6 +263,39 @@ func findWorktree(exec *executor.Executor, repoPath, query string) (worktree.Wor
 	return matches[0], nil
 }
 
+type switchItem struct {
+	Label    string
+	Worktree worktree.Worktree
+}
+
+func selectWorktree(worktrees []worktree.Worktree) (worktree.Worktree, error) {
+	items := make([]switchItem, 0, len(worktrees))
+	for _, wt := range worktrees {
+		items = append(items, switchItem{
+			Label:    fmt.Sprintf("%s  %s", worktreeLabel(wt), wt.Path),
+			Worktree: wt,
+		})
+	}
+
+	prompt := promptui.Select{
+		Label:        "Select worktree",
+		Items:        items,
+		HideSelected: true,
+		Templates: &promptui.SelectTemplates{
+			Label:    "{{ . }}",
+			Active:   "🐼 {{ .Label | cyan }}",
+			Inactive: "  {{ .Label }}",
+			Selected: "🐼 {{ .Label }}",
+		},
+	}
+
+	index, _, err := prompt.Run()
+	if err != nil {
+		return worktree.Worktree{}, err
+	}
+	return items[index].Worktree, nil
+}
+
 func matchWorktrees(worktrees []worktree.Worktree, query string) []worktree.Worktree {
 	if query == "" {
 		return worktrees
@@ -256,13 +334,24 @@ func mainWorktreePath(worktrees []worktree.Worktree, fallback string) string {
 	return fallback
 }
 
-func printWorktree(wt worktree.Worktree) {
+func printWorktree(exec *executor.Executor, wt worktree.Worktree) {
 	head := wt.Head
 	if len(head) > 7 {
 		head = head[:7]
 	}
 
-	fmt.Printf("%s  %s  %s\n", worktreeLabel(wt), head, wt.Path)
+	state := "clean"
+	dirty, err := worktree.IsDirty(exec, wt.Path)
+	if err == nil && dirty {
+		state = "dirty"
+	}
+
+	modified := "unknown"
+	if info, err := os.Stat(wt.Path); err == nil {
+		modified = info.ModTime().Format("2006-01-02")
+	}
+
+	fmt.Printf("%s  %s  %s  %s  %s\n", worktreeLabel(wt), head, state, modified, wt.Path)
 }
 
 func worktreeLabel(wt worktree.Worktree) string {

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -284,12 +284,7 @@ func selectWorktree(exec *executor.Executor, worktrees []worktree.Worktree) (wor
 		Label:        "Select worktree",
 		Items:        items,
 		HideSelected: true,
-		Templates: &promptui.SelectTemplates{
-			Label:    "{{ . }}",
-			Active:   "🐼 {{ .Label | cyan }}",
-			Inactive: "  {{ .Label }}",
-			Selected: "🐼 {{ .Label }}",
-		},
+		Templates:    worktreeSwitchTemplates(),
 	}
 
 	index, _, err := prompt.Run()
@@ -297,6 +292,15 @@ func selectWorktree(exec *executor.Executor, worktrees []worktree.Worktree) (wor
 		return worktree.Worktree{}, err
 	}
 	return items[index].Worktree, nil
+}
+
+func worktreeSwitchTemplates() *promptui.SelectTemplates {
+	return &promptui.SelectTemplates{
+		Label:    "{{ . }}",
+		Active:   "🐼 {{ .Label | cyan }}",
+		Inactive: "   {{ .Label }}",
+		Selected: "🐼 {{ .Label }}",
+	}
 }
 
 func matchWorktrees(worktrees []worktree.Worktree, query string) []worktree.Worktree {

--- a/pkg/cmd/worktree_test.go
+++ b/pkg/cmd/worktree_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/devbuddy/devbuddy/pkg/worktree"
+)
+
+func TestFormatWorktreeRowsAlignsColumns(t *testing.T) {
+	rows := []worktreeRow{
+		{
+			Worktree: worktree.Worktree{Path: "/src/github.com/acme/api", Branch: "main"},
+			Branch:   "main",
+			Head:     "1111111",
+			State:    "clean",
+			Modified: "2026-05-15",
+		},
+		{
+			Worktree: worktree.Worktree{Path: "/src/github.com/acme/api--agent-1", Branch: "long-feature-branch"},
+			Branch:   "long-feature-branch",
+			Head:     "2222222",
+			State:    "dirty",
+			Modified: "2026-05-15",
+		},
+	}
+
+	lines := formatWorktreeRows(rows, false)
+
+	require.Len(t, lines, 2)
+	require.Equal(t, strings.Index(lines[0], "/src/"), strings.Index(lines[1], "/src/"))
+	require.Contains(t, lines[0], "main")
+	require.Contains(t, lines[1], "long-feature-branch")
+}

--- a/pkg/cmd/worktree_test.go
+++ b/pkg/cmd/worktree_test.go
@@ -34,3 +34,10 @@ func TestFormatWorktreeRowsAlignsColumns(t *testing.T) {
 	require.Contains(t, lines[0], "main")
 	require.Contains(t, lines[1], "long-feature-branch")
 }
+
+func TestWorktreeSwitchMenuTemplateAlignsInactiveRowsWithPandaMarker(t *testing.T) {
+	templates := worktreeSwitchTemplates()
+
+	require.Equal(t, "🐼 {{ .Label | cyan }}", templates.Active)
+	require.Equal(t, "   {{ .Label }}", templates.Inactive)
+}

--- a/pkg/cmd/worktree_test.go
+++ b/pkg/cmd/worktree_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -40,4 +43,27 @@ func TestWorktreeSwitchMenuTemplateAlignsInactiveRowsWithPandaMarker(t *testing.
 
 	require.Equal(t, "🐼 {{ .Label | cyan }}", templates.Active)
 	require.Equal(t, "   {{ .Label }}", templates.Inactive)
+}
+
+func TestInactiveWorktreesSkipsMainAndRecentWorktrees(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "api")
+	oldPath := filepath.Join(dir, "api--old")
+	recentPath := filepath.Join(dir, "api--recent")
+	require.NoError(t, os.Mkdir(mainPath, 0755))
+	require.NoError(t, os.Mkdir(oldPath, 0755))
+	require.NoError(t, os.Mkdir(recentPath, 0755))
+
+	now := time.Date(2026, 5, 15, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, os.Chtimes(mainPath, now.Add(-14*24*time.Hour), now.Add(-14*24*time.Hour)))
+	require.NoError(t, os.Chtimes(oldPath, now.Add(-8*24*time.Hour), now.Add(-8*24*time.Hour)))
+	require.NoError(t, os.Chtimes(recentPath, now.Add(-2*24*time.Hour), now.Add(-2*24*time.Hour)))
+
+	got := inactiveWorktrees([]worktree.Worktree{
+		{Path: mainPath, Branch: "main"},
+		{Path: oldPath, Branch: "old"},
+		{Path: recentPath, Branch: "recent"},
+	}, now, 7*24*time.Hour)
+
+	require.Equal(t, []worktree.Worktree{{Path: oldPath, Branch: "old"}}, got)
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -13,8 +13,9 @@ import (
 
 // Project represents a project whether it exists locally or not
 type Project struct {
-	hosting *hostingInfo
-	Path    string // Local path of this project on disk
+	hosting        *hostingInfo
+	Path           string // Local path of this project on disk
+	WorktreeBranch string
 }
 
 // NewFromID creates an instance of Project from a short id like "org/name" or "name"
@@ -54,6 +55,9 @@ func (p *Project) Name() string {
 
 // FullName returns a logical id like platform:org/project
 func (p *Project) FullName() string {
+	if p.WorktreeBranch != "" {
+		return fmt.Sprintf("%s:%s/%s [%s]", p.hosting.platform, p.hosting.organisation, p.hosting.repository, p.WorktreeBranch)
+	}
 	return fmt.Sprintf("%s:%s/%s", p.hosting.platform, p.hosting.organisation, p.hosting.repository)
 }
 

--- a/pkg/project/search.go
+++ b/pkg/project/search.go
@@ -3,12 +3,14 @@ package project
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/sahilm/fuzzy"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
 	"github.com/devbuddy/devbuddy/pkg/utils"
+	wt "github.com/devbuddy/devbuddy/pkg/worktree"
 )
 
 func FindBestMatch(expr string, cfg *config.Config) (found *Project, err error) {
@@ -30,6 +32,9 @@ func FindBestMatch(expr string, cfg *config.Config) (found *Project, err error) 
 	}
 
 	found = projectMatch(expr, projects)
+	if found == nil {
+		found = worktreeMatch(expr, projects)
+	}
 	if found == nil {
 		err = fmt.Errorf("no project found for %s", expr)
 	}
@@ -67,6 +72,65 @@ func projectMatch(expr string, projects []*Project) *Project {
 	}
 
 	return nil
+}
+
+func worktreeMatch(expr string, projects []*Project) *Project {
+	type candidate struct {
+		project *Project
+		branch  string
+	}
+
+	candidatesByPath := map[string]candidate{}
+	for _, p := range projects {
+		output, err := exec.Command("git", "-C", p.Path, "worktree", "list", "--porcelain").Output()
+		if err != nil {
+			continue
+		}
+
+		worktrees, err := wt.ParseListPorcelain(string(output))
+		if err != nil {
+			continue
+		}
+
+		for _, worktree := range worktrees {
+			if worktree.Branch == "" {
+				continue
+			}
+
+			c := candidate{
+				project: projectFromWorktree(p, worktree.Path, worktree.Branch),
+				branch:  worktree.Branch,
+			}
+			if worktree.Branch == expr {
+				return c.project
+			}
+			candidatesByPath[worktree.Path] = c
+		}
+	}
+
+	candidates := make([]candidate, 0, len(candidatesByPath))
+	index := make([]string, 0, len(candidatesByPath))
+	for _, c := range candidatesByPath {
+		candidates = append(candidates, c)
+		index = append(index, c.branch)
+	}
+
+	matches := fuzzy.Find(expr, index)
+	if matches.Len() >= 1 {
+		return candidates[matches[0].Index].project
+	}
+
+	return nil
+}
+
+func projectFromWorktree(base *Project, path string, branch string) *Project {
+	hosting := *base.hosting
+	hosting.repository = filepath.Base(path)
+	return &Project{
+		hosting:        &hosting,
+		Path:           path,
+		WorktreeBranch: branch,
+	}
 }
 
 func getAllProjects(sourceDir string) ([]*Project, error) {

--- a/pkg/worktree/git.go
+++ b/pkg/worktree/git.go
@@ -1,0 +1,55 @@
+package worktree
+
+import (
+	"github.com/devbuddy/devbuddy/pkg/executor"
+)
+
+func List(exec *executor.Executor, repoPath string) ([]Worktree, error) {
+	cmd := executor.New("git", "worktree", "list", "--porcelain")
+	cmd.Cwd = repoPath
+
+	result := exec.Capture(cmd)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return ParseListPorcelain(result.Output)
+}
+
+func AddNewBranch(exec *executor.Executor, repoPath, path, branch string) error {
+	cmd := executor.New("git", "worktree", "add", "-b", branch, path)
+	cmd.Cwd = repoPath
+	return exec.Run(cmd).Error
+}
+
+func AddExistingBranch(exec *executor.Executor, repoPath, path, branch string) error {
+	cmd := executor.New("git", "worktree", "add", path, branch)
+	cmd.Cwd = repoPath
+	return exec.Run(cmd).Error
+}
+
+func Remove(exec *executor.Executor, repoPath, path string) error {
+	cmd := executor.New("git", "worktree", "remove", path)
+	cmd.Cwd = repoPath
+	return exec.Run(cmd).Error
+}
+
+func Prune(exec *executor.Executor, repoPath string) error {
+	cmd := executor.New("git", "worktree", "prune")
+	cmd.Cwd = repoPath
+	return exec.Run(cmd).Error
+}
+
+func BranchExists(exec *executor.Executor, repoPath, branch string) (bool, error) {
+	cmd := executor.New("git", "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	cmd.Cwd = repoPath
+
+	result := exec.Run(cmd)
+	if result.Code == 1 {
+		return false, nil
+	}
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return true, nil
+}

--- a/pkg/worktree/git.go
+++ b/pkg/worktree/git.go
@@ -1,6 +1,8 @@
 package worktree
 
 import (
+	"strings"
+
 	"github.com/devbuddy/devbuddy/pkg/executor"
 )
 
@@ -52,4 +54,15 @@ func BranchExists(exec *executor.Executor, repoPath, branch string) (bool, error
 		return false, result.Error
 	}
 	return true, nil
+}
+
+func IsDirty(exec *executor.Executor, path string) (bool, error) {
+	cmd := executor.New("git", "status", "--short")
+	cmd.Cwd = path
+
+	result := exec.Capture(cmd)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return strings.TrimSpace(result.Output) != "", nil
 }

--- a/pkg/worktree/git_test.go
+++ b/pkg/worktree/git_test.go
@@ -65,3 +65,17 @@ func TestAddExistingBranchBuildsGitCommand(t *testing.T) {
 	require.Equal(t, []string{"worktree", "add", "/src/github.com/acme/api--feature-a", "feature-a"}, runner.runCmds[0].Args)
 	require.Equal(t, "/src/github.com/acme/api", runner.runCmds[0].Cwd)
 }
+
+func TestIsDirtyRunsGitStatusShort(t *testing.T) {
+	runner := &runnerSpy{output: " M README.md\n"}
+	exec := &executor.Executor{Runner: runner}
+
+	got, err := IsDirty(exec, "/src/github.com/acme/api--feature-a")
+
+	require.NoError(t, err)
+	require.True(t, got)
+	require.Len(t, runner.captureCmds, 1)
+	require.Equal(t, "git", runner.captureCmds[0].Program)
+	require.Equal(t, []string{"status", "--short"}, runner.captureCmds[0].Args)
+	require.Equal(t, "/src/github.com/acme/api--feature-a", runner.captureCmds[0].Cwd)
+}

--- a/pkg/worktree/git_test.go
+++ b/pkg/worktree/git_test.go
@@ -1,0 +1,67 @@
+package worktree
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/devbuddy/devbuddy/pkg/executor"
+)
+
+type runnerSpy struct {
+	runCmds     []*executor.Command
+	captureCmds []*executor.Command
+	output      string
+}
+
+func (s *runnerSpy) Run(cmd *executor.Command) *executor.Result {
+	s.runCmds = append(s.runCmds, cmd)
+	return &executor.Result{}
+}
+
+func (s *runnerSpy) Capture(cmd *executor.Command) *executor.Result {
+	s.captureCmds = append(s.captureCmds, cmd)
+	return &executor.Result{Output: s.output}
+}
+
+func TestListRunsGitWorktreeListPorcelain(t *testing.T) {
+	runner := &runnerSpy{
+		output: "worktree /src/github.com/acme/api\nHEAD 1111111111111111111111111111111111111111\nbranch refs/heads/main\n",
+	}
+	exec := &executor.Executor{Runner: runner}
+
+	got, err := List(exec, "/src/github.com/acme/api")
+
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "main", got[0].Branch)
+	require.Len(t, runner.captureCmds, 1)
+	require.Equal(t, "git", runner.captureCmds[0].Program)
+	require.Equal(t, []string{"worktree", "list", "--porcelain"}, runner.captureCmds[0].Args)
+	require.Equal(t, "/src/github.com/acme/api", runner.captureCmds[0].Cwd)
+}
+
+func TestAddNewBranchBuildsGitCommand(t *testing.T) {
+	runner := &runnerSpy{}
+	exec := &executor.Executor{Runner: runner}
+
+	err := AddNewBranch(exec, "/src/github.com/acme/api", "/src/github.com/acme/api--feature-a", "feature-a")
+
+	require.NoError(t, err)
+	require.Len(t, runner.runCmds, 1)
+	require.Equal(t, "git", runner.runCmds[0].Program)
+	require.Equal(t, []string{"worktree", "add", "-b", "feature-a", "/src/github.com/acme/api--feature-a"}, runner.runCmds[0].Args)
+	require.Equal(t, "/src/github.com/acme/api", runner.runCmds[0].Cwd)
+}
+
+func TestAddExistingBranchBuildsGitCommand(t *testing.T) {
+	runner := &runnerSpy{}
+	exec := &executor.Executor{Runner: runner}
+
+	err := AddExistingBranch(exec, "/src/github.com/acme/api", "/src/github.com/acme/api--feature-a", "feature-a")
+
+	require.NoError(t, err)
+	require.Len(t, runner.runCmds, 1)
+	require.Equal(t, []string{"worktree", "add", "/src/github.com/acme/api--feature-a", "feature-a"}, runner.runCmds[0].Args)
+	require.Equal(t, "/src/github.com/acme/api", runner.runCmds[0].Cwd)
+}

--- a/pkg/worktree/worktree.go
+++ b/pkg/worktree/worktree.go
@@ -1,0 +1,111 @@
+package worktree
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"unicode"
+)
+
+// Worktree is one record from `git worktree list --porcelain`.
+type Worktree struct {
+	Path     string
+	Head     string
+	Branch   string
+	Detached bool
+	Bare     bool
+}
+
+func ParseListPorcelain(output string) ([]Worktree, error) {
+	var worktrees []Worktree
+	var current *Worktree
+
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			if current != nil {
+				worktrees = append(worktrees, *current)
+				current = nil
+			}
+			continue
+		}
+
+		key, value, _ := strings.Cut(line, " ")
+		switch key {
+		case "worktree":
+			if current != nil {
+				worktrees = append(worktrees, *current)
+			}
+			if value == "" {
+				return nil, fmt.Errorf("invalid git worktree record: missing path")
+			}
+			current = &Worktree{Path: value}
+		case "HEAD":
+			if current == nil {
+				return nil, fmt.Errorf("invalid git worktree record: HEAD before worktree")
+			}
+			current.Head = value
+		case "branch":
+			if current == nil {
+				return nil, fmt.Errorf("invalid git worktree record: branch before worktree")
+			}
+			current.Branch = strings.TrimPrefix(value, "refs/heads/")
+		case "detached":
+			if current == nil {
+				return nil, fmt.Errorf("invalid git worktree record: detached before worktree")
+			}
+			current.Detached = true
+		case "bare":
+			if current == nil {
+				return nil, fmt.Errorf("invalid git worktree record: bare before worktree")
+			}
+			current.Bare = true
+		}
+	}
+
+	if current != nil {
+		worktrees = append(worktrees, *current)
+	}
+
+	return worktrees, nil
+}
+
+func ManagedPath(repoPath, name string) (string, error) {
+	slug := Slug(name)
+	if slug == "" {
+		return "", fmt.Errorf("worktree name must contain letters or numbers")
+	}
+
+	return filepath.Join(filepath.Dir(repoPath), filepath.Base(repoPath)+"--"+slug), nil
+}
+
+func Slug(name string) string {
+	var b strings.Builder
+	lastDash := false
+
+	for _, r := range strings.TrimSpace(name) {
+		keep := unicode.IsLetter(r) || unicode.IsNumber(r) || r == '.' || r == '_'
+		if keep {
+			b.WriteRune(r)
+			lastDash = false
+			continue
+		}
+
+		if !lastDash {
+			b.WriteRune('-')
+			lastDash = true
+		}
+	}
+
+	return strings.Trim(b.String(), "-")
+}
+
+func CheckedOutBranch(worktrees []Worktree, branch string) *Worktree {
+	branch = strings.TrimPrefix(branch, "refs/heads/")
+	for i := range worktrees {
+		if worktrees[i].Branch == branch {
+			return &worktrees[i]
+		}
+	}
+	return nil
+}

--- a/pkg/worktree/worktree_test.go
+++ b/pkg/worktree/worktree_test.go
@@ -1,0 +1,56 @@
+package worktree
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseListPorcelain(t *testing.T) {
+	input := `worktree /src/github.com/acme/api
+HEAD 1111111111111111111111111111111111111111
+branch refs/heads/main
+
+worktree /src/github.com/acme/api--feature-a
+HEAD 2222222222222222222222222222222222222222
+branch refs/heads/feature-a
+
+worktree /src/github.com/acme/api--detached
+HEAD 3333333333333333333333333333333333333333
+detached
+`
+
+	got, err := ParseListPorcelain(input)
+
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	require.Equal(t, "/src/github.com/acme/api", got[0].Path)
+	require.Equal(t, "1111111111111111111111111111111111111111", got[0].Head)
+	require.Equal(t, "main", got[0].Branch)
+	require.False(t, got[0].Detached)
+	require.Equal(t, "/src/github.com/acme/api--detached", got[2].Path)
+	require.Equal(t, "3333333333333333333333333333333333333333", got[2].Head)
+	require.Empty(t, got[2].Branch)
+	require.True(t, got[2].Detached)
+}
+
+func TestManagedPath(t *testing.T) {
+	got, err := ManagedPath("/src/github.com/acme/api", "feature/login flow")
+
+	require.NoError(t, err)
+	require.Equal(t, filepath.Clean("/src/github.com/acme/api--feature-login-flow"), got)
+}
+
+func TestCheckedOutBranch(t *testing.T) {
+	worktrees := []Worktree{
+		{Path: "/src/github.com/acme/api", Branch: "main"},
+		{Path: "/src/github.com/acme/api--feature-a", Branch: "feature-a"},
+	}
+
+	got := CheckedOutBranch(worktrees, "feature-a")
+
+	require.NotNil(t, got)
+	require.Equal(t, "/src/github.com/acme/api--feature-a", got.Path)
+	require.Nil(t, CheckedOutBranch(worktrees, "missing"))
+}

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -220,10 +220,14 @@ func (c *TestContext) Write(t *testing.T, path, content string) {
 	t.Helper()
 
 	if hostPath, ok := c.hostPath(t, path); ok {
-		err := os.MkdirAll(filepath.Dir(hostPath), 0755)
+		dirPath := filepath.Dir(hostPath)
+		err := os.MkdirAll(dirPath, 0777)
 		require.NoError(t, err)
-		err = os.Chmod(filepath.Dir(hostPath), 0777)
-		require.NoError(t, err)
+		// chmod each directory from the leaf up to the workspace root so the
+		// container user can create sibling directories alongside host-created ones.
+		for current := dirPath; current != c.workspaceHostPath; current = filepath.Dir(current) {
+			require.NoError(t, os.Chmod(current, 0777))
+		}
 
 		err = os.WriteFile(hostPath, []byte(content), 0644)
 		require.NoError(t, err)
@@ -334,7 +338,7 @@ func (c *TestContext) WaitPrompt(t *testing.T) []string {
 		line, err := c.expect.Line()
 		require.NoError(t, err)
 
-		line = strings.Replace(line, "\r", "", -1)
+		line = strings.ReplaceAll(line, "\r", "")
 		if line == "##\n" {
 			return StripAnsiSlice(output)
 		}

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -314,6 +314,34 @@ func (c *TestContext) hostPath(t *testing.T, containerPath string) (string, bool
 	return filepath.Join(c.workspaceHostPath, filepath.FromSlash(relPath)), true
 }
 
+func (c *TestContext) Send(t *testing.T, text string) {
+	t.Helper()
+	err := c.expect.Send(text)
+	require.NoError(t, err)
+}
+
+func (c *TestContext) Expect(t *testing.T, text string) string {
+	t.Helper()
+	line, err := c.expect.Expect(text)
+	require.NoError(t, err)
+	return StripAnsi(line)
+}
+
+func (c *TestContext) WaitPrompt(t *testing.T) []string {
+	t.Helper()
+	var output []string
+	for {
+		line, err := c.expect.Line()
+		require.NoError(t, err)
+
+		line = strings.Replace(line, "\r", "", -1)
+		if line == "##\n" {
+			return StripAnsiSlice(output)
+		}
+		output = append(output, strings.TrimSuffix(line, "\n"))
+	}
+}
+
 func (c *TestContext) debugLine(format string, a ...any) {
 	if c.debug {
 		format = strings.TrimSuffix(format, "\n") + "\n"

--- a/tests/context/context.go
+++ b/tests/context/context.go
@@ -221,17 +221,18 @@ func (c *TestContext) Write(t *testing.T, path, content string) {
 
 	if hostPath, ok := c.hostPath(t, path); ok {
 		dirPath := filepath.Dir(hostPath)
-		err := os.MkdirAll(dirPath, 0777)
-		require.NoError(t, err)
-		// chmod each directory from the leaf up to the workspace root so the
-		// container user can create sibling directories alongside host-created ones.
-		for current := dirPath; current != c.workspaceHostPath; current = filepath.Dir(current) {
-			require.NoError(t, os.Chmod(current, 0777))
+		if err := os.MkdirAll(dirPath, 0777); err == nil {
+			// chmod each dir from the leaf up to the workspace root so the container
+			// user can create siblings. May fail for container-created dirs (different
+			// owner on Linux) — best-effort only.
+			for current := dirPath; current != c.workspaceHostPath; current = filepath.Dir(current) {
+				_ = os.Chmod(current, 0777)
+			}
+			if err := os.WriteFile(hostPath, []byte(content), 0644); err == nil {
+				return
+			}
 		}
-
-		err = os.WriteFile(hostPath, []byte(content), 0644)
-		require.NoError(t, err)
-		return
+		// Fall through: directory owned by container user (Linux CI) — write via shell.
 	}
 
 	b64content := base64.StdEncoding.EncodeToString([]byte(content))

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -62,7 +62,7 @@ func Test_Cmd_Tree_Cd_Matches_Branch_When_Different_From_Worktree_Name(t *testin
 }
 
 func Test_Cmd_Tree_Switch_Interactive(t *testing.T) {
-	c := CreateContextAndInit(t)
+	c := CreatePTYContextAndInit(t)
 	projectPath := "/home/tester/src/github.com/orgname/projname"
 	worktreePath := "/home/tester/src/github.com/orgname/projname--feature-a"
 
@@ -92,7 +92,7 @@ func Test_Cmd_Tree_BranchConflict(t *testing.T) {
 }
 
 func Test_Cmd_Tree_Prune_Asks_To_Delete_Inactive_Worktrees(t *testing.T) {
-	c := CreateContextAndInit(t)
+	c := CreatePTYContextAndInit(t)
 	projectPath := "/home/tester/src/github.com/orgname/projname"
 	oldWorktreePath := "/home/tester/src/github.com/orgname/projname--old-branch"
 	recentWorktreePath := "/home/tester/src/github.com/orgname/projname--recent-branch"
@@ -146,15 +146,16 @@ func assertPathColumnAligned(t *testing.T, lines []string) {
 func createGitProject(t *testing.T, c *testcontext.TestContext, path string) {
 	t.Helper()
 
-	c.Run(t, "mkdir -p "+path)
-	c.Run(t, "git -C "+path+" init")
-	c.Run(t, "git -C "+path+" checkout -b main")
-	c.Run(t, "git -C "+path+" config user.email tester@example.com")
-	c.Run(t, "git -C "+path+" config user.name Tester")
+	// Write via host path first so the directory is created with host-side
+	// ownership before the container touches it (avoids chmod permission errors).
 	c.WriteLines(t, path+"/dev.yml",
 		"commands:",
 		"  where: pwd > pwd.txt",
 	)
+	c.Run(t, "git -C "+path+" init")
+	c.Run(t, "git -C "+path+" checkout -b main")
+	c.Run(t, "git -C "+path+" config user.email tester@example.com")
+	c.Run(t, "git -C "+path+" config user.name Tester")
 	c.Run(t, "git -C "+path+" add dev.yml")
 	c.Run(t, "git -C "+path+" commit -m init")
 }

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -15,34 +15,72 @@ func Test_Cmd_Worktree_New_And_Cd(t *testing.T) {
 	createGitProject(t, c, projectPath)
 	c.Cd(t, projectPath)
 
-	output := c.Run(t, "bud wt new feature-a")
+	output := c.Run(t, "bud tree new feature-a")
 	OutputContains(t, output, "created worktree", "feature-a", worktreePath)
 	c.AssertExist(t, worktreePath+"/dev.yml")
 
 	branch := c.Run(t, "git -C "+worktreePath+" branch --show-current")
 	require.Equal(t, []string{"feature-a"}, branch)
 
+	c.Write(t, worktreePath+"/scratch.txt", "dirty\n")
+	output = c.Run(t, "bud tree list feature-a")
+	OutputContains(t, output, "feature-a", "dirty", worktreePath)
+
 	output = c.Run(t, "bud cd feature-a")
 	OutputContains(t, output, "jumping to", "projname--feature-a")
 	require.Equal(t, worktreePath, c.Cwd(t))
 
 	c.Cd(t, projectPath)
-	output = c.Run(t, "bud wt cd feature-a")
+	output = c.Run(t, "bud tree cd feature-a")
+	OutputContains(t, output, "jumping to", "feature-a")
+	require.Equal(t, worktreePath, c.Cwd(t))
+
+	c.Run(t, "bud where")
+	c.AssertContains(t, worktreePath+"/pwd.txt", worktreePath)
+}
+
+func Test_Cmd_Tree_Cd_Matches_Branch_When_Different_From_Worktree_Name(t *testing.T) {
+	c := CreateContextAndInit(t)
+	projectPath := "/home/tester/src/github.com/orgname/projname"
+	worktreePath := "/home/tester/src/github.com/orgname/projname--agent-1"
+
+	createGitProject(t, c, projectPath)
+	c.Cd(t, projectPath)
+	c.Run(t, "bud tree new agent-1 feature-a")
+
+	output := c.Run(t, "bud cd feature-a")
 	OutputContains(t, output, "jumping to", "feature-a")
 	require.Equal(t, worktreePath, c.Cwd(t))
 }
 
-func Test_Cmd_Worktree_BranchConflict(t *testing.T) {
+func Test_Cmd_Tree_Switch_Interactive(t *testing.T) {
 	c := CreateContextAndInit(t)
 	projectPath := "/home/tester/src/github.com/orgname/projname"
 	worktreePath := "/home/tester/src/github.com/orgname/projname--feature-a"
 
 	createGitProject(t, c, projectPath)
 	c.Cd(t, projectPath)
-	c.Run(t, "bud wt new feature-a")
+	c.Run(t, "bud tree new feature-a")
 
-	output := c.Run(t, "bud wt new duplicate feature-a", testcontext.ExitCode(1))
-	OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud wt cd feature-a")
+	c.Send(t, "bud tree switch\n")
+	c.Expect(t, "Select worktree")
+	c.Send(t, "\x1b[B\r")
+	c.WaitPrompt(t)
+
+	require.Equal(t, worktreePath, c.Cwd(t))
+}
+
+func Test_Cmd_Tree_BranchConflict(t *testing.T) {
+	c := CreateContextAndInit(t)
+	projectPath := "/home/tester/src/github.com/orgname/projname"
+	worktreePath := "/home/tester/src/github.com/orgname/projname--feature-a"
+
+	createGitProject(t, c, projectPath)
+	c.Cd(t, projectPath)
+	c.Run(t, "bud tree new feature-a")
+
+	output := c.Run(t, "bud tree new duplicate feature-a", testcontext.ExitCode(1))
+	OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud tree cd feature-a")
 }
 
 func createGitProject(t *testing.T, c *testcontext.TestContext, path string) {
@@ -53,7 +91,10 @@ func createGitProject(t *testing.T, c *testcontext.TestContext, path string) {
 	c.Run(t, "git -C "+path+" checkout -b main")
 	c.Run(t, "git -C "+path+" config user.email tester@example.com")
 	c.Run(t, "git -C "+path+" config user.name Tester")
-	c.WriteLines(t, path+"/dev.yml", "commands: {}")
+	c.WriteLines(t, path+"/dev.yml",
+		"commands:",
+		"  where: pwd > pwd.txt",
+	)
 	c.Run(t, "git -C "+path+" add dev.yml")
 	c.Run(t, "git -C "+path+" commit -m init")
 }

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -19,6 +19,7 @@ func Test_Cmd_Worktree_New_And_Cd(t *testing.T) {
 	output := c.Run(t, "bud tree new feature-a")
 	OutputContains(t, output, "created worktree", "feature-a", worktreePath)
 	c.AssertExist(t, worktreePath+"/dev.yml")
+	require.Equal(t, worktreePath, c.Cwd(t))
 
 	branch := c.Run(t, "git -C "+worktreePath+" branch --show-current")
 	require.Equal(t, []string{"feature-a"}, branch)
@@ -88,6 +89,29 @@ func Test_Cmd_Tree_BranchConflict(t *testing.T) {
 
 	output := c.Run(t, "bud tree new duplicate feature-a", testcontext.ExitCode(1))
 	OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud tree cd feature-a")
+}
+
+func Test_Cmd_Tree_Prune_Asks_To_Delete_Inactive_Worktrees(t *testing.T) {
+	c := CreateContextAndInit(t)
+	projectPath := "/home/tester/src/github.com/orgname/projname"
+	oldWorktreePath := "/home/tester/src/github.com/orgname/projname--old-branch"
+	recentWorktreePath := "/home/tester/src/github.com/orgname/projname--recent-branch"
+
+	createGitProject(t, c, projectPath)
+	c.Cd(t, projectPath)
+	c.Run(t, "bud tree new old-branch")
+	c.Cd(t, projectPath)
+	c.Run(t, "bud tree new recent-branch")
+	c.Cd(t, projectPath)
+	c.Run(t, "touch -d '8 days ago' "+oldWorktreePath)
+
+	c.Send(t, "bud tree prune\n")
+	c.Expect(t, "Delete inactive worktree old-branch")
+	c.Send(t, "y\r")
+	c.WaitPrompt(t)
+
+	c.Run(t, "test ! -e "+oldWorktreePath)
+	c.AssertExist(t, recentWorktreePath)
 }
 
 func Test_Cmd_Tree_Has_No_Short_Aliases(t *testing.T) {

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"strings"
 	"testing"
 
 	testcontext "github.com/devbuddy/devbuddy/tests/context"
@@ -21,10 +22,16 @@ func Test_Cmd_Worktree_New_And_Cd(t *testing.T) {
 
 	branch := c.Run(t, "git -C "+worktreePath+" branch --show-current")
 	require.Equal(t, []string{"feature-a"}, branch)
+	c.Run(t, "bud tree new agent-1 long-feature-branch")
 
 	c.Write(t, worktreePath+"/scratch.txt", "dirty\n")
-	output = c.Run(t, "bud tree list feature-a")
+	output = c.Run(t, "bud tree list")
+	OutputContains(t, output, "BRANCH", "HEAD", "STATE", "MODIFIED", "PATH")
 	OutputContains(t, output, "feature-a", "dirty", worktreePath)
+	assertPathColumnAligned(t, output)
+
+	output = c.Run(t, `bud __complete tree cd ""`)
+	OutputContains(t, output, "feature-a", "long-feature-branch")
 
 	output = c.Run(t, "bud cd feature-a")
 	OutputContains(t, output, "jumping to", "projname--feature-a")
@@ -81,6 +88,35 @@ func Test_Cmd_Tree_BranchConflict(t *testing.T) {
 
 	output := c.Run(t, "bud tree new duplicate feature-a", testcontext.ExitCode(1))
 	OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud tree cd feature-a")
+}
+
+func Test_Cmd_Tree_Has_No_Short_Aliases(t *testing.T) {
+	c := CreateContext(t)
+
+	output := c.Run(t, "bud wt", testcontext.ExitCode(1))
+	OutputContains(t, output, `unknown command "wt"`)
+
+	output = c.Run(t, "bud worktree", testcontext.ExitCode(1))
+	OutputContains(t, output, `unknown command "worktree"`)
+}
+
+func assertPathColumnAligned(t *testing.T, lines []string) {
+	t.Helper()
+
+	pathColumn := -1
+	for _, line := range lines {
+		if !strings.Contains(line, "/home/tester/src") {
+			continue
+		}
+
+		column := strings.Index(line, "/home/tester/src")
+		if pathColumn == -1 {
+			pathColumn = column
+			continue
+		}
+		require.Equal(t, pathColumn, column, "path column should be aligned in line %q", line)
+	}
+	require.NotEqual(t, -1, pathColumn, "expected at least one worktree path")
 }
 
 func createGitProject(t *testing.T, c *testcontext.TestContext, path string) {

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"testing"
+
+	testcontext "github.com/devbuddy/devbuddy/tests/context"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Cmd_Worktree_New_And_Cd(t *testing.T) {
+	c := CreateContextAndInit(t)
+	projectPath := "/home/tester/src/github.com/orgname/projname"
+	worktreePath := "/home/tester/src/github.com/orgname/projname--feature-a"
+
+	createGitProject(t, c, projectPath)
+	c.Cd(t, projectPath)
+
+	output := c.Run(t, "bud wt new feature-a")
+	OutputContains(t, output, "created worktree", "feature-a", worktreePath)
+	c.AssertExist(t, worktreePath+"/dev.yml")
+
+	branch := c.Run(t, "git -C "+worktreePath+" branch --show-current")
+	require.Equal(t, []string{"feature-a"}, branch)
+
+	output = c.Run(t, "bud cd feature-a")
+	OutputContains(t, output, "jumping to", "projname--feature-a")
+	require.Equal(t, worktreePath, c.Cwd(t))
+
+	c.Cd(t, projectPath)
+	output = c.Run(t, "bud wt cd feature-a")
+	OutputContains(t, output, "jumping to", "feature-a")
+	require.Equal(t, worktreePath, c.Cwd(t))
+}
+
+func Test_Cmd_Worktree_BranchConflict(t *testing.T) {
+	c := CreateContextAndInit(t)
+	projectPath := "/home/tester/src/github.com/orgname/projname"
+	worktreePath := "/home/tester/src/github.com/orgname/projname--feature-a"
+
+	createGitProject(t, c, projectPath)
+	c.Cd(t, projectPath)
+	c.Run(t, "bud wt new feature-a")
+
+	output := c.Run(t, "bud wt new duplicate feature-a", testcontext.ExitCode(1))
+	OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud wt cd feature-a")
+}
+
+func createGitProject(t *testing.T, c *testcontext.TestContext, path string) {
+	t.Helper()
+
+	c.Run(t, "mkdir -p "+path)
+	c.Run(t, "git -C "+path+" init")
+	c.Run(t, "git -C "+path+" checkout -b main")
+	c.Run(t, "git -C "+path+" config user.email tester@example.com")
+	c.Run(t, "git -C "+path+" config user.name Tester")
+	c.WriteLines(t, path+"/dev.yml", "commands: {}")
+	c.Run(t, "git -C "+path+" add dev.yml")
+	c.Run(t, "git -C "+path+" commit -m init")
+}


### PR DESCRIPTION
## Summary

- documents the proposed DevBuddy worktree UX in `docs/plans/worktree-ux.md` and README
- adds `bud tree` for listing, creating, jumping to, switching between, removing, and pruning Git worktrees
- creates sibling worktrees with the `repo--<name>` layout and jumps into new worktrees by default
- makes `bud cd` branch-aware for managed worktrees, including when branch and directory names differ
- adds an interactive `bud tree switch` selector using up/down keys plus enter
- aligns `bud tree list` and `bud tree switch` columns
- adds `bud tree cd` shell completion for worktree branches/names
- shows dirty/clean state in `bud tree list` and improves branch conflict messages
- makes `bud tree prune` clean stale metadata and ask about deleting each worktree untouched for more than one week

## Validation

- `git diff --check`
- `go test ./pkg/...`
- `TEST_SHELL=bash go test -run 'Test_Cmd_(Worktree|Tree)' -count=1 ./tests/shell`
- `TEST_SHELL=zsh go test -run 'Test_Cmd_(Worktree|Tree)' -count=1 ./tests/shell`

## Notes

- The PR is draft.
- Short aliases for `bud tree` are intentionally not included.
