### PR TITLE
Add default_org and default_platform to user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,23 @@ type bud > /dev/null 2> /dev/null && eval "$(bud --shell-init --with-completion)
 
 ### Configuration
 
-If you usually work with repos from the same GitHub organization, set it as a default:
+DevBuddy reads `~/.config/devbuddy/config.yml` (respecting `$XDG_CONFIG_HOME`). All keys are optional.
 
-```bash
-export BUD_DEFAULT_ORG="myorg"
+```yaml
+# Default organization: "bud clone myrepo" becomes "bud clone myorg/myrepo"
+default_org: myorg
+
+# Default hosting platform (default: github.com)
+# Supported: github.com, gitlab.com, bitbucket.org, codeberg.org,
+#            git.sr.ht, any self-hosted Gitea/GitLab instance
+default_platform: gitlab.com
+
+shell:
+  defer_init: false
 ```
 
-Then `bud clone myrepo` is equivalent to `bud clone myorg/myrepo`.
+`bud clone` and `bud cd` accept short `org/repo` identifiers, full SSH URLs
+(`git@host:org/repo.git`), and full HTTPS URLs (`https://host/org/repo[.git]`).
 
 ## Using in CI
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,11 +7,12 @@ import (
 
 // Config represents the user system and environment configuration
 type Config struct {
-	homeDir      string // the user home directory
-	DebugEnabled bool   // whether debug logging is activated
-	SourceDir    string // projects base directory
-	dataDir      string // directory managed by DevBuddy (languages distribs, virtualenvs...)
-	DefaultOrg   string // [optional] default repo organisation
+	homeDir         string // the user home directory
+	DebugEnabled    bool   // whether debug logging is activated
+	SourceDir       string // projects base directory
+	dataDir         string // directory managed by DevBuddy (languages distribs, virtualenvs...)
+	DefaultOrg      string // [optional] default repo organisation
+	DefaultPlatform string // default hosting platform (e.g. github.com)
 }
 
 func NewTestConfig() *Config {
@@ -28,13 +29,20 @@ func Load() (*Config, error) {
 	}
 
 	userDataDir := getXdgUserDataDir(homedir)
+	userCfg := LoadUserConfig()
+
+	defaultPlatform := userCfg.DefaultPlatform
+	if defaultPlatform == "" {
+		defaultPlatform = "github.com"
+	}
 
 	c := Config{
-		homeDir:      homedir,
-		DebugEnabled: debugEnabled(),
-		SourceDir:    filepath.Join(homedir, "src"),
-		dataDir:      filepath.Join(userDataDir, "bud"),
-		DefaultOrg:   os.Getenv("BUD_DEFAULT_ORG"),
+		homeDir:         homedir,
+		DebugEnabled:    debugEnabled(),
+		SourceDir:       filepath.Join(homedir, "src"),
+		dataDir:         filepath.Join(userDataDir, "bud"),
+		DefaultOrg:      userCfg.DefaultOrg,
+		DefaultPlatform: defaultPlatform,
 	}
 	return &c, nil
 }

--- a/pkg/config/userconfig.go
+++ b/pkg/config/userconfig.go
@@ -8,7 +8,9 @@ import (
 )
 
 type UserConfig struct {
-	Shell ShellConfig `yaml:"shell"`
+	Shell           ShellConfig `yaml:"shell"`
+	DefaultOrg      string      `yaml:"default_org"`
+	DefaultPlatform string      `yaml:"default_platform"`
 }
 
 type ShellConfig struct {

--- a/pkg/config/userconfig_test.go
+++ b/pkg/config/userconfig_test.go
@@ -14,6 +14,8 @@ func TestLoadUserConfig_MissingFile(t *testing.T) {
 	cfg := LoadUserConfig()
 
 	require.Equal(t, false, cfg.Shell.DeferInit)
+	require.Equal(t, "", cfg.DefaultOrg)
+	require.Equal(t, "", cfg.DefaultPlatform)
 }
 
 func TestLoadUserConfig_ValidFile(t *testing.T) {
@@ -24,13 +26,15 @@ func TestLoadUserConfig_ValidFile(t *testing.T) {
 	require.NoError(t, os.MkdirAll(configDir, 0o755))
 	require.NoError(t, os.WriteFile(
 		filepath.Join(configDir, "config.yml"),
-		[]byte("shell:\n  defer_init: true\n"),
+		[]byte("shell:\n  defer_init: true\ndefault_org: myorg\ndefault_platform: gitlab.com\n"),
 		0o644,
 	))
 
 	cfg := LoadUserConfig()
 
 	require.Equal(t, true, cfg.Shell.DeferInit)
+	require.Equal(t, "myorg", cfg.DefaultOrg)
+	require.Equal(t, "gitlab.com", cfg.DefaultPlatform)
 }
 
 func TestLoadUserConfig_InvalidYAML(t *testing.T) {

--- a/pkg/project/hosting.go
+++ b/pkg/project/hosting.go
@@ -7,9 +7,11 @@ import (
 	"strings"
 )
 
-func getPlatformNames() []string {
-	return []string{"github.com", "bitbucket.org"}
-}
+var (
+	reShort = regexp.MustCompile(`^([\w.~-]+)/([\w.-]+)$`)
+	reSSH   = regexp.MustCompile(`^git@([\w.-]+):([\w.~-]+)/([\w.-]+?)(?:\.git)?$`)
+	reHTTPS = regexp.MustCompile(`^https://([\w.-]+)/([\w.~-]+)/([\w.-]+?)(?:\.git)?$`)
+)
 
 type hostingInfo struct {
 	platform     string
@@ -19,27 +21,19 @@ type hostingInfo struct {
 	remoteURL string
 }
 
-func newHostingInfoByURL(url string) (*hostingInfo, error) {
+func newHostingInfoByURL(url string, defaultPlatform string) (*hostingInfo, error) {
 	url = strings.Trim(url, " ")
 
-	reGithubFull := regexp.MustCompile(`^([\w.-]+)/([\w.-]+)$`)
-	if match := reGithubFull.FindStringSubmatch(url); match != nil {
-		return newGithubHostingInfo("", match[1], match[2]), nil
+	if match := reShort.FindStringSubmatch(url); match != nil {
+		return newHostingInfoFromParts("", defaultPlatform, match[1], match[2]), nil
 	}
 
-	reGithubGitURL := regexp.MustCompile(`^git@github.com:([\w.-]+)/([\w.-]+).git$`)
-	if match := reGithubGitURL.FindStringSubmatch(url); match != nil {
-		return newGithubHostingInfo(url, match[1], match[2]), nil
+	if match := reSSH.FindStringSubmatch(url); match != nil {
+		return newHostingInfoFromParts(url, match[1], match[2], match[3]), nil
 	}
 
-	reGithubGitHTTPURL := regexp.MustCompile(`^https://github.com/([\w.-]+)/([\w.-]+).git$`)
-	if match := reGithubGitHTTPURL.FindStringSubmatch(url); match != nil {
-		return newGithubHostingInfo(url, match[1], match[2]), nil
-	}
-
-	reBitbucketGitURL := regexp.MustCompile(`^git@bitbucket.org:([\w.-]+)/([\w.-]+).git$`)
-	if match := reBitbucketGitURL.FindStringSubmatch(url); match != nil {
-		return newBitbucketHostingInfo(match[1], match[2]), nil
+	if match := reHTTPS.FindStringSubmatch(url); match != nil {
+		return newHostingInfoFromParts(url, match[1], match[2], match[3]), nil
 	}
 
 	return nil, fmt.Errorf("unrecognized project url: %s", url)
@@ -51,23 +45,14 @@ func newHostingInfoByPath(path string) *hostingInfo {
 	}
 }
 
-func newGithubHostingInfo(remoteURL, organisation, repository string) *hostingInfo {
+func newHostingInfoFromParts(remoteURL, platform, organisation, repository string) *hostingInfo {
 	if remoteURL == "" {
-		remoteURL = fmt.Sprintf("git@github.com:%s/%s.git", organisation, repository)
+		remoteURL = fmt.Sprintf("git@%s:%s/%s.git", platform, organisation, repository)
 	}
 	return &hostingInfo{
-		platform:     "github.com",
+		platform:     platform,
 		organisation: organisation,
 		repository:   repository,
 		remoteURL:    remoteURL,
-	}
-}
-
-func newBitbucketHostingInfo(organisation, repository string) *hostingInfo {
-	return &hostingInfo{
-		platform:     "bitbucket.org",
-		organisation: organisation,
-		repository:   repository,
-		remoteURL:    fmt.Sprintf("git@bitbucket.org:%s/%s.git", organisation, repository),
 	}
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -26,7 +26,7 @@ func NewFromID(id string, conf *config.Config) (p *Project, err error) {
 		}
 	}
 
-	hosting, err := newHostingInfoByURL(id)
+	hosting, err := newHostingInfoByURL(id, conf.DefaultPlatform)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var cfg = &config.Config{SourceDir: "/src"}
+var cfg = &config.Config{SourceDir: "/src", DefaultPlatform: "github.com"}
 
 func TestNewFromID(t *testing.T) {
 	proj, err := NewFromID("golang/go", cfg)
@@ -28,17 +28,25 @@ func TestNewFromIDError(t *testing.T) {
 	proj, err := NewFromID("", cfg)
 	require.Error(t, err, "NewFromID() should fail")
 	require.Nil(t, proj)
-
-	proj, err = NewFromID("golang", cfg)
-	require.Error(t, err, "NewFromID() should fail")
-	require.Nil(t, proj)
 }
 
 func TestNewFromID_DefaultOrg(t *testing.T) {
-	cfg = &config.Config{SourceDir: "/src", DefaultOrg: "golang"}
+	cfg := &config.Config{SourceDir: "/src", DefaultPlatform: "github.com", DefaultOrg: "golang"}
 	proj, err := NewFromID("go", cfg)
 	require.NoError(t, err)
 	require.Equal(t, "github.com:golang/go", proj.FullName())
+}
+
+func TestNewFromID_DefaultPlatform(t *testing.T) {
+	cfg := &config.Config{SourceDir: "/src", DefaultPlatform: "gitlab.com"}
+	proj, err := NewFromID("myorg/myrepo", cfg)
+	require.NoError(t, err)
+	require.Equal(t, "gitlab.com:myorg/myrepo", proj.FullName())
+	require.Equal(t, "/src/gitlab.com/myorg/myrepo", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.NoError(t, err)
+	require.Equal(t, "git@gitlab.com:myorg/myrepo.git", url)
 }
 
 func TestNewFromIDGithubFullURL(t *testing.T) {
@@ -81,4 +89,33 @@ func TestNewFromIDBitbucketFullURL(t *testing.T) {
 	require.Equal(t, "git@bitbucket.org:zzzeek/dogpile.cache.git", url)
 
 	require.Equal(t, "dogpile.cache-669781729", proj.Slug())
+}
+
+func TestNewFromIDCodeberg(t *testing.T) {
+	proj, err := NewFromID("git@codeberg.org:myorg/myrepo.git", cfg)
+	require.NoError(t, err)
+	require.Equal(t, "codeberg.org:myorg/myrepo", proj.FullName())
+	require.Equal(t, "/src/codeberg.org/myorg/myrepo", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.NoError(t, err)
+	require.Equal(t, "git@codeberg.org:myorg/myrepo.git", url)
+}
+
+func TestNewFromIDSourcehut(t *testing.T) {
+	proj, err := NewFromID("git@git.sr.ht:~myuser/myrepo", cfg)
+	require.NoError(t, err)
+	require.Equal(t, "git.sr.ht:~myuser/myrepo", proj.FullName())
+	require.Equal(t, "/src/git.sr.ht/~myuser/myrepo", proj.Path)
+
+	url, err := proj.GetRemoteURL()
+	require.NoError(t, err)
+	require.Equal(t, "git@git.sr.ht:~myuser/myrepo", url)
+}
+
+func TestNewFromIDHTTPSWithoutDotGit(t *testing.T) {
+	proj, err := NewFromID("https://gitlab.com/myorg/myrepo", cfg)
+	require.NoError(t, err)
+	require.Equal(t, "gitlab.com:myorg/myrepo", proj.FullName())
+	require.Equal(t, "/src/gitlab.com/myorg/myrepo", proj.Path)
 }

--- a/pkg/project/search.go
+++ b/pkg/project/search.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sahilm/fuzzy"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
-	"github.com/devbuddy/devbuddy/pkg/utils"
 	wt "github.com/devbuddy/devbuddy/pkg/worktree"
 )
 
@@ -134,16 +133,15 @@ func projectFromWorktree(base *Project, path string, branch string) *Project {
 }
 
 func getAllProjects(sourceDir string) ([]*Project, error) {
+	platforms, err := listChildDir(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+
 	var projects []*Project
 
-	for _, platform := range getPlatformNames() {
+	for _, platform := range platforms {
 		platformPath := filepath.Join(sourceDir, platform)
-		if !utils.PathExists(platformPath) {
-			continue
-		}
-
-		var orgPath string
-		var projPath string
 
 		orgs, err := listChildDir(platformPath)
 		if err != nil {
@@ -151,7 +149,7 @@ func getAllProjects(sourceDir string) ([]*Project, error) {
 		}
 
 		for _, org := range orgs {
-			orgPath = filepath.Join(platformPath, org)
+			orgPath := filepath.Join(platformPath, org)
 
 			repos, err := listChildDir(orgPath)
 			if err != nil {
@@ -159,7 +157,7 @@ func getAllProjects(sourceDir string) ([]*Project, error) {
 			}
 
 			for _, repo := range repos {
-				projPath = filepath.Join(orgPath, repo)
+				projPath := filepath.Join(orgPath, repo)
 
 				projects = append(projects, &Project{
 					hosting: &hostingInfo{


### PR DESCRIPTION
## Summary

- Adds `default_org` and `default_platform` keys to `~/.config/devbuddy/config.yml`
- Removes `BUD_DEFAULT_ORG` env var (superseded by config file)
- Generalizes URL parsing to support any git hosting platform via three generic regexes (short `org/repo`, SSH, HTTPS)
- Project discovery (`bud cd`) now scans `sourceDir` dynamically instead of a hardcoded platform list

### Supported platforms

`default_platform` accepts any hostname: `github.com`, `gitlab.com`, `bitbucket.org`, `codeberg.org`, `git.sr.ht`, self-hosted Gitea/GitLab instances, etc.

### Config example

```yaml
default_org: myorg
default_platform: gitlab.com
```

## Test plan

- [ ] `script/test` passes (unit tests cover new config fields, generic URL parsing for GitHub/GitLab/Bitbucket/Codeberg/Sourcehut, HTTPS without `.git`)
- [ ] `script/lint` passes
- [ ] Manual: set `default_platform: gitlab.com` in config, verify `bud clone org/repo` clones from GitLab