### PR TITLE
Extract shared bud-binary build helper

### DIFF
--- a/tests/context/config.go
+++ b/tests/context/config.go
@@ -3,12 +3,11 @@ package context
 import (
 	"fmt"
 	"os"
-	"path"
 )
 
 type Config struct {
 	ShellName              string
-	BinaryPath             string
+	BinaryPath             string // set by the caller (e.g. via budbuild.TempBinaryPath)
 	DockerImage            string
 	WorkspaceHostPath      string
 	WorkspaceContainerPath string
@@ -16,11 +15,6 @@ type Config struct {
 }
 
 func LoadConfig() (Config, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return Config{}, fmt.Errorf("getting current working directory: %w", err)
-	}
-
 	dockerImage, ok := os.LookupEnv("TEST_DOCKER_IMAGE")
 	if !ok {
 		return Config{}, fmt.Errorf("missing env var TEST_DOCKER_IMAGE")
@@ -33,7 +27,6 @@ func LoadConfig() (Config, error) {
 
 	return Config{
 		ShellName:   shellName,
-		BinaryPath:  path.Join(cwd, "bud"),
 		DockerImage: dockerImage,
 	}, nil
 }

--- a/tests/internal/budbuild/budbuild.go
+++ b/tests/internal/budbuild/budbuild.go
@@ -1,0 +1,77 @@
+// Package budbuild compiles the `bud` binary for integration test harnesses.
+//
+// Both the docker harness (cross-compiled Linux binary mounted into a
+// container) and the fast cliharness (host binary executed directly) need to
+// build `cmd/bud` before their tests start. The variations are small enough
+// to share: cross-compile env, optional ldflags, and output path.
+package budbuild
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// Options describe a single build invocation. OutputPath must be an absolute
+// path to the binary file (its parent directory must exist).
+type Options struct {
+	OutputPath string
+	Env        []string // appended to os.Environ()
+	LdFlags    string   // -ldflags value (omitted if empty)
+}
+
+// Build compiles ./cmd/bud from the repo root with the given options.
+func Build(opts Options) error {
+	repoRoot, err := FindRepoRoot()
+	if err != nil {
+		return fmt.Errorf("finding repo root: %w", err)
+	}
+
+	args := []string{"build"}
+	if opts.LdFlags != "" {
+		args = append(args, "-ldflags", opts.LdFlags)
+	}
+	args = append(args, "-o", opts.OutputPath, "./cmd/bud")
+
+	cmd := exec.Command("go", args...)
+	cmd.Dir = repoRoot
+	if len(opts.Env) > 0 {
+		cmd.Env = append(os.Environ(), opts.Env...)
+	}
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("building %s: %w\n%s", opts.OutputPath, err, output)
+	}
+	return nil
+}
+
+// FindRepoRoot walks up from the working directory until it finds a go.mod.
+func FindRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found from %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// TempBinaryPath returns a unique absolute path under os.TempDir for a test
+// binary, and ensures the parent directory exists. The path is process-scoped
+// to avoid collisions with parallel test runs.
+func TempBinaryPath(name string) (string, error) {
+	path := filepath.Join(os.TempDir(), fmt.Sprintf("bud-test-%d", os.Getpid()), name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return "", fmt.Errorf("creating binary directory: %w", err)
+	}
+	return path, nil
+}

--- a/tests/internal/cliharness/main.go
+++ b/tests/internal/cliharness/main.go
@@ -3,54 +3,32 @@ package cliharness
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/devbuddy/devbuddy/tests/internal/budbuild"
 )
 
 var binaryPath string
 
 func TestMain(m *testing.M) {
 	start := time.Now()
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		fmt.Printf("Error finding repo root: %s\n", err)
-		os.Exit(1)
-	}
 
-	binaryPath = filepath.Join(os.TempDir(), fmt.Sprintf("bud-test-%d", os.Getpid()), "bud")
-	if err := os.MkdirAll(filepath.Dir(binaryPath), 0755); err != nil {
-		fmt.Printf("Error creating binary directory: %s\n", err)
+	path, err := budbuild.TempBinaryPath("bud")
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
 	}
-	cmd := exec.Command("go", "build", "-ldflags", "-X main.Version=devel", "-o", binaryPath, "./cmd/bud")
-	cmd.Dir = repoRoot
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("Error when building binary: %s\n%s\n", err.Error(), string(output))
+	binaryPath = path
+
+	if err := budbuild.Build(budbuild.Options{
+		OutputPath: binaryPath,
+		LdFlags:    "-X main.Version=devel",
+	}); err != nil {
+		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
 	}
 
 	fmt.Printf("Built host binary in %s\n", time.Since(start))
 	os.Exit(m.Run())
-}
-
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("go.mod not found from %s", dir)
-		}
-		dir = parent
-	}
 }

--- a/tests/internal/harness/main.go
+++ b/tests/internal/harness/main.go
@@ -3,63 +3,41 @@ package harness
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/devbuddy/devbuddy/tests/context"
+	"github.com/devbuddy/devbuddy/tests/internal/budbuild"
 )
 
 var config context.Config
 
 func TestMain(m *testing.M) {
-	// call flag.Parse() here if TestMain uses flags
-
 	var err error
 	config, err = context.LoadConfig()
 	if err != nil {
 		fmt.Printf("Error loading config: %s\n", err)
 		os.Exit(1)
 	}
+
+	config.BinaryPath, err = budbuild.TempBinaryPath("bud")
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+		os.Exit(1)
+	}
+
 	fmt.Printf("Starting with config: %+v\n", config)
 
 	fmt.Printf("Building linux binary\n")
 	start := time.Now()
-	repoRoot, err := findRepoRoot()
-	if err != nil {
-		fmt.Printf("Error finding repo root: %s\n", err)
-		os.Exit(1)
-	}
-	cmd := exec.Command("go", "build", "-o", config.BinaryPath, "./cmd/bud")
-	cmd.Dir = repoRoot
-	cmd.Env = append(os.Environ(), "GOOS=linux", "CGO_ENABLED=0")
-
-	cmdOutput, err := cmd.CombinedOutput()
-	if err != nil {
-		fmt.Printf("Error when building binary: %s\n%s\n", err.Error(), string(cmdOutput))
+	if err := budbuild.Build(budbuild.Options{
+		OutputPath: config.BinaryPath,
+		Env:        []string{"GOOS=linux", "CGO_ENABLED=0"},
+	}); err != nil {
+		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("Built in %s\n", time.Since(start))
 
 	os.Exit(m.Run())
-}
-
-func findRepoRoot() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir, nil
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return "", fmt.Errorf("go.mod not found from %s", dir)
-		}
-		dir = parent
-	}
 }


### PR DESCRIPTION
## Summary

Stacked on #553.

- Lift the duplicated TestMain + \`findRepoRoot\` + \`go build\` scaffolding from \`tests/internal/harness\` and \`tests/internal/cliharness\` into a new \`tests/internal/budbuild\` package. The two harnesses now differ only in output path, ldflags, and cross-compile env — exactly what \`budbuild.Options\` exposes.
- Drop \`BinaryPath\` from \`context.LoadConfig()\`. It was being set to \`cwd/bud\`, which left a stale 13 MB binary in the test package directory (\`tests/docker/bud\`, etc.) after every run. The docker TestMain now picks a process-scoped path under \`os.TempDir()\` via \`budbuild.TempBinaryPath\` — the same convention cliharness already used.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\`
- [x] \`go test ./tests/fast\`
- [x] \`TEST_SHELL=bash TEST_DOCKER_IMAGE=ghcr.io/devbuddy/docker-testing:sha-7fd13f4 go test ./tests/shell\`
- [x] \`script/lint\`
- [ ] CI on all matrix jobs (will rebase onto main once #553 lands)