### PR TITLE
Remove tree cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,13 +191,13 @@ Create and jump between worktrees from any checkout in the repository:
 
 ```bash
 bud tree new feature-a
-bud tree cd feature-a
+bud tree switch feature-a
 bud tree switch
 ```
 
 `bud tree new` creates the worktree and jumps into it. `bud tree prune` cleans stale Git worktree metadata and asks whether to delete each existing worktree that has not been touched for more than one week.
 
-`bud tree switch` opens an interactive selector with up/down keys and enter. Regular `bud cd` also understands managed worktree branches, so `bud cd feature-a` can jump to a worktree even when its directory is named for a different agent or task.
+`bud tree switch` jumps directly when given a query, or opens an interactive selector with up/down keys and enter when no query is provided. Regular `bud cd` also understands managed worktree branches, so `bud cd feature-a` can jump to a worktree even when its directory is named for a different agent or task.
 
 If a branch is already checked out in another worktree, DevBuddy shows the existing path and a command to jump there instead of leaving you with Git's raw error.
 

--- a/docs/plans/worktree-ux.md
+++ b/docs/plans/worktree-ux.md
@@ -20,8 +20,7 @@ The existing clone path remains the main/default worktree. Additional worktrees 
 - Make `bud cd` worktree-aware so fuzzy navigation can jump to either the canonical project or a managed sibling worktree.
 - Add `bud tree list [query]` to show grouped worktrees with path, branch, HEAD short SHA, dirty state, and last modified time.
 - Add `bud tree new <name> [branch]` to create `repo--<name>` from the current project repository and jump into it.
-- Add `bud tree cd <query>` to jump to a worktree by branch, worktree name, or fuzzy match, using the existing shell finalizer.
-- Add `bud tree switch [query]` to show an interactive up/down/enter selector and jump to the selected worktree.
+- Add `bud tree switch [query]` to jump to a worktree by branch, worktree name, or fuzzy match when a query is provided, or show an interactive up/down/enter selector when it is not.
 - Add `bud tree remove [query]` and `bud tree prune` for cleanup. `prune` should also ask whether to delete each existing worktree that has not been touched for more than one week.
 
 ## Branch Conflict UX
@@ -60,7 +59,7 @@ Non-interactive behavior should fail with a clear message and exact commands to 
 - Unit test branch occupancy detection.
 - Unit test project search with canonical repos and `repo--name` worktrees.
 - Integration test `bud tree new feature-a` creates `repo--feature-a`.
-- Integration test `bud tree cd feature-a` changes shell cwd through the existing finalizer.
+- Integration test `bud tree switch feature-a` changes shell cwd through the existing finalizer.
 - Integration test `bud tree switch` can select a worktree with down-arrow and enter.
 - Integration test `bud cd feature-a` jumps directly to a managed worktree branch, including when the branch name differs from the worktree directory suffix.
 - Integration test branch conflict output for interactive and non-interactive use.

--- a/pkg/cmd/helpers.go
+++ b/pkg/cmd/helpers.go
@@ -29,6 +29,13 @@ func noArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func subcommandOnlyRun(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return fmt.Errorf("unknown command %q for %q", args[0], cmd.CommandPath())
+	}
+	return cmd.Help()
+}
+
 func zeroOrOneArg(_ *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("expecting zero or one argument")

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -22,6 +22,7 @@ var worktreeCmd = &cobra.Command{
 	Use:          "tree",
 	Short:        "Manage git worktrees",
 	GroupID:      "devbuddy",
+	RunE:         subcommandOnlyRun,
 	SilenceUsage: true,
 }
 
@@ -41,21 +42,13 @@ var worktreeNewCmd = &cobra.Command{
 	SilenceUsage: true,
 }
 
-var worktreeCdCmd = &cobra.Command{
-	Use:               "cd QUERY",
-	Short:             "Jump to a git worktree",
-	Args:              onlyOneArg,
-	RunE:              worktreeCdRun,
-	ValidArgsFunction: worktreeCdCompletions,
-	SilenceUsage:      true,
-}
-
 var worktreeSwitchCmd = &cobra.Command{
-	Use:          "switch [QUERY]",
-	Short:        "Select and jump to a git worktree",
-	Args:         zeroOrOneArg,
-	RunE:         worktreeSwitchRun,
-	SilenceUsage: true,
+	Use:               "switch [QUERY]",
+	Short:             "Select and jump to a git worktree",
+	Args:              zeroOrOneArg,
+	RunE:              worktreeSwitchRun,
+	ValidArgsFunction: worktreeSwitchCompletions,
+	SilenceUsage:      true,
 }
 
 var worktreeRemoveCmd = &cobra.Command{
@@ -77,7 +70,6 @@ var worktreePruneCmd = &cobra.Command{
 func init() {
 	worktreeCmd.AddCommand(worktreeListCmd)
 	worktreeCmd.AddCommand(worktreeNewCmd)
-	worktreeCmd.AddCommand(worktreeCdCmd)
 	worktreeCmd.AddCommand(worktreeSwitchCmd)
 	worktreeCmd.AddCommand(worktreeRemoveCmd)
 	worktreeCmd.AddCommand(worktreePruneCmd)
@@ -127,7 +119,7 @@ func worktreeNewRun(_ *cobra.Command, args []string) error {
 	}
 
 	if conflict := worktree.CheckedOutBranch(worktrees, branch); conflict != nil {
-		return fmt.Errorf("branch %s is already checked out at %s\nRun: bud tree cd %s", branch, conflict.Path, branch)
+		return fmt.Errorf("branch %s is already checked out at %s\nRun: bud tree switch %s", branch, conflict.Path, branch)
 	}
 
 	repoPath := mainWorktreePath(worktrees, ctx.Project.Path)
@@ -152,21 +144,6 @@ func worktreeNewRun(_ *cobra.Command, args []string) error {
 
 	fmt.Printf("🐼  created worktree %s at %s\n", branch, path)
 	return integration.AddFinalizerCd(path)
-}
-
-func worktreeCdRun(_ *cobra.Command, args []string) error {
-	ctx, err := context.LoadWithProject()
-	if err != nil {
-		return err
-	}
-
-	wt, err := findWorktree(ctx.Executor, ctx.Project.Path, args[0])
-	if err != nil {
-		return err
-	}
-
-	ctx.UI.JumpProject(worktreeLabel(wt))
-	return integration.AddFinalizerCd(wt.Path)
 }
 
 func worktreeSwitchRun(_ *cobra.Command, args []string) error {
@@ -275,19 +252,6 @@ func oneOrTwoArgs(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("expecting one or two arguments")
 	}
 	return nil
-}
-
-func findWorktree(exec *executor.Executor, repoPath, query string) (worktree.Worktree, error) {
-	worktrees, err := worktree.List(exec, repoPath)
-	if err != nil {
-		return worktree.Worktree{}, err
-	}
-
-	matches := matchWorktrees(worktrees, query)
-	if len(matches) == 0 {
-		return worktree.Worktree{}, fmt.Errorf("no worktree found for %s", query)
-	}
-	return matches[0], nil
 }
 
 type switchItem struct {
@@ -473,7 +437,7 @@ func formatWorktreeRows(rows []worktreeRow, includeHeader bool) []string {
 	return lines
 }
 
-func worktreeCdCompletions(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func worktreeSwitchCompletions(_ *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -31,7 +31,7 @@ func Test_Cmd_Worktree_New_And_Cd(t *testing.T) {
 	harness.OutputContains(t, output, "feature-a", "dirty", worktreePath)
 	assertPathColumnAligned(t, output)
 
-	output = c.Run(t, `bud __complete tree cd ""`)
+	output = c.Run(t, `bud __complete tree switch ""`)
 	harness.OutputContains(t, output, "feature-a", "long-feature-branch")
 
 	output = c.Run(t, "bud cd feature-a")
@@ -39,7 +39,7 @@ func Test_Cmd_Worktree_New_And_Cd(t *testing.T) {
 	require.Equal(t, worktreePath, c.Cwd(t))
 
 	c.Cd(t, projectPath)
-	output = c.Run(t, "bud tree cd feature-a")
+	output = c.Run(t, "bud tree switch feature-a")
 	harness.OutputContains(t, output, "jumping to", "feature-a")
 	require.Equal(t, worktreePath, c.Cwd(t))
 
@@ -88,7 +88,7 @@ func Test_Cmd_Tree_BranchConflict(t *testing.T) {
 	c.Run(t, "bud tree new feature-a")
 
 	output := c.Run(t, "bud tree new duplicate feature-a", harness.ExitCode(1))
-	harness.OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud tree cd feature-a")
+	harness.OutputContains(t, output, "branch feature-a is already checked out", worktreePath, "bud tree switch feature-a")
 }
 
 func Test_Cmd_Tree_Prune_Asks_To_Delete_Inactive_Worktrees(t *testing.T) {


### PR DESCRIPTION
## Summary

- Remove the redundant `bud tree cd` command now that `bud tree switch [QUERY]` handles direct worktree jumps.
- Move worktree completion from `tree cd` to `tree switch`.
- Update the branch-conflict hint, README, and worktree plan docs to point to `bud tree switch <query>`.

## Validation

- `env GOCACHE=/private/tmp/devbuddy-go-cache script/test`
- `env GOCACHE=/private/tmp/devbuddy-go-cache TEST_DOCKER_IMAGE=ghcr.io/devbuddy/docker-testing:sha-7fd13f4 TEST_SHELL=bash go test -run 'Test_Cmd_(Worktree|Tree)' -count=1 ./tests/shell`
- `env GOCACHE=/private/tmp/devbuddy-go-cache TEST_DOCKER_IMAGE=ghcr.io/devbuddy/docker-testing:sha-7fd13f4 TEST_SHELL=zsh go test -run 'Test_Cmd_(Worktree|Tree)' -count=1 ./tests/shell`
