### PR TITLE
Introduce UI event recorder

### DIFF
--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	color "github.com/logrusorgru/aurora"
+
+	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
 
 type Feature interface {
@@ -15,18 +17,25 @@ type Feature interface {
 
 func (u *UI) HookFeaturesActivated(features []Feature) {
 	parts := make([]string, len(features))
+	plainParts := make([]string, len(features))
+	fields := make([]baseui.Field, len(features))
 	for i, f := range features {
+		fields[i] = baseui.F(f.FeatureName(), f.FeatureParam())
 		param := f.FeatureParam()
 		if param == "" || strings.HasPrefix(param, "{") {
+			plainParts[i] = f.FeatureName()
 			parts[i] = fmt.Sprintf("%s", color.Blue(f.FeatureName()))
 		} else {
+			plainParts[i] = fmt.Sprintf("%s[%s]", f.FeatureName(), param)
 			parts[i] = fmt.Sprintf("%s%s%s%s", color.Blue(f.FeatureName()), color.Gray(12, "["), color.Cyan(param), color.Gray(12, "]"))
 		}
 	}
+	u.record(baseui.Event{Kind: baseui.KindHookActivated, Text: strings.Join(plainParts, ", "), Fields: fields})
 	Fprintf(u.out, "🐼  %s %s\n", color.Cyan("activated:"), strings.Join(parts, color.Gray(12, ", ").String()))
 }
 
 func (u *UI) HookFeatureFailure(name string, param string) {
+	u.record(baseui.Event{Kind: baseui.KindHookFeatureFailed, Text: name, Fields: []baseui.Field{baseui.F("param", param)}})
 	msg := fmt.Sprintf("failed to activate %s. Try running 'bud up' first!", name)
 
 	paramStr := ""
@@ -38,6 +47,7 @@ func (u *UI) HookFeatureFailure(name string, param string) {
 }
 
 func (u *UI) HookDevYmlChanged() {
+	u.record(baseui.Event{Kind: baseui.KindHookDevYMLChanged})
 	Fprintf(u.out, "🐼  %s\n", color.Yellow("dev.yml changed, run `bud up` to apply"))
 }
 

--- a/pkg/termui/task.go
+++ b/pkg/termui/task.go
@@ -5,9 +5,12 @@ import (
 	"strings"
 
 	color "github.com/logrusorgru/aurora"
+
+	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
 
 func (u *UI) TaskHeader(name, param, reason string) {
+	u.record(baseui.Event{Kind: baseui.KindTaskHeader, Text: name, Fields: []baseui.Field{baseui.F("param", param), baseui.F("reason", reason)}})
 	if param != "" {
 		param = fmt.Sprintf(" (%s)", color.Blue(param))
 	}
@@ -18,22 +21,27 @@ func (u *UI) TaskHeader(name, param, reason string) {
 }
 
 func (u *UI) TaskCommand(cmdline string, args ...string) {
+	u.record(baseui.Event{Kind: baseui.KindTaskCommand, Text: cmdline, Fields: []baseui.Field{baseui.F("args", strings.Join(args, " "))}})
 	Fprintf(u.out, "  Running: %s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
 }
 
 func (u *UI) TaskShell(cmdline string) {
+	u.record(baseui.Event{Kind: baseui.KindTaskShell, Text: cmdline})
 	Fprintf(u.out, "  Running: %s\n", color.Cyan(cmdline))
 }
 
 func (u *UI) TaskActed() {
+	u.record(baseui.Event{Kind: baseui.KindTaskActed})
 	Fprintf(u.out, "  %s\n", color.Green("Done!"))
 }
 
 func (u *UI) TaskAlreadyOk() {
+	u.record(baseui.Event{Kind: baseui.KindTaskAlreadyOK})
 	Fprintf(u.out, "  %s\n", color.Green("Already OK!"))
 }
 
 func (u *UI) TaskError(err error) {
+	u.record(baseui.Event{Kind: baseui.KindTaskError, Text: err.Error()})
 	Fprintf(u.out, "  %s\n", color.Red(err.Error()))
 }
 
@@ -42,21 +50,26 @@ func (u *UI) TaskErrorf(message string, a ...interface{}) {
 }
 
 func (u *UI) TaskWarning(message string) {
+	u.record(baseui.Event{Kind: baseui.KindTaskWarning, Text: message})
 	Fprintf(u.out, "  Warning: %s\n", color.Yellow(message))
 }
 
 func (u *UI) TaskActionHeader(desc string) {
+	u.record(baseui.Event{Kind: baseui.KindTaskActionHeader, Text: desc})
 	Fprintf(u.out, "  %s%s\n", color.Yellow("▪︎"), color.Magenta(desc))
 }
 
 func (u *UI) ActionHeader(description string) {
+	u.record(baseui.Event{Kind: baseui.KindActionHeader, Text: description})
 	Fprintf(u.out, "🐼  %s\n", color.Cyan(description))
 }
 
 func (u *UI) ActionNotice(text string) {
+	u.record(baseui.Event{Kind: baseui.KindActionNotice, Text: text})
 	Fprintf(u.out, "⚠️   %s\n", color.Yellow(text))
 }
 
 func (u *UI) ActionDone() {
+	u.record(baseui.Event{Kind: baseui.KindActionDone})
 	Fprintf(u.out, "✅  %s\n", color.Green("Done!"))
 }

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -11,6 +11,7 @@ import (
 	color "github.com/logrusorgru/aurora"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
+	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
 
 func Fprintf(w io.Writer, format string, a ...any) {
@@ -23,12 +24,14 @@ func Fprintf(w io.Writer, format string, a ...any) {
 type UI struct {
 	out          io.Writer
 	debugEnabled bool
+	recorder     *baseui.UI
 }
 
 func New(cfg *config.Config) *UI {
 	return &UI{
 		out:          os.Stdout,
 		debugEnabled: cfg.DebugEnabled,
+		recorder:     baseui.New(),
 	}
 }
 
@@ -37,7 +40,16 @@ func NewTesting(debugEnabled bool) (*bytes.Buffer, *UI) {
 	return buffer, &UI{
 		out:          buffer,
 		debugEnabled: debugEnabled,
+		recorder:     baseui.New(),
 	}
+}
+
+func (u *UI) Events() []baseui.Event {
+	return u.recorder.Events()
+}
+
+func (u *UI) record(event baseui.Event) {
+	u.recorder.Record(event)
 }
 
 func (u *UI) SetOutputToStderr() {
@@ -48,31 +60,38 @@ func (u *UI) Debug(format string, params ...any) {
 	if u.debugEnabled {
 		msg := fmt.Sprintf(format, params...)
 		msg = strings.TrimSuffix(msg, "\n")
+		u.record(baseui.Event{Kind: baseui.KindDebug, Text: msg})
 		Fprintf(u.out, "%s: %s\n", color.Yellow("BUD_DEBUG"), color.Gray(12, msg))
 	}
 }
 
 func (u *UI) Warningf(format string, params ...any) {
 	msg := fmt.Sprintf(format, params...)
+	u.record(baseui.Event{Kind: baseui.KindWarning, Text: msg})
 	Fprintf(u.out, "%s: %s\n", color.Bold(color.Yellow("WARNING")), msg)
 }
 
 func (u *UI) CommandHeader(cmdline string) {
+	u.record(baseui.Event{Kind: baseui.KindCommandHeader, Text: cmdline})
 	Fprintf(os.Stderr, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
 }
 
 func (u *UI) CommandRun(cmdline string, args ...string) {
+	u.record(baseui.Event{Kind: baseui.KindCommandRun, Text: cmdline, Fields: []baseui.Field{baseui.F("args", strings.Join(args, " "))}})
 	Fprintf(u.out, "%s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
 }
 
 func (u *UI) CommandActed() {
+	u.record(baseui.Event{Kind: baseui.KindCommandActed})
 	Fprintf(u.out, "  %s\n", color.Green("Done!"))
 }
 
 func (u *UI) ProjectExists() {
+	u.record(baseui.Event{Kind: baseui.KindProjectExists})
 	Fprintf(u.out, "🐼  %s\n", color.Yellow("project already exists locally"))
 }
 
 func (u *UI) JumpProject(name string) {
+	u.record(baseui.Event{Kind: baseui.KindJumpProject, Text: name})
 	Fprintf(u.out, "🐼  %s %s\n", color.Yellow("jumping to"), color.Green(name))
 }

--- a/pkg/termui/ui_test.go
+++ b/pkg/termui/ui_test.go
@@ -1,0 +1,44 @@
+package termui
+
+import (
+	"testing"
+
+	baseui "github.com/devbuddy/devbuddy/pkg/ui"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIRecordsEventsWhileRendering(t *testing.T) {
+	buf, ui := NewTesting(false)
+
+	ui.JumpProject("github.com/org/repo")
+
+	require.Contains(t, buf.String(), "jumping to")
+	require.Equal(t, []baseui.Event{
+		{Kind: baseui.KindJumpProject, Text: "github.com/org/repo"},
+	}, ui.Events())
+}
+
+func TestUIDoesNotRecordDisabledDebugEvents(t *testing.T) {
+	_, ui := NewTesting(false)
+
+	ui.Debug("hidden")
+
+	require.Empty(t, ui.Events())
+}
+
+func TestUIRecordsTaskFields(t *testing.T) {
+	_, ui := NewTesting(false)
+
+	ui.TaskHeader("python", "3.9.0", "disabled")
+
+	require.Equal(t, []baseui.Event{
+		{
+			Kind: baseui.KindTaskHeader,
+			Text: "python",
+			Fields: []baseui.Field{
+				baseui.F("param", "3.9.0"),
+				baseui.F("reason", "disabled"),
+			},
+		},
+	}, ui.Events())
+}

--- a/pkg/ui/event.go
+++ b/pkg/ui/event.go
@@ -1,0 +1,42 @@
+package ui
+
+type Kind string
+
+const (
+	KindDebug             Kind = "debug"
+	KindWarning           Kind = "warning"
+	KindCommandHeader     Kind = "command_header"
+	KindCommandRun        Kind = "command_run"
+	KindCommandActed      Kind = "command_acted"
+	KindProjectExists     Kind = "project_exists"
+	KindJumpProject       Kind = "jump_project"
+	KindTaskHeader        Kind = "task_header"
+	KindTaskCommand       Kind = "task_command"
+	KindTaskShell         Kind = "task_shell"
+	KindTaskActed         Kind = "task_acted"
+	KindTaskAlreadyOK     Kind = "task_already_ok"
+	KindTaskError         Kind = "task_error"
+	KindTaskWarning       Kind = "task_warning"
+	KindTaskActionHeader  Kind = "task_action_header"
+	KindActionHeader      Kind = "action_header"
+	KindActionNotice      Kind = "action_notice"
+	KindActionDone        Kind = "action_done"
+	KindHookActivated     Kind = "hook_activated"
+	KindHookFeatureFailed Kind = "hook_feature_failed"
+	KindHookDevYMLChanged Kind = "hook_devyml_changed"
+)
+
+type Field struct {
+	Name  string
+	Value string
+}
+
+type Event struct {
+	Kind   Kind
+	Text   string
+	Fields []Field
+}
+
+func F(name, value string) Field {
+	return Field{Name: name, Value: value}
+}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -1,0 +1,17 @@
+package ui
+
+type UI struct {
+	events []Event
+}
+
+func New() *UI {
+	return &UI{}
+}
+
+func (u *UI) Record(event Event) {
+	u.events = append(u.events, event)
+}
+
+func (u *UI) Events() []Event {
+	return append([]Event(nil), u.events...)
+}

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -1,0 +1,25 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUIRecordsEvents(t *testing.T) {
+	ui := New()
+
+	ui.Record(Event{Kind: KindJumpProject, Text: "org/repo"})
+
+	require.Equal(t, []Event{{Kind: KindJumpProject, Text: "org/repo"}}, ui.Events())
+}
+
+func TestUIEventsReturnsCopy(t *testing.T) {
+	ui := New()
+	ui.Record(Event{Kind: KindWarning, Text: "careful"})
+
+	events := ui.Events()
+	events[0].Text = "mutated"
+
+	require.Equal(t, []Event{{Kind: KindWarning, Text: "careful"}}, ui.Events())
+}


### PR DESCRIPTION
## Summary

- Add `pkg/ui` event types and a small recorder for intent-level UI events.
- Wire existing `termui` methods to record events while preserving the current rendering path.
- Add focused tests for UI event recording through `termui`.

## Validation

- `go test -count=1 ./pkg/ui ./pkg/termui ./pkg/context ./pkg/autoenv ./pkg/tasks/taskengine`
- `script/lint`
- `script/test`

Stacked on #558.
