### PR TITLE
Centralize terminal UI rendering

### DIFF
--- a/pkg/termui/hook.go
+++ b/pkg/termui/hook.go
@@ -1,11 +1,8 @@
 package termui
 
 import (
-	"fmt"
 	"os"
 	"strings"
-
-	color "github.com/logrusorgru/aurora"
 
 	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
@@ -16,7 +13,6 @@ type Feature interface {
 }
 
 func (u *UI) HookFeaturesActivated(features []Feature) {
-	parts := make([]string, len(features))
 	plainParts := make([]string, len(features))
 	fields := make([]baseui.Field, len(features))
 	for i, f := range features {
@@ -24,33 +20,21 @@ func (u *UI) HookFeaturesActivated(features []Feature) {
 		param := f.FeatureParam()
 		if param == "" || strings.HasPrefix(param, "{") {
 			plainParts[i] = f.FeatureName()
-			parts[i] = fmt.Sprintf("%s", color.Blue(f.FeatureName()))
 		} else {
-			plainParts[i] = fmt.Sprintf("%s[%s]", f.FeatureName(), param)
-			parts[i] = fmt.Sprintf("%s%s%s%s", color.Blue(f.FeatureName()), color.Gray(12, "["), color.Cyan(param), color.Gray(12, "]"))
+			plainParts[i] = f.FeatureName() + "[" + param + "]"
 		}
 	}
-	u.record(baseui.Event{Kind: baseui.KindHookActivated, Text: strings.Join(plainParts, ", "), Fields: fields})
-	Fprintf(u.out, "🐼  %s %s\n", color.Cyan("activated:"), strings.Join(parts, color.Gray(12, ", ").String()))
+	u.emit(baseui.Event{Kind: baseui.KindHookActivated, Text: strings.Join(plainParts, ", "), Fields: fields})
 }
 
 func (u *UI) HookFeatureFailure(name string, param string) {
-	u.record(baseui.Event{Kind: baseui.KindHookFeatureFailed, Text: name, Fields: []baseui.Field{baseui.F("param", param)}})
-	msg := fmt.Sprintf("failed to activate %s. Try running 'bud up' first!", name)
-
-	paramStr := ""
-	if param != "" {
-		paramStr = fmt.Sprintf(" (%s)", param)
-	}
-
-	Fprintf(u.out, "🐼  %s%s\n", color.Red(msg), color.Yellow(paramStr))
+	u.emit(baseui.Event{Kind: baseui.KindHookFeatureFailed, Text: name, Fields: []baseui.Field{baseui.F("param", param)}})
 }
 
 func (u *UI) HookDevYmlChanged() {
-	u.record(baseui.Event{Kind: baseui.KindHookDevYMLChanged})
-	Fprintf(u.out, "🐼  %s\n", color.Yellow("dev.yml changed, run `bud up` to apply"))
+	u.emit(baseui.Event{Kind: baseui.KindHookDevYMLChanged})
 }
 
 func HookShellDetectionError(err error) {
-	Fprintf(os.Stderr, "%s %s\n", color.Yellow("Could not detect your shell:"), err.Error())
+	Fprintf(os.Stderr, "%s", baseui.TerminalRenderer{}.Render(baseui.Event{Kind: baseui.KindShellDetectError, Text: err.Error()}))
 }

--- a/pkg/termui/task.go
+++ b/pkg/termui/task.go
@@ -4,45 +4,31 @@ import (
 	"fmt"
 	"strings"
 
-	color "github.com/logrusorgru/aurora"
-
 	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
 
 func (u *UI) TaskHeader(name, param, reason string) {
-	u.record(baseui.Event{Kind: baseui.KindTaskHeader, Text: name, Fields: []baseui.Field{baseui.F("param", param), baseui.F("reason", reason)}})
-	if param != "" {
-		param = fmt.Sprintf(" (%s)", color.Blue(param))
-	}
-	if reason != "" {
-		reason = fmt.Sprintf(" (%s)", color.Yellow(reason))
-	}
-	Fprintf(u.out, "%s %s%s%s\n", color.Yellow("◼︎"), color.Magenta(name), param, reason)
+	u.emit(baseui.Event{Kind: baseui.KindTaskHeader, Text: name, Fields: []baseui.Field{baseui.F("param", param), baseui.F("reason", reason)}})
 }
 
 func (u *UI) TaskCommand(cmdline string, args ...string) {
-	u.record(baseui.Event{Kind: baseui.KindTaskCommand, Text: cmdline, Fields: []baseui.Field{baseui.F("args", strings.Join(args, " "))}})
-	Fprintf(u.out, "  Running: %s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
+	u.emit(baseui.Event{Kind: baseui.KindTaskCommand, Text: cmdline, Fields: []baseui.Field{baseui.F("args", strings.Join(args, " "))}})
 }
 
 func (u *UI) TaskShell(cmdline string) {
-	u.record(baseui.Event{Kind: baseui.KindTaskShell, Text: cmdline})
-	Fprintf(u.out, "  Running: %s\n", color.Cyan(cmdline))
+	u.emit(baseui.Event{Kind: baseui.KindTaskShell, Text: cmdline})
 }
 
 func (u *UI) TaskActed() {
-	u.record(baseui.Event{Kind: baseui.KindTaskActed})
-	Fprintf(u.out, "  %s\n", color.Green("Done!"))
+	u.emit(baseui.Event{Kind: baseui.KindTaskActed})
 }
 
 func (u *UI) TaskAlreadyOk() {
-	u.record(baseui.Event{Kind: baseui.KindTaskAlreadyOK})
-	Fprintf(u.out, "  %s\n", color.Green("Already OK!"))
+	u.emit(baseui.Event{Kind: baseui.KindTaskAlreadyOK})
 }
 
 func (u *UI) TaskError(err error) {
-	u.record(baseui.Event{Kind: baseui.KindTaskError, Text: err.Error()})
-	Fprintf(u.out, "  %s\n", color.Red(err.Error()))
+	u.emit(baseui.Event{Kind: baseui.KindTaskError, Text: err.Error()})
 }
 
 func (u *UI) TaskErrorf(message string, a ...interface{}) {
@@ -50,26 +36,21 @@ func (u *UI) TaskErrorf(message string, a ...interface{}) {
 }
 
 func (u *UI) TaskWarning(message string) {
-	u.record(baseui.Event{Kind: baseui.KindTaskWarning, Text: message})
-	Fprintf(u.out, "  Warning: %s\n", color.Yellow(message))
+	u.emit(baseui.Event{Kind: baseui.KindTaskWarning, Text: message})
 }
 
 func (u *UI) TaskActionHeader(desc string) {
-	u.record(baseui.Event{Kind: baseui.KindTaskActionHeader, Text: desc})
-	Fprintf(u.out, "  %s%s\n", color.Yellow("▪︎"), color.Magenta(desc))
+	u.emit(baseui.Event{Kind: baseui.KindTaskActionHeader, Text: desc})
 }
 
 func (u *UI) ActionHeader(description string) {
-	u.record(baseui.Event{Kind: baseui.KindActionHeader, Text: description})
-	Fprintf(u.out, "🐼  %s\n", color.Cyan(description))
+	u.emit(baseui.Event{Kind: baseui.KindActionHeader, Text: description})
 }
 
 func (u *UI) ActionNotice(text string) {
-	u.record(baseui.Event{Kind: baseui.KindActionNotice, Text: text})
-	Fprintf(u.out, "⚠️   %s\n", color.Yellow(text))
+	u.emit(baseui.Event{Kind: baseui.KindActionNotice, Text: text})
 }
 
 func (u *UI) ActionDone() {
-	u.record(baseui.Event{Kind: baseui.KindActionDone})
-	Fprintf(u.out, "✅  %s\n", color.Green("Done!"))
+	u.emit(baseui.Event{Kind: baseui.KindActionDone})
 }

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strings"
 
-	color "github.com/logrusorgru/aurora"
-
 	"github.com/devbuddy/devbuddy/pkg/config"
 	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
@@ -23,15 +21,19 @@ func Fprintf(w io.Writer, format string, a ...any) {
 
 type UI struct {
 	out          io.Writer
+	err          io.Writer
 	debugEnabled bool
 	recorder     *baseui.UI
+	renderer     baseui.Renderer
 }
 
 func New(cfg *config.Config) *UI {
 	return &UI{
 		out:          os.Stdout,
+		err:          os.Stderr,
 		debugEnabled: cfg.DebugEnabled,
 		recorder:     baseui.New(),
+		renderer:     baseui.TerminalRenderer{},
 	}
 }
 
@@ -39,8 +41,10 @@ func NewTesting(debugEnabled bool) (*bytes.Buffer, *UI) {
 	buffer := bytes.NewBufferString("")
 	return buffer, &UI{
 		out:          buffer,
+		err:          buffer,
 		debugEnabled: debugEnabled,
 		recorder:     baseui.New(),
+		renderer:     baseui.PlainRenderer{},
 	}
 }
 
@@ -52,46 +56,49 @@ func (u *UI) record(event baseui.Event) {
 	u.recorder.Record(event)
 }
 
+func (u *UI) emit(event baseui.Event) {
+	u.record(event)
+	Fprintf(u.out, "%s", u.renderer.Render(event))
+}
+
+func (u *UI) emitErr(event baseui.Event) {
+	u.record(event)
+	Fprintf(u.err, "%s", u.renderer.Render(event))
+}
+
 func (u *UI) SetOutputToStderr() {
-	u.out = os.Stderr
+	u.out = u.err
 }
 
 func (u *UI) Debug(format string, params ...any) {
 	if u.debugEnabled {
 		msg := fmt.Sprintf(format, params...)
 		msg = strings.TrimSuffix(msg, "\n")
-		u.record(baseui.Event{Kind: baseui.KindDebug, Text: msg})
-		Fprintf(u.out, "%s: %s\n", color.Yellow("BUD_DEBUG"), color.Gray(12, msg))
+		u.emit(baseui.Event{Kind: baseui.KindDebug, Text: msg})
 	}
 }
 
 func (u *UI) Warningf(format string, params ...any) {
 	msg := fmt.Sprintf(format, params...)
-	u.record(baseui.Event{Kind: baseui.KindWarning, Text: msg})
-	Fprintf(u.out, "%s: %s\n", color.Bold(color.Yellow("WARNING")), msg)
+	u.emit(baseui.Event{Kind: baseui.KindWarning, Text: msg})
 }
 
 func (u *UI) CommandHeader(cmdline string) {
-	u.record(baseui.Event{Kind: baseui.KindCommandHeader, Text: cmdline})
-	Fprintf(os.Stderr, "🐼  %s %s\n", color.Blue("running"), color.Cyan(cmdline))
+	u.emitErr(baseui.Event{Kind: baseui.KindCommandHeader, Text: cmdline})
 }
 
 func (u *UI) CommandRun(cmdline string, args ...string) {
-	u.record(baseui.Event{Kind: baseui.KindCommandRun, Text: cmdline, Fields: []baseui.Field{baseui.F("args", strings.Join(args, " "))}})
-	Fprintf(u.out, "%s %s\n", color.Bold(color.Cyan(cmdline)), color.Cyan(strings.Join(args, " ")))
+	u.emit(baseui.Event{Kind: baseui.KindCommandRun, Text: cmdline, Fields: []baseui.Field{baseui.F("args", strings.Join(args, " "))}})
 }
 
 func (u *UI) CommandActed() {
-	u.record(baseui.Event{Kind: baseui.KindCommandActed})
-	Fprintf(u.out, "  %s\n", color.Green("Done!"))
+	u.emit(baseui.Event{Kind: baseui.KindCommandActed})
 }
 
 func (u *UI) ProjectExists() {
-	u.record(baseui.Event{Kind: baseui.KindProjectExists})
-	Fprintf(u.out, "🐼  %s\n", color.Yellow("project already exists locally"))
+	u.emit(baseui.Event{Kind: baseui.KindProjectExists})
 }
 
 func (u *UI) JumpProject(name string) {
-	u.record(baseui.Event{Kind: baseui.KindJumpProject, Text: name})
-	Fprintf(u.out, "🐼  %s %s\n", color.Yellow("jumping to"), color.Green(name))
+	u.emit(baseui.Event{Kind: baseui.KindJumpProject, Text: name})
 }

--- a/pkg/ui/event.go
+++ b/pkg/ui/event.go
@@ -24,6 +24,7 @@ const (
 	KindHookActivated     Kind = "hook_activated"
 	KindHookFeatureFailed Kind = "hook_feature_failed"
 	KindHookDevYMLChanged Kind = "hook_devyml_changed"
+	KindShellDetectError  Kind = "shell_detect_error"
 )
 
 type Field struct {

--- a/pkg/ui/renderer.go
+++ b/pkg/ui/renderer.go
@@ -1,0 +1,185 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	color "github.com/logrusorgru/aurora"
+)
+
+type Renderer interface {
+	Render(Event) string
+}
+
+type PlainRenderer struct{}
+type TerminalRenderer struct{}
+
+func (PlainRenderer) Render(event Event) string {
+	return renderPlain(event)
+}
+
+func (TerminalRenderer) Render(event Event) string {
+	switch event.Kind {
+	case KindDebug:
+		return fmt.Sprintf("%s: %s\n", color.Yellow("BUD_DEBUG"), color.Gray(12, event.Text))
+	case KindWarning:
+		return fmt.Sprintf("%s: %s\n", color.Bold(color.Yellow("WARNING")), event.Text)
+	case KindCommandHeader:
+		return fmt.Sprintf("🐼  %s %s\n", color.Blue("running"), color.Cyan(event.Text))
+	case KindCommandRun:
+		return fmt.Sprintf("%s %s\n", color.Bold(color.Cyan(event.Text)), color.Cyan(field(event, "args")))
+	case KindCommandActed:
+		return fmt.Sprintf("  %s\n", color.Green("Done!"))
+	case KindProjectExists:
+		return fmt.Sprintf("🐼  %s\n", color.Yellow("project already exists locally"))
+	case KindJumpProject:
+		return fmt.Sprintf("🐼  %s %s\n", color.Yellow("jumping to"), color.Green(event.Text))
+	case KindTaskHeader:
+		return renderTaskHeader(event, true)
+	case KindTaskCommand:
+		return fmt.Sprintf("  Running: %s %s\n", color.Bold(color.Cyan(event.Text)), color.Cyan(field(event, "args")))
+	case KindTaskShell:
+		return fmt.Sprintf("  Running: %s\n", color.Cyan(event.Text))
+	case KindTaskActed:
+		return fmt.Sprintf("  %s\n", color.Green("Done!"))
+	case KindTaskAlreadyOK:
+		return fmt.Sprintf("  %s\n", color.Green("Already OK!"))
+	case KindTaskError:
+		return fmt.Sprintf("  %s\n", color.Red(event.Text))
+	case KindTaskWarning:
+		return fmt.Sprintf("  Warning: %s\n", color.Yellow(event.Text))
+	case KindTaskActionHeader:
+		return fmt.Sprintf("  %s%s\n", color.Yellow("▪︎"), color.Magenta(event.Text))
+	case KindActionHeader:
+		return fmt.Sprintf("🐼  %s\n", color.Cyan(event.Text))
+	case KindActionNotice:
+		return fmt.Sprintf("⚠️   %s\n", color.Yellow(event.Text))
+	case KindActionDone:
+		return fmt.Sprintf("✅  %s\n", color.Green("Done!"))
+	case KindHookActivated:
+		return fmt.Sprintf("🐼  %s %s\n", color.Cyan("activated:"), renderFeatureList(event, true))
+	case KindHookFeatureFailed:
+		param := field(event, "param")
+		if param != "" {
+			param = fmt.Sprintf(" (%s)", color.Yellow(param))
+		}
+		return fmt.Sprintf("🐼  %s%s\n", color.Red(fmt.Sprintf("failed to activate %s. Try running 'bud up' first!", event.Text)), param)
+	case KindHookDevYMLChanged:
+		return fmt.Sprintf("🐼  %s\n", color.Yellow("dev.yml changed, run `bud up` to apply"))
+	case KindShellDetectError:
+		return fmt.Sprintf("%s %s\n", color.Yellow("Could not detect your shell:"), event.Text)
+	default:
+		return renderPlain(event)
+	}
+}
+
+func renderPlain(event Event) string {
+	switch event.Kind {
+	case KindDebug:
+		return fmt.Sprintf("BUD_DEBUG: %s\n", event.Text)
+	case KindWarning:
+		return fmt.Sprintf("WARNING: %s\n", event.Text)
+	case KindCommandHeader:
+		return fmt.Sprintf("🐼  running %s\n", event.Text)
+	case KindCommandRun:
+		return fmt.Sprintf("%s %s\n", event.Text, field(event, "args"))
+	case KindCommandActed:
+		return "  Done!\n"
+	case KindProjectExists:
+		return "🐼  project already exists locally\n"
+	case KindJumpProject:
+		return fmt.Sprintf("🐼  jumping to %s\n", event.Text)
+	case KindTaskHeader:
+		return renderTaskHeader(event, false)
+	case KindTaskCommand:
+		return fmt.Sprintf("  Running: %s %s\n", event.Text, field(event, "args"))
+	case KindTaskShell:
+		return fmt.Sprintf("  Running: %s\n", event.Text)
+	case KindTaskActed:
+		return "  Done!\n"
+	case KindTaskAlreadyOK:
+		return "  Already OK!\n"
+	case KindTaskError:
+		return fmt.Sprintf("  %s\n", event.Text)
+	case KindTaskWarning:
+		return fmt.Sprintf("  Warning: %s\n", event.Text)
+	case KindTaskActionHeader:
+		return fmt.Sprintf("  ▪︎%s\n", event.Text)
+	case KindActionHeader:
+		return fmt.Sprintf("🐼  %s\n", event.Text)
+	case KindActionNotice:
+		return fmt.Sprintf("⚠️   %s\n", event.Text)
+	case KindActionDone:
+		return "✅  Done!\n"
+	case KindHookActivated:
+		return fmt.Sprintf("🐼  activated: %s\n", renderFeatureList(event, false))
+	case KindHookFeatureFailed:
+		param := field(event, "param")
+		if param != "" {
+			param = fmt.Sprintf(" (%s)", param)
+		}
+		return fmt.Sprintf("🐼  failed to activate %s. Try running 'bud up' first!%s\n", event.Text, param)
+	case KindHookDevYMLChanged:
+		return "🐼  dev.yml changed, run `bud up` to apply\n"
+	case KindShellDetectError:
+		return fmt.Sprintf("Could not detect your shell: %s\n", event.Text)
+	default:
+		return event.Text + "\n"
+	}
+}
+
+func renderTaskHeader(event Event, styled bool) string {
+	name := event.Text
+	param := field(event, "param")
+	reason := field(event, "reason")
+	if styled {
+		name = color.Magenta(name).String()
+		if param != "" {
+			param = fmt.Sprintf(" (%s)", color.Blue(param))
+		}
+		if reason != "" {
+			reason = fmt.Sprintf(" (%s)", color.Yellow(reason))
+		}
+		return fmt.Sprintf("%s %s%s%s\n", color.Yellow("◼︎"), name, param, reason)
+	}
+	if param != "" {
+		param = fmt.Sprintf(" (%s)", param)
+	}
+	if reason != "" {
+		reason = fmt.Sprintf(" (%s)", reason)
+	}
+	return fmt.Sprintf("◼︎ %s%s%s\n", name, param, reason)
+}
+
+func renderFeatureList(event Event, styled bool) string {
+	parts := make([]string, 0, len(event.Fields))
+	for _, feature := range event.Fields {
+		if feature.Value == "" || strings.HasPrefix(feature.Value, "{") {
+			if styled {
+				parts = append(parts, color.Blue(feature.Name).String())
+			} else {
+				parts = append(parts, feature.Name)
+			}
+			continue
+		}
+		if styled {
+			parts = append(parts, fmt.Sprintf("%s%s%s%s", color.Blue(feature.Name), color.Gray(12, "["), color.Cyan(feature.Value), color.Gray(12, "]")))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s[%s]", feature.Name, feature.Value))
+		}
+	}
+	separator := ", "
+	if styled {
+		separator = color.Gray(12, separator).String()
+	}
+	return strings.Join(parts, separator)
+}
+
+func field(event Event, name string) string {
+	for _, field := range event.Fields {
+		if field.Name == name {
+			return field.Value
+		}
+	}
+	return ""
+}

--- a/pkg/ui/renderer_test.go
+++ b/pkg/ui/renderer_test.go
@@ -1,0 +1,33 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlainRendererDoesNotEmitANSI(t *testing.T) {
+	got := PlainRenderer{}.Render(Event{Kind: KindJumpProject, Text: "org/repo"})
+
+	require.Equal(t, "🐼  jumping to org/repo\n", got)
+}
+
+func TestTerminalRendererStylesOutput(t *testing.T) {
+	got := TerminalRenderer{}.Render(Event{Kind: KindJumpProject, Text: "org/repo"})
+
+	require.Contains(t, got, "\x1b[")
+	require.Contains(t, got, "jumping to")
+	require.Contains(t, got, "org/repo")
+}
+
+func TestRendererFormatsFeatureList(t *testing.T) {
+	event := Event{
+		Kind: KindHookActivated,
+		Fields: []Field{
+			F("python", "3.9.0"),
+			F("env", ""),
+		},
+	}
+
+	require.Equal(t, "🐼  activated: python[3.9.0], env\n", PlainRenderer{}.Render(event))
+}


### PR DESCRIPTION
## Summary

- Add plain and terminal renderers for UI events.
- Move `termui` output formatting through the new renderer path.
- Keep ANSI/color concerns centralized in `pkg/ui` while preserving current production output style.

## Validation

- `go test -count=1 ./pkg/ui ./pkg/termui ./pkg/context ./pkg/autoenv ./pkg/tasks/taskengine`
- `script/lint`
- `script/test`

Stacked on #559.
