### PR TITLE
Add prompt abstraction for worktree switching

### DIFF
--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
 	"github.com/devbuddy/devbuddy/pkg/integration"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 	"github.com/devbuddy/devbuddy/pkg/worktree"
 )
 
@@ -169,7 +170,10 @@ func worktreeSwitchRun(_ *cobra.Command, args []string) error {
 
 	wt := matches[0]
 	if query == "" && len(matches) > 1 {
-		selected, err := selectWorktree(ctx.Executor, matches)
+		selected, err := selectWorktree(ctx.UI.Prompts(), ctx.Executor, matches)
+		if errors.Is(err, ui.ErrPromptCancelled) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
@@ -254,43 +258,32 @@ func oneOrTwoArgs(_ *cobra.Command, args []string) error {
 	return nil
 }
 
-type switchItem struct {
-	Label    string
-	Worktree worktree.Worktree
-}
-
-func selectWorktree(exec *executor.Executor, worktrees []worktree.Worktree) (worktree.Worktree, error) {
+func selectWorktree(prompts ui.Prompts, exec *executor.Executor, worktrees []worktree.Worktree) (worktree.Worktree, error) {
 	rows := buildWorktreeRows(exec, worktrees)
 	labels := formatWorktreeRows(rows, false)
-	items := make([]switchItem, 0, len(rows))
+	options := make([]ui.SelectOption, 0, len(rows))
+	byPath := map[string]worktree.Worktree{}
 	for i, row := range rows {
-		items = append(items, switchItem{
-			Label:    labels[i],
-			Worktree: row.Worktree,
+		options = append(options, ui.SelectOption{
+			Value: row.Worktree.Path,
+			Label: labels[i],
 		})
+		byPath[row.Worktree.Path] = row.Worktree
 	}
 
-	prompt := promptui.Select{
-		Label:        "Select worktree",
-		Items:        items,
-		HideSelected: true,
-		Templates:    worktreeSwitchTemplates(),
-	}
-
-	index, _, err := prompt.Run()
+	path, err := prompts.Select(ui.SelectRequest{
+		Label:   "Select worktree",
+		Options: options,
+	})
 	if err != nil {
 		return worktree.Worktree{}, err
 	}
-	return items[index].Worktree, nil
-}
 
-func worktreeSwitchTemplates() *promptui.SelectTemplates {
-	return &promptui.SelectTemplates{
-		Label:    "{{ . }}",
-		Active:   "🐼 {{ .Label | cyan }}",
-		Inactive: "   {{ .Label }}",
-		Selected: "🐼 {{ .Label }}",
+	wt, ok := byPath[path]
+	if !ok {
+		return worktree.Worktree{}, fmt.Errorf("selected worktree no longer exists: %s", path)
 	}
+	return wt, nil
 }
 
 func matchWorktrees(worktrees []worktree.Worktree, query string) []worktree.Worktree {

--- a/pkg/cmd/worktree_test.go
+++ b/pkg/cmd/worktree_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 	"github.com/devbuddy/devbuddy/pkg/worktree"
 )
 
@@ -38,11 +40,46 @@ func TestFormatWorktreeRowsAlignsColumns(t *testing.T) {
 	require.Contains(t, lines[1], "long-feature-branch")
 }
 
-func TestWorktreeSwitchMenuTemplateAlignsInactiveRowsWithPandaMarker(t *testing.T) {
-	templates := worktreeSwitchTemplates()
+func TestSelectWorktreeUsesPromptOptions(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "api")
+	secondPath := filepath.Join(dir, "api--feature-a")
+	require.NoError(t, os.Mkdir(firstPath, 0755))
+	require.NoError(t, os.Mkdir(secondPath, 0755))
 
-	require.Equal(t, "🐼 {{ .Label | cyan }}", templates.Active)
-	require.Equal(t, "   {{ .Label }}", templates.Inactive)
+	prompts := &ui.FakePrompts{SelectValue: secondPath}
+	exec := &executor.Executor{Runner: worktreeRunner{}}
+
+	got, err := selectWorktree(prompts, exec, []worktree.Worktree{
+		{Path: firstPath, Branch: "main", Head: "111111111111"},
+		{Path: secondPath, Branch: "feature-a", Head: "222222222222"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, secondPath, got.Path)
+	require.Len(t, prompts.SelectRequests, 1)
+	require.Equal(t, "Select worktree", prompts.SelectRequests[0].Label)
+	require.Equal(t, []ui.SelectOption{
+		{Value: firstPath, Label: prompts.SelectRequests[0].Options[0].Label},
+		{Value: secondPath, Label: prompts.SelectRequests[0].Options[1].Label},
+	}, prompts.SelectRequests[0].Options)
+	require.Contains(t, prompts.SelectRequests[0].Options[0].Label, "main")
+	require.Contains(t, prompts.SelectRequests[0].Options[1].Label, "feature-a")
+}
+
+func TestSelectWorktreeReturnsPromptCancellation(t *testing.T) {
+	dir := t.TempDir()
+	worktreePath := filepath.Join(dir, "api")
+	require.NoError(t, os.Mkdir(worktreePath, 0755))
+
+	prompts := &ui.FakePrompts{SelectErr: ui.ErrPromptCancelled}
+	exec := &executor.Executor{Runner: worktreeRunner{}}
+
+	_, err := selectWorktree(prompts, exec, []worktree.Worktree{
+		{Path: worktreePath, Branch: "main", Head: "111111111111"},
+	})
+
+	require.ErrorIs(t, err, ui.ErrPromptCancelled)
 }
 
 func TestInactiveWorktreesSkipsMainAndRecentWorktrees(t *testing.T) {
@@ -66,4 +103,14 @@ func TestInactiveWorktreesSkipsMainAndRecentWorktrees(t *testing.T) {
 	}, now, 7*24*time.Hour)
 
 	require.Equal(t, []worktree.Worktree{{Path: oldPath, Branch: "old"}}, got)
+}
+
+type worktreeRunner struct{}
+
+func (worktreeRunner) Run(*executor.Command) *executor.Result {
+	return &executor.Result{}
+}
+
+func (worktreeRunner) Capture(*executor.Command) *executor.Result {
+	return &executor.Result{}
 }

--- a/pkg/termui/ui.go
+++ b/pkg/termui/ui.go
@@ -39,17 +39,26 @@ func New(cfg *config.Config) *UI {
 
 func NewTesting(debugEnabled bool) (*bytes.Buffer, *UI) {
 	buffer := bytes.NewBufferString("")
+	_, recorder := baseui.NewTesting()
 	return buffer, &UI{
 		out:          buffer,
 		err:          buffer,
 		debugEnabled: debugEnabled,
-		recorder:     baseui.New(),
+		recorder:     recorder,
 		renderer:     baseui.PlainRenderer{},
 	}
 }
 
 func (u *UI) Events() []baseui.Event {
 	return u.recorder.Events()
+}
+
+func (u *UI) Prompts() baseui.Prompts {
+	return u.recorder.Prompts()
+}
+
+func (u *UI) SetPrompts(prompts baseui.Prompts) {
+	u.recorder.SetPrompts(prompts)
 }
 
 func (u *UI) record(event baseui.Event) {

--- a/pkg/ui/fake_prompts.go
+++ b/pkg/ui/fake_prompts.go
@@ -1,0 +1,20 @@
+package ui
+
+type FakePrompts struct {
+	SelectRequests  []SelectRequest
+	ConfirmRequests []ConfirmRequest
+	SelectValue     string
+	SelectErr       error
+	ConfirmValue    bool
+	ConfirmErr      error
+}
+
+func (p *FakePrompts) Select(req SelectRequest) (string, error) {
+	p.SelectRequests = append(p.SelectRequests, req)
+	return p.SelectValue, p.SelectErr
+}
+
+func (p *FakePrompts) Confirm(req ConfirmRequest) (bool, error) {
+	p.ConfirmRequests = append(p.ConfirmRequests, req)
+	return p.ConfirmValue, p.ConfirmErr
+}

--- a/pkg/ui/prompts.go
+++ b/pkg/ui/prompts.go
@@ -1,0 +1,24 @@
+package ui
+
+import "errors"
+
+var ErrPromptCancelled = errors.New("prompt cancelled")
+
+type SelectOption struct {
+	Value string
+	Label string
+}
+
+type SelectRequest struct {
+	Label   string
+	Options []SelectOption
+}
+
+type ConfirmRequest struct {
+	Label string
+}
+
+type Prompts interface {
+	Select(SelectRequest) (string, error)
+	Confirm(ConfirmRequest) (bool, error)
+}

--- a/pkg/ui/promptui_prompts.go
+++ b/pkg/ui/promptui_prompts.go
@@ -1,0 +1,58 @@
+package ui
+
+import (
+	"errors"
+
+	"github.com/manifoldco/promptui"
+)
+
+type PromptUIPrompts struct{}
+
+func (PromptUIPrompts) Select(req SelectRequest) (string, error) {
+	items := make([]selectItem, 0, len(req.Options))
+	for _, opt := range req.Options {
+		items = append(items, selectItem(opt))
+	}
+
+	prompt := promptui.Select{
+		Label:        req.Label,
+		Items:        items,
+		HideSelected: true,
+		Templates:    promptUISelectTemplates(),
+	}
+
+	index, _, err := prompt.Run()
+	if errors.Is(err, promptui.ErrInterrupt) || errors.Is(err, promptui.ErrEOF) {
+		return "", ErrPromptCancelled
+	}
+	if err != nil {
+		return "", err
+	}
+	return items[index].Value, nil
+}
+
+func (PromptUIPrompts) Confirm(req ConfirmRequest) (bool, error) {
+	prompt := promptui.Prompt{
+		Label:     req.Label,
+		IsConfirm: true,
+	}
+	_, err := prompt.Run()
+	if errors.Is(err, promptui.ErrAbort) || errors.Is(err, promptui.ErrInterrupt) || errors.Is(err, promptui.ErrEOF) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
+type selectItem struct {
+	Value string
+	Label string
+}
+
+func promptUISelectTemplates() *promptui.SelectTemplates {
+	return &promptui.SelectTemplates{
+		Label:    "{{ . }}",
+		Active:   "🐼 {{ .Label | cyan }}",
+		Inactive: "   {{ .Label }}",
+		Selected: "🐼 {{ .Label }}",
+	}
+}

--- a/pkg/ui/promptui_prompts_test.go
+++ b/pkg/ui/promptui_prompts_test.go
@@ -1,0 +1,14 @@
+package ui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPromptUISelectTemplatesAlignInactiveRowsWithPandaMarker(t *testing.T) {
+	templates := promptUISelectTemplates()
+
+	require.Equal(t, "🐼 {{ .Label | cyan }}", templates.Active)
+	require.Equal(t, "   {{ .Label }}", templates.Inactive)
+}

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -1,11 +1,17 @@
 package ui
 
 type UI struct {
-	events []Event
+	events  []Event
+	prompts Prompts
 }
 
 func New() *UI {
-	return &UI{}
+	return &UI{prompts: PromptUIPrompts{}}
+}
+
+func NewTesting() (*FakePrompts, *UI) {
+	prompts := &FakePrompts{}
+	return prompts, &UI{prompts: prompts}
 }
 
 func (u *UI) Record(event Event) {
@@ -14,4 +20,12 @@ func (u *UI) Record(event Event) {
 
 func (u *UI) Events() []Event {
 	return append([]Event(nil), u.events...)
+}
+
+func (u *UI) Prompts() Prompts {
+	return u.prompts
+}
+
+func (u *UI) SetPrompts(prompts Prompts) {
+	u.prompts = prompts
 }

--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -23,3 +23,14 @@ func TestUIEventsReturnsCopy(t *testing.T) {
 
 	require.Equal(t, []Event{{Kind: KindWarning, Text: "careful"}}, ui.Events())
 }
+
+func TestNewTestingInstallsFakePrompts(t *testing.T) {
+	prompts, ui := NewTesting()
+
+	prompts.SelectValue = "feature-a"
+	got, err := ui.Prompts().Select(SelectRequest{Label: "Select"})
+
+	require.NoError(t, err)
+	require.Equal(t, "feature-a", got)
+	require.Len(t, prompts.SelectRequests, 1)
+}


### PR DESCRIPTION
## Summary
- add a `ui.Prompts` boundary with select/confirm requests and fake prompts for tests
- keep production promptui behavior behind a `PromptUIPrompts` adapter
- route `bud tree switch` interactive selection through the prompt interface

Stacked on #560.

## Validation
- `go test -count=1 ./pkg/ui ./pkg/termui ./pkg/cmd ./pkg/worktree`
- `script/lint`
- `script/test`