### PR TITLE
Migrate prompts to UI runtime

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/goccy/go-yaml v1.19.2
 	github.com/joho/godotenv v1.5.1
 	github.com/logrusorgru/aurora v2.0.3+incompatible
-	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/sahilm/fuzzy v0.1.2
 	github.com/spf13/cobra v1.10.2
@@ -18,7 +17,6 @@ require (
 )
 
 require (
-	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,12 +2,6 @@ github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkk
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
-github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
-github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
-github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
-github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
@@ -31,8 +25,6 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczGlG91VSDkswnjF5A8=
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
-github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
-github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
@@ -67,7 +59,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/cmd/clone.go
+++ b/pkg/cmd/clone.go
@@ -1,13 +1,15 @@
 package cmd
 
 import (
-	"github.com/manifoldco/promptui"
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/integration"
 	"github.com/devbuddy/devbuddy/pkg/manifest"
 	"github.com/devbuddy/devbuddy/pkg/project"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 )
 
 var cloneCmd = &cobra.Command{
@@ -39,11 +41,13 @@ func cloneRun(_ *cobra.Command, args []string) error {
 	}
 
 	if !manifest.ExistsIn(proj.Path) {
-		prompt := promptui.Prompt{
-			Label:     "This project has no dev.yml. Create one",
-			IsConfirm: true,
+		confirmed, err := ctx.UI.Prompts().Confirm(ui.ConfirmRequest{
+			Label: "This project has no dev.yml. Create one",
+		})
+		if err != nil && !errors.Is(err, ui.ErrPromptCancelled) {
+			return err
 		}
-		if _, err := prompt.Run(); err == nil {
+		if confirmed {
 			if err := createManifest(ctx.UI, proj.Path, ""); err != nil {
 				return err
 			}

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,15 +1,16 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"slices"
 
-	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
 	"github.com/devbuddy/devbuddy/pkg/manifest"
 	"github.com/devbuddy/devbuddy/pkg/termui"
+	baseui "github.com/devbuddy/devbuddy/pkg/ui"
 )
 
 var initCmd = &cobra.Command{
@@ -46,17 +47,24 @@ func createManifest(ui *termui.UI, projectPath string, templateName string) erro
 	templates := manifest.ListTemplates()
 
 	if templateName == "" || !slices.Contains(templates, templateName) {
-		prompt := promptui.Select{
-			Label:        "Select a template",
-			Items:        templates,
-			HideSelected: true,
+		options := make([]baseui.SelectOption, 0, len(templates))
+		for _, template := range templates {
+			options = append(options, baseui.SelectOption{
+				Value: template,
+				Label: template,
+			})
 		}
 
-		_, result, err := prompt.Run()
+		result, err := ui.Prompts().Select(baseui.SelectRequest{
+			Label:   "Select a template",
+			Options: options,
+		})
+		if errors.Is(err, baseui.ErrPromptCancelled) {
+			return nil
+		}
 		if err != nil {
 			return err
 		}
-
 		templateName = result
 	}
 

--- a/pkg/cmd/init_test.go
+++ b/pkg/cmd/init_test.go
@@ -1,0 +1,39 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/devbuddy/devbuddy/pkg/termui"
+	"github.com/devbuddy/devbuddy/pkg/ui"
+)
+
+func TestCreateManifestPromptsForTemplate(t *testing.T) {
+	projectPath := t.TempDir()
+	_, cmdUI := termui.NewTesting(false)
+	prompts := &ui.FakePrompts{SelectValue: "go"}
+	cmdUI.SetPrompts(prompts)
+
+	err := createManifest(cmdUI, projectPath, "")
+
+	require.NoError(t, err)
+	require.FileExists(t, filepath.Join(projectPath, "dev.yml"))
+	require.Len(t, prompts.SelectRequests, 1)
+	require.Equal(t, "Select a template", prompts.SelectRequests[0].Label)
+	require.Contains(t, prompts.SelectRequests[0].Options, ui.SelectOption{Value: "go", Label: "go"})
+}
+
+func TestCreateManifestPromptCancellationSkipsManifest(t *testing.T) {
+	projectPath := t.TempDir()
+	_, cmdUI := termui.NewTesting(false)
+	cmdUI.SetPrompts(&ui.FakePrompts{SelectErr: ui.ErrPromptCancelled})
+
+	err := createManifest(cmdUI, projectPath, "")
+
+	require.NoError(t, err)
+	_, statErr := os.Stat(filepath.Join(projectPath, "dev.yml"))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/manifoldco/promptui"
 	"github.com/sahilm/fuzzy"
 	"github.com/spf13/cobra"
 
@@ -229,16 +228,17 @@ func worktreePruneRun(_ *cobra.Command, _ []string) error {
 	}
 
 	for _, wt := range inactiveWorktrees(worktrees, time.Now(), 7*24*time.Hour) {
-		prompt := promptui.Prompt{
-			Label:     fmt.Sprintf("Delete inactive worktree %s at %s", worktreeLabel(wt), wt.Path),
-			IsConfirm: true,
+		confirmed, err := ctx.UI.Prompts().Confirm(ui.ConfirmRequest{
+			Label: fmt.Sprintf("Delete inactive worktree %s at %s", worktreeLabel(wt), wt.Path),
+		})
+		if errors.Is(err, ui.ErrPromptCancelled) {
+			continue
 		}
-
-		if _, err := prompt.Run(); err != nil {
-			if errors.Is(err, promptui.ErrAbort) {
-				continue
-			}
+		if err != nil {
 			return err
+		}
+		if !confirmed {
+			continue
 		}
 
 		if err := worktree.Remove(ctx.Executor, ctx.Project.Path, wt.Path); err != nil {

--- a/pkg/ui/survey_prompts.go
+++ b/pkg/ui/survey_prompts.go
@@ -1,7 +1,12 @@
 package ui
 
 import (
+	"bufio"
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
 
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/AlecAivazis/survey/v2/terminal"
@@ -32,12 +37,20 @@ func (SurveyPrompts) Select(req SelectRequest) (string, error) {
 }
 
 func (SurveyPrompts) Confirm(req ConfirmRequest) (bool, error) {
-	var confirmed bool
-	err := survey.AskOne(&survey.Confirm{
-		Message: req.Label,
-	}, &confirmed)
-	if errors.Is(err, terminal.InterruptErr) {
-		return false, ErrPromptCancelled
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Fprintf(os.Stderr, "%s (y/N): ", req.Label)
+		answer, err := reader.ReadString('\n')
+		fmt.Fprintln(os.Stderr)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, err
+		}
+
+		switch strings.ToLower(strings.TrimSpace(answer)) {
+		case "y", "yes":
+			return true, nil
+		case "", "n", "no":
+			return false, nil
+		}
 	}
-	return confirmed, err
 }

--- a/tests/shell/cmd_worktree_test.go
+++ b/tests/shell/cmd_worktree_test.go
@@ -106,10 +106,8 @@ func Test_Cmd_Tree_Prune_Asks_To_Delete_Inactive_Worktrees(t *testing.T) {
 	c.Cd(t, projectPath)
 	c.Run(t, "touch -d '8 days ago' "+oldWorktreePath)
 
-	c.Send(t, "bud tree prune\n")
-	c.Expect(t, "Delete inactive worktree old-branch")
-	c.Send(t, "y\r")
-	c.WaitPrompt(t)
+	output := c.Run(t, "printf 'y\\n' | /usr/local/bin/bud tree prune")
+	harness.OutputContains(t, output, "Delete inactive worktree old-branch")
 
 	c.Run(t, "test ! -e "+oldWorktreePath)
 	c.AssertExist(t, recentWorktreePath)


### PR DESCRIPTION
## Summary
- migrate init template selection, clone manifest confirmation, and worktree prune confirmation onto the UI prompt runtime
- keep survey for interactive selection and use a simple line-based confirmation prompt
- remove the remaining promptui dependency from go.mod/go.sum
- add unit coverage for init template prompting and cancellation

## Validation
- script/test
- script/lint
- go test -count=1 ./pkg/cmd ./pkg/ui ./pkg/termui
- TEST_DOCKER_IMAGE="ghcr.io/devbuddy/docker-testing:sha-7fd13f4" TEST_SHELL=bash go test -v -timeout 120s -run 'Test_Cmd_(Init|Clone|Tree_Prune)' -count=1 ./tests/shell\n- TEST_DOCKER_IMAGE="ghcr.io/devbuddy/docker-testing:sha-7fd13f4" TEST_SHELL=zsh go test -v -timeout 120s -run 'Test_Cmd_(Init|Clone|Tree_Prune)' -count=1 ./tests/shell\n- rg -n "promptui|manifoldco" pkg go.mod go.sum tests