### PR TITLE
Prevent main worktree removal and jump back after removal

### DIFF
--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -189,7 +189,15 @@ func worktreeRemoveRun(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	worktrees, err := worktree.List(ctx.Executor, ctx.Project.Path)
+	return runWorktreeRemove(ctx, args, worktree.List)
+}
+
+func runWorktreeRemove(
+	ctx *context.Context,
+	args []string,
+	listWorktrees func(*executor.Executor, string) ([]worktree.Worktree, error),
+) error {
+	worktrees, err := listWorktrees(ctx.Executor, ctx.Project.Path)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -227,7 +227,9 @@ func worktreeRemoveRun(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("🐼  removed worktree %s\n", wt.Path)
-	return integration.AddFinalizerCd(repoPath)
+	mainWt := mainWorktree(worktrees)
+	ctx.UI.JumpProject(worktreeLabel(mainWt))
+	return integration.AddFinalizerCd(mainWt.Path)
 }
 
 func worktreePruneRun(_ *cobra.Command, _ []string) error {
@@ -333,13 +335,21 @@ func worktreeExactMatch(wt worktree.Worktree, query string) bool {
 	return wt.Branch == query || base == query || strings.HasSuffix(base, "--"+query)
 }
 
-func mainWorktreePath(worktrees []worktree.Worktree, fallback string) string {
+func mainWorktree(worktrees []worktree.Worktree) worktree.Worktree {
 	for _, wt := range worktrees {
 		if !wt.Bare {
-			return wt.Path
+			return wt
 		}
 	}
-	return fallback
+	return worktree.Worktree{}
+}
+
+func mainWorktreePath(worktrees []worktree.Worktree, fallback string) string {
+	wt := mainWorktree(worktrees)
+	if wt.Path == "" {
+		return fallback
+	}
+	return wt.Path
 }
 
 func removableWorktrees(worktrees []worktree.Worktree, mainPath string) []worktree.Worktree {

--- a/pkg/cmd/worktree_test.go
+++ b/pkg/cmd/worktree_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
+	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/project"
 	"github.com/devbuddy/devbuddy/pkg/ui"
 	"github.com/devbuddy/devbuddy/pkg/worktree"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFormatWorktreeRowsAlignsColumns(t *testing.T) {
@@ -108,6 +109,79 @@ func TestInactiveWorktreesSkipsMainAndRecentWorktrees(t *testing.T) {
 type worktreeRunner struct{}
 
 func (worktreeRunner) Run(*executor.Command) *executor.Result {
+	return &executor.Result{}
+}
+
+func (worktreeRunner) Capture(*executor.Command) *executor.Result {
+	return &executor.Result{}
+}
+
+func TestWorktreeRemoveRun(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "api")
+	otherPath := filepath.Join(dir, "api--feat")
+	require.NoError(t, os.Mkdir(mainPath, 0755))
+	require.NoError(t, os.Mkdir(otherPath, 0755))
+
+	worktrees := []worktree.Worktree{
+		{Path: mainPath, Branch: "main"},
+		{Path: otherPath, Branch: "feat"},
+	}
+
+	t.Run("refuses to remove main worktree", func(t *testing.T) {
+		_, buf := ui.NewBufferedTesting(false)
+		ctx := &context.Context{
+			Project:  &project.Project{Path: mainPath},
+			Executor: &executor.Executor{Runner: worktreeRunner{}},
+			UI:       buf,
+		}
+
+		args := []string{"main"}
+		err := __worktreeRemoveRun(ctx, args, func(*executor.Executor, string) ([]worktree.Worktree, error) {
+			return worktrees, nil
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "refusing to remove the main worktree")
+	})
+}
+
+func TestWorktreeRemoveRunSuccess(t *testing.T) {
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "api")
+	otherPath := filepath.Join(dir, "api--feat")
+	require.NoError(t, os.Mkdir(mainPath, 0755))
+	require.NoError(t, os.Mkdir(otherPath, 0755))
+
+	worktrees := []worktree.Worktree{
+		{Path: mainPath, Branch: "main"},
+		{Path: otherPath, Branch: "feat"},
+	}
+
+	_, buf := ui.NewBufferedTesting(false)
+	ctx := &context.Context{
+		Project:  &project.Project{Path: mainPath},
+		Executor: &executor.Executor{Runner: worktreeRunner{}},
+		UI:       buf,
+	}
+	os.Setenv("BUD_FINALIZER_FILE", filepath.Join(dir, "finalizer"))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "finalizer"), []byte(""), 0644))
+
+	args := []string{"feat"}
+	err := __worktreeRemoveRun(ctx, args, func(*executor.Executor, string) ([]worktree.Worktree, error) {
+		return worktrees, nil
+	})
+
+	require.NoError(t, err)
+}
+
+type worktreeRunner struct{}
+
+func (worktreeRunner) Run(*executor.Command) *executor.Result {
+	return &executor.Result{}
+}
+
+func (worktreeRunner) Capture(*executor.Command) *executor.Result {
 	return &executor.Result{}
 }
 

--- a/pkg/cmd/worktree_test.go
+++ b/pkg/cmd/worktree_test.go
@@ -137,7 +137,7 @@ func TestWorktreeRemoveRun(t *testing.T) {
 		}
 
 		args := []string{"main"}
-		err := __worktreeRemoveRun(ctx, args, func(*executor.Executor, string) ([]worktree.Worktree, error) {
+		err := runWorktreeRemove(ctx, args, func(*executor.Executor, string) ([]worktree.Worktree, error) {
 			return worktrees, nil
 		})
 
@@ -168,23 +168,9 @@ func TestWorktreeRemoveRunSuccess(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "finalizer"), []byte(""), 0644))
 
 	args := []string{"feat"}
-	err := __worktreeRemoveRun(ctx, args, func(*executor.Executor, string) ([]worktree.Worktree, error) {
+	err := runWorktreeRemove(ctx, args, func(*executor.Executor, string) ([]worktree.Worktree, error) {
 		return worktrees, nil
 	})
 
 	require.NoError(t, err)
-}
-
-type worktreeRunner struct{}
-
-func (worktreeRunner) Run(*executor.Command) *executor.Result {
-	return &executor.Result{}
-}
-
-func (worktreeRunner) Capture(*executor.Command) *executor.Result {
-	return &executor.Result{}
-}
-
-func (worktreeRunner) Capture(*executor.Command) *executor.Result {
-	return &executor.Result{}
 }


### PR DESCRIPTION
## Summary
- Prevent `bud tree remove` from deleting the main worktree.
- Automatically `cd` back to the main worktree and update project context after removing a worktree.
- Refactor main worktree lookup into a shared `mainWorktree` function to avoid duplication.