### PR TITLE
tree remove: cd to main worktree after deletion

### DIFF
--- a/pkg/cmd/worktree.go
+++ b/pkg/cmd/worktree.go
@@ -209,7 +209,7 @@ func worktreeRemoveRun(_ *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("🐼  removed worktree %s\n", wt.Path)
-	return nil
+	return integration.AddFinalizerCd(repoPath)
 }
 
 func worktreePruneRun(_ *cobra.Command, _ []string) error {


### PR DESCRIPTION
## Summary
- After a successful `bud tree remove`, queue a finalizer to cd back to the main worktree so the shell doesn't end up in a deleted directory.
- Rejection of removing the main worktree itself was already in place (pkg/cmd/worktree.go:203).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/cmd/ -run Worktree`
- [ ] Manual: `bud tree new foo`, `cd` into it, `bud tree remove foo` — shell lands back in the main worktree.