### PR TITLE
Handle macOS Xcode CLT prerequisites

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -56,6 +56,17 @@ the `commands` section and in your shell.
 
 ## Tasks
 
+Some language tasks compile runtimes from source. On macOS, DevBuddy checks for
+the Xcode command-line tools before starting those compilers. If they're missing,
+DevBuddy runs `xcode-select --install`, then asks you to complete Apple's installer
+dialog and re-run `bud up`.
+
+DevBuddy also checks Xcode first-launch setup with `xcodebuild -checkFirstLaunchStatus`.
+If setup is incomplete and `bud up` is running in an interactive terminal, DevBuddy runs
+`sudo xcodebuild -runFirstLaunch`. That command installs required Xcode components and
+accepts the Xcode/SDK license. In non-interactive sessions, DevBuddy prints the command
+for you to run manually.
+
 ### `apt`
 
 This task will install the Debian packages specified if DevBuddy is running on Debian.
@@ -80,8 +91,10 @@ up:
 
 ### `python`
 
-This task will install the Python version (with pyenv, which must be installed), create
-a virtualenv and activate it in your shell.
+This task will install the Python version with pyenv, create a virtualenv, and
+activate it in your shell. If pyenv is missing, DevBuddy installs it with Homebrew.
+On macOS, DevBuddy checks for the Xcode command-line tools before invoking
+`pyenv install`.
 
 ```yaml
 up:
@@ -208,11 +221,11 @@ the `dev.yml` version. Remove one to silence the warning.
 - **macOS-first install path.** Bootstrapping rbenv is done via `brew install rbenv`.
   On Linux, install rbenv yourself before running `bud up`; the task will detect it
   and proceed.
-- **Native build dependencies are not installed.** `rbenv install` compiles Ruby from
+- **Native build dependencies are partly guided.** `rbenv install` compiles Ruby from
   source and needs system headers (`libssl-dev`, `libyaml-dev`, `libffi-dev`, etc. on
-  Linux; the Xcode command-line tools on macOS). If they're missing, `rbenv install`
-  will fail with its own error and you'll need to install them manually. Tracked in
-  [#547](https://github.com/devbuddy/devbuddy/issues/547).
+  Linux; the Xcode command-line tools on macOS). DevBuddy handles the macOS check
+  described above; Linux system packages still need to be handled through `apt:` or
+  installed manually.
 - **No shims, no `GEM_HOME`/`RUBYOPT`.** The autoenv feature simply prepends the
   selected version's `bin/` directory to `PATH`, which is enough for `ruby`, `gem`,
   `bundle`, and gem-installed executables. Tools that rely on rbenv shims or that

--- a/pkg/helpers/osidentity/osidentity.go
+++ b/pkg/helpers/osidentity/osidentity.go
@@ -11,6 +11,11 @@ func NewMacOSForTest() *Identity {
 	return &Identity{"darwin", ""}
 }
 
+// NewDebianForTest returns new debian-like linux identity
+func NewDebianForTest() *Identity {
+	return &Identity{"linux", "debian"}
+}
+
 // IsDebianLike returns true if current platform behave like debian (including ubuntu)
 func (i *Identity) IsDebianLike() bool {
 	return i.platform == "linux" && i.release == "debian"

--- a/pkg/helpers/xcode_clt.go
+++ b/pkg/helpers/xcode_clt.go
@@ -1,0 +1,61 @@
+package helpers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/helpers/osidentity"
+)
+
+const xcodeCLTInstallMessage = "Xcode Command Line Tools are required. Complete the installer dialog, then re-run bud up."
+const xcodeFirstLaunchMessage = "Xcode first-launch setup is required. Run `sudo xcodebuild -runFirstLaunch`, then re-run bud up."
+
+// EnsureXcodeCommandLineTools verifies the macOS native build toolchain needed
+// by source-built language installers such as pyenv and rbenv.
+func EnsureXcodeCommandLineTools(ctx *context.Context) error {
+	return ensureXcodeCommandLineTools(ctx, osidentity.Detect(), term.IsTerminal(int(os.Stdin.Fd())))
+}
+
+func ensureXcodeCommandLineTools(ctx *context.Context, osIdent *osidentity.Identity, interactive bool) error {
+	if !osIdent.IsMacOS() {
+		return nil
+	}
+
+	result := ctx.Executor.Capture(executor.New("xcode-select", "-p"))
+	if result.Error == nil {
+		return ensureXcodeFirstLaunch(ctx, interactive)
+	}
+
+	ctx.UI.Warningf(xcodeCLTInstallMessage)
+	ctx.UI.TaskCommand("xcode-select", "--install")
+	result = ctx.Executor.Run(executor.New("xcode-select", "--install"))
+	if result.Error != nil {
+		return fmt.Errorf("failed to start Xcode Command Line Tools installer: %w", result.Error)
+	}
+
+	return errors.New(xcodeCLTInstallMessage)
+}
+
+func ensureXcodeFirstLaunch(ctx *context.Context, interactive bool) error {
+	result := ctx.Executor.Capture(executor.New("xcodebuild", "-checkFirstLaunchStatus"))
+	if result.Error == nil {
+		return nil
+	}
+	if !interactive {
+		ctx.UI.Warningf(xcodeFirstLaunchMessage)
+		return errors.New(xcodeFirstLaunchMessage)
+	}
+
+	ctx.UI.Warningf("Xcode first-launch setup is required. DevBuddy will run `sudo xcodebuild -runFirstLaunch`; this installs required Xcode components and accepts the Xcode/SDK license.")
+	ctx.UI.TaskCommand("sudo", "xcodebuild", "-runFirstLaunch")
+	result = ctx.Executor.Run(executor.New("sudo", "xcodebuild", "-runFirstLaunch"))
+	if result.Error != nil {
+		return fmt.Errorf("failed to run Xcode first-launch setup: %w", result.Error)
+	}
+	return nil
+}

--- a/pkg/helpers/xcode_clt_test.go
+++ b/pkg/helpers/xcode_clt_test.go
@@ -1,0 +1,149 @@
+package helpers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/env"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/helpers/osidentity"
+	"github.com/devbuddy/devbuddy/pkg/ui"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureXcodeCommandLineToolsNoopsOutsideMacOS(t *testing.T) {
+	runner := &xcodeCLTRunner{}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewDebianForTest(), false)
+
+	require.NoError(t, err)
+	require.Empty(t, runner.commands)
+}
+
+func TestEnsureXcodeCommandLineToolsReturnsNilWhenInstalled(t *testing.T) {
+	runner := &xcodeCLTRunner{}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewMacOSForTest(), false)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"capture xcode-select -p", "capture xcodebuild -checkFirstLaunchStatus"}, runner.commands)
+}
+
+func TestEnsureXcodeCommandLineToolsStartsInstallerWhenMissing(t *testing.T) {
+	runner := &xcodeCLTRunner{
+		xcodeSelectErr: errors.New("missing"),
+	}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewMacOSForTest(), false)
+
+	require.EqualError(t, err, "Xcode Command Line Tools are required. Complete the installer dialog, then re-run bud up.")
+	require.Equal(t, []string{"capture xcode-select -p", "run xcode-select --install"}, runner.commands)
+}
+
+func TestEnsureXcodeCommandLineToolsReportsInstallerLaunchFailure(t *testing.T) {
+	runner := &xcodeCLTRunner{
+		xcodeSelectErr: errors.New("missing"),
+		installerErr:   errors.New("launch failed"),
+	}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewMacOSForTest(), false)
+
+	require.EqualError(t, err, "failed to start Xcode Command Line Tools installer: launch failed")
+	require.Equal(t, []string{"capture xcode-select -p", "run xcode-select --install"}, runner.commands)
+}
+
+func TestEnsureXcodeCommandLineToolsReportsFirstLaunchWhenNonInteractive(t *testing.T) {
+	runner := &xcodeCLTRunner{
+		xcodeBuildErr: errors.New("first launch incomplete"),
+	}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewMacOSForTest(), false)
+
+	require.EqualError(t, err, "Xcode first-launch setup is required. Run `sudo xcodebuild -runFirstLaunch`, then re-run bud up.")
+	require.Equal(t, []string{"capture xcode-select -p", "capture xcodebuild -checkFirstLaunchStatus"}, runner.commands)
+}
+
+func TestEnsureXcodeCommandLineToolsRunsFirstLaunchWhenInteractive(t *testing.T) {
+	runner := &xcodeCLTRunner{
+		xcodeBuildErr: errors.New("first launch incomplete"),
+	}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewMacOSForTest(), true)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"capture xcode-select -p",
+		"capture xcodebuild -checkFirstLaunchStatus",
+		"run sudo xcodebuild -runFirstLaunch",
+	}, runner.commands)
+}
+
+func TestEnsureXcodeCommandLineToolsReportsFirstLaunchFailure(t *testing.T) {
+	runner := &xcodeCLTRunner{
+		xcodeBuildErr:     errors.New("first launch incomplete"),
+		firstLaunchRunErr: errors.New("sudo failed"),
+	}
+	ctx := newXcodeCLTContext(runner)
+
+	err := ensureXcodeCommandLineTools(ctx, osidentity.NewMacOSForTest(), true)
+
+	require.EqualError(t, err, "failed to run Xcode first-launch setup: sudo failed")
+	require.Equal(t, []string{
+		"capture xcode-select -p",
+		"capture xcodebuild -checkFirstLaunchStatus",
+		"run sudo xcodebuild -runFirstLaunch",
+	}, runner.commands)
+}
+
+func newXcodeCLTContext(runner *xcodeCLTRunner) *context.Context {
+	_, testUI := ui.NewBufferedTesting(false)
+	return &context.Context{
+		Cfg: config.NewTestConfig(),
+		Env: env.New([]string{}),
+		UI:  testUI,
+		Executor: &executor.Executor{
+			Runner: runner,
+			Env:    env.New([]string{}),
+		},
+	}
+}
+
+type xcodeCLTRunner struct {
+	commands          []string
+	xcodeSelectErr    error
+	xcodeBuildErr     error
+	installerErr      error
+	firstLaunchRunErr error
+}
+
+func (r *xcodeCLTRunner) Run(cmd *executor.Command) *executor.Result {
+	r.commands = append(r.commands, "run "+commandString(cmd))
+	if cmd.Program == "sudo" {
+		return &executor.Result{Error: r.firstLaunchRunErr}
+	}
+	return &executor.Result{Error: r.installerErr}
+}
+
+func (r *xcodeCLTRunner) Capture(cmd *executor.Command) *executor.Result {
+	r.commands = append(r.commands, "capture "+commandString(cmd))
+	if cmd.Program == "xcodebuild" {
+		return &executor.Result{Error: r.xcodeBuildErr}
+	}
+	return &executor.Result{Error: r.xcodeSelectErr}
+}
+
+func commandString(cmd *executor.Command) string {
+	result := cmd.Program
+	for _, arg := range cmd.Args {
+		result += " " + arg
+	}
+	return result
+}

--- a/pkg/tasks/python.go
+++ b/pkg/tasks/python.go
@@ -67,6 +67,9 @@ func parserPythonInstallPythonVersion(task *api.Task, version string) {
 		return api.NotNeeded()
 	}
 	run := func(ctx *context.Context) error {
+		if err := helpers.EnsureXcodeCommandLineTools(ctx); err != nil {
+			return err
+		}
 		ctx.UI.TaskCommand("pyenv", "install", version)
 		result := ctx.Executor.Run(executor.New("pyenv", "install", version))
 		if result.Error != nil {

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -86,6 +86,9 @@ func parserRubyInstallRubyVersion(task *api.Task, version string) {
 		return api.NotNeeded()
 	}
 	run := func(ctx *context.Context) error {
+		if err := helpers.EnsureXcodeCommandLineTools(ctx); err != nil {
+			return err
+		}
 		ctx.UI.TaskCommand("rbenv", "install", version)
 		result := ctx.Executor.Run(executor.New("rbenv", "install", version))
 		if result.Error != nil {


### PR DESCRIPTION
## Summary

- Add a shared macOS Xcode Command Line Tools prerequisite check for source-built runtimes.
- Run `xcode-select --install` when the tools are missing and stop with a clear rerun message.
- Check Xcode first-launch/license status with `xcodebuild -checkFirstLaunchStatus`.
- In interactive shells, run `sudo xcodebuild -runFirstLaunch` when first-launch setup is incomplete; in non-interactive sessions, print the command to run manually.
- Call the check before `pyenv install` and `rbenv install`.
- Update `dev.yml` docs for Python/Ruby native build prerequisites and the Xcode first-launch/license behavior.

## Validation

- `go test -count=1 ./pkg/helpers ./pkg/tasks`
- `script/test`
- `script/lint`
- PR CI: green

Fixes: #547
