### PR TITLE
Install Ruby gems into project bundle path

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -195,9 +195,10 @@ up:
 ### `ruby`
 
 This task will install the Ruby version (with rbenv, which is installed automatically via
-Homebrew if missing) and activate it in your shell. If a `Gemfile` is present, gems will
-be installed with `bundle install`. Both `Gemfile` and `Gemfile.lock` are watched, so
-either changing will re-trigger the install.
+Homebrew if missing) and activate it in your shell. If a `Gemfile` is present, DevBuddy
+configures Bundler to install gems into `vendor/bundle`, then runs `bundle install`.
+Both `Gemfile` and `Gemfile.lock` are watched, so either changing will re-trigger the
+install.
 
 The Ruby version can be set explicitly in `dev.yml`, or omitted to read it from a
 `.ruby-version` file at the project root (an optional `ruby-` engine prefix is stripped):
@@ -233,9 +234,9 @@ the `dev.yml` version. Remove one to silence the warning.
 - **Bundler is assumed to ship with Ruby.** Ruby 2.6 and later bundle Bundler in the
   stdlib, so the task does not install it explicitly. Older Ruby versions are not
   supported.
-- **Gems install into the rbenv version directory** rather than a per-project
-  `vendor/bundle`. If you want isolation, run `bundle config set --local path vendor/bundle`
-  in the project before `bud up`.
+- **Gems install into `vendor/bundle`.** DevBuddy writes this through Bundler's local
+  project config (`bundle config set --local path vendor/bundle`). Add `vendor/bundle`
+  to `.gitignore` if your project does not already ignore it.
 
 ### `custom`
 

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -106,8 +106,13 @@ func parserRubyBundleInstall(task *api.Task, version string) {
 			return err
 		}
 		bundle := rbEnv.Which(version, "bundle")
+		ctx.UI.TaskCommand("bundle", "config", "set", "--local", "path", "vendor/bundle")
+		result := ctx.Executor.Run(executor.New(bundle, "config", "set", "--local", "path", "vendor/bundle"))
+		if result.Error != nil {
+			return fmt.Errorf("bundle config failed: %w", result.Error)
+		}
 		ctx.UI.TaskCommand("bundle", "install")
-		result := ctx.Executor.Run(executor.New(bundle, "install"))
+		result = ctx.Executor.Run(executor.New(bundle, "install"))
 		if result.Error != nil {
 			return fmt.Errorf("bundle install failed: %w", result.Error)
 		}

--- a/pkg/tasks/ruby_test.go
+++ b/pkg/tasks/ruby_test.go
@@ -5,7 +5,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/env"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/project"
 	"github.com/devbuddy/devbuddy/pkg/tasks/api"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 	yaml "github.com/goccy/go-yaml"
 	"github.com/stretchr/testify/require"
 )
@@ -72,4 +78,52 @@ func TestRubyInvalid(t *testing.T) {
 	_, err := loadTestTask(t, `ruby: 3`)
 
 	require.Error(t, err, "buildFromDefinition() should have failed")
+}
+
+func TestRubyBundleInstallUsesProjectLocalBundlePath(t *testing.T) {
+	task := ensureLoadTestTask(t, `ruby: 3.3.0`)
+	runner := &rubyRunner{}
+	_, testUI := ui.NewBufferedTesting(false)
+	ctx := &context.Context{
+		Cfg:     config.NewTestConfig(),
+		Env:     env.New([]string{}),
+		UI:      testUI,
+		Project: project.NewFromPath("/project"),
+		Executor: &executor.Executor{
+			Runner: runner,
+			Cwd:    "/project",
+			Env:    env.New([]string{}),
+		},
+	}
+
+	err := task.Actions[2].Run(ctx)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"capture rbenv root",
+		"run /rbenv/versions/3.3.0/bin/bundle config set --local path vendor/bundle",
+		"run /rbenv/versions/3.3.0/bin/bundle install",
+	}, runner.commands)
+}
+
+type rubyRunner struct {
+	commands []string
+}
+
+func (r *rubyRunner) Run(cmd *executor.Command) *executor.Result {
+	r.commands = append(r.commands, "run "+rubyCommandString(cmd))
+	return &executor.Result{}
+}
+
+func (r *rubyRunner) Capture(cmd *executor.Command) *executor.Result {
+	r.commands = append(r.commands, "capture "+rubyCommandString(cmd))
+	return &executor.Result{Output: "/rbenv\n"}
+}
+
+func rubyCommandString(cmd *executor.Command) string {
+	result := cmd.Program
+	for _, arg := range cmd.Args {
+		result += " " + arg
+	}
+	return result
 }


### PR DESCRIPTION
## Summary

- Configure Bundler to install Ruby gems into `vendor/bundle` before running `bundle install`.
- Keep Bundler's local project config as the source of truth for the install path.
- Update Ruby task docs to describe the project-local gem path and `.gitignore` expectation.

## Why

DevBuddy already runs `bundle install`, so gems should not land in the shared rbenv version directory where projects on the same Ruby version can conflict.

## Validation

- `go test -count=1 ./pkg/tasks`
- `script/test`
- `script/lint`

Closes #550

