### PR TITLE
Improve upgrade confirmation flow

### DIFF
--- a/pkg/cmd/upgrade.go
+++ b/pkg/cmd/upgrade.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 	"github.com/devbuddy/devbuddy/pkg/updatecheck"
 )
 
@@ -31,8 +34,7 @@ func upgradeRun(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	plan := updatecheck.UpgradePlan(commandVersion(cmd), release.Version)
-	return runUpgradePlan(ctx.Executor, plan)
+	return runUpgrade(ctx.Executor, ctx.UI.Prompts(), cmd.OutOrStdout(), commandVersion(cmd), *release)
 }
 
 func commandVersion(cmd *cobra.Command) string {
@@ -41,6 +43,41 @@ func commandVersion(cmd *cobra.Command) string {
 
 type upgradeExecutor interface {
 	Run(cmd *executor.Command) *executor.Result
+}
+
+func runUpgrade(runner upgradeExecutor, prompts ui.Prompts, out io.Writer, currentVersion string, release updatecheck.Release) error {
+	currentDisplay := displayVersion(currentVersion)
+	fmt.Fprintf(out, "Current version: %s\n", currentDisplay)
+	fmt.Fprintf(out, "Latest version:  %s\n", release.Version)
+
+	if currentDisplay == release.Version {
+		fmt.Fprintln(out, "DevBuddy is already at the latest version.")
+		return nil
+	}
+
+	confirmed, err := prompts.Confirm(ui.ConfirmRequest{Label: fmt.Sprintf("Upgrade DevBuddy to %s now", release.Version)})
+	if errors.Is(err, ui.ErrPromptCancelled) {
+		fmt.Fprintln(out, "Upgrade cancelled.")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !confirmed {
+		fmt.Fprintln(out, "Upgrade cancelled.")
+		return nil
+	}
+
+	plan := updatecheck.UpgradePlan(currentVersion, release.Version)
+	return runUpgradePlan(runner, plan)
+}
+
+func displayVersion(version string) string {
+	info := updatecheck.ParseVersion(version)
+	if info.Version != "" {
+		return info.Version
+	}
+	return version
 }
 
 func runUpgradePlan(runner upgradeExecutor, plan updatecheck.Plan) error {

--- a/pkg/cmd/upgrade_test.go
+++ b/pkg/cmd/upgrade_test.go
@@ -1,23 +1,56 @@
 package cmd
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 	"github.com/devbuddy/devbuddy/pkg/updatecheck"
 )
 
-func TestRunUpgradeExecutesSharedUpgradePlan(t *testing.T) {
+func TestRunUpgradePrintsVersionsAsksConfirmationAndExecutesSharedPlan(t *testing.T) {
 	runner := &upgradeRunnerSpy{}
-	plan := updatecheck.Plan{Command: "curl -sSL install.sh | VERSION=v0.17.0 sh"}
+	prompts := &ui.FakePrompts{ConfirmValue: true}
+	var out bytes.Buffer
 
-	err := runUpgradePlan(runner, plan)
+	err := runUpgrade(runner, prompts, &out, "v0.16.1 [2026-05-17 12:00:00 +0000 UTC]", updatecheck.Release{Version: "v0.17.0"})
 
 	require.NoError(t, err)
-	require.Equal(t, "curl -sSL install.sh | VERSION=v0.17.0 sh", runner.command)
+	require.Contains(t, out.String(), "Current version: v0.16.1")
+	require.Contains(t, out.String(), "Latest version:  v0.17.0")
+	require.Equal(t, []ui.ConfirmRequest{{Label: "Upgrade DevBuddy to v0.17.0 now"}}, prompts.ConfirmRequests)
+	require.Equal(t, "curl -sSL https://raw.githubusercontent.com/devbuddy/devbuddy/main/install.sh | VERSION=v0.17.0 sh", runner.command)
+}
+
+func TestRunUpgradeSkipsCommandWhenVersionIsCurrent(t *testing.T) {
+	runner := &upgradeRunnerSpy{}
+	prompts := &ui.FakePrompts{ConfirmValue: true}
+	var out bytes.Buffer
+
+	err := runUpgrade(runner, prompts, &out, "v0.17.0", updatecheck.Release{Version: "v0.17.0"})
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "Current version: v0.17.0")
+	require.Contains(t, out.String(), "Latest version:  v0.17.0")
+	require.Contains(t, out.String(), "DevBuddy is already at the latest version.")
+	require.Empty(t, prompts.ConfirmRequests)
+	require.Empty(t, runner.command)
+}
+
+func TestRunUpgradeSkipsCommandWhenUserDeclines(t *testing.T) {
+	runner := &upgradeRunnerSpy{}
+	prompts := &ui.FakePrompts{ConfirmValue: false}
+	var out bytes.Buffer
+
+	err := runUpgrade(runner, prompts, &out, "v0.16.1", updatecheck.Release{Version: "v0.17.0"})
+
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "Upgrade cancelled.")
+	require.Empty(t, runner.command)
 }
 
 func TestRunUpgradeReturnsPlanNoteWithoutCommand(t *testing.T) {


### PR DESCRIPTION
## Summary

- Print the installed DevBuddy version and latest release version before upgrading.
- Skip the upgrade command when the installed version already matches the latest release.
- Ask for confirmation before running the shared install-method-aware upgrade command.

## Validation

- `go test ./pkg/cmd -run Upgrade -count=1`
- `script/test`
