### PR TITLE
Centralize task command execution

### DIFF
--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -7,8 +7,22 @@ import (
 
 	"github.com/devbuddy/devbuddy/pkg/executor"
 	"github.com/devbuddy/devbuddy/pkg/project"
+	"github.com/devbuddy/devbuddy/pkg/ui"
 	"github.com/stretchr/testify/require"
 )
+
+type taskCommandRunnerSpy struct {
+	runCmd *executor.Command
+}
+
+func (s *taskCommandRunnerSpy) Run(cmd *executor.Command) *executor.Result {
+	s.runCmd = cmd
+	return &executor.Result{}
+}
+
+func (s *taskCommandRunnerSpy) Capture(cmd *executor.Command) *executor.Result {
+	return &executor.Result{}
+}
 
 func withCwd(t *testing.T, path string) {
 	t.Helper()
@@ -52,4 +66,25 @@ func TestLoadWithProject_ReturnsProjectNotFound(t *testing.T) {
 	ctx, err := LoadWithProject()
 	require.ErrorIs(t, err, project.ErrProjectNotFound)
 	require.Nil(t, ctx)
+}
+
+func TestRunTaskCommand_DisplaysAndRunsSameCommand(t *testing.T) {
+	_, testingUI := ui.NewTesting()
+	runner := &taskCommandRunnerSpy{}
+	ctx := &Context{
+		UI:       testingUI,
+		Executor: &executor.Executor{Runner: runner},
+	}
+	cmd := executor.New("pip", "install", "-r", "requirements.txt").AddOutputFilter("already satisfied")
+
+	result := ctx.RunTaskCommand(cmd)
+
+	require.NoError(t, result.Error)
+	require.Same(t, cmd, runner.runCmd)
+
+	events := testingUI.Events()
+	require.Len(t, events, 1)
+	require.Equal(t, ui.KindTaskCommand, events[0].Kind)
+	require.Equal(t, "pip", events[0].Text)
+	require.Equal(t, []ui.Field{ui.F("args", "install -r requirements.txt")}, events[0].Fields)
 }

--- a/pkg/context/task_command.go
+++ b/pkg/context/task_command.go
@@ -1,0 +1,10 @@
+package context
+
+import "github.com/devbuddy/devbuddy/pkg/executor"
+
+// RunTaskCommand records the command shown in task output and runs that same
+// inspectable command request.
+func (ctx *Context) RunTaskCommand(cmd *executor.Command) *executor.Result {
+	ctx.UI.TaskCommand(cmd.Program, cmd.Args...)
+	return ctx.Executor.Run(cmd)
+}

--- a/pkg/helpers/xcode_clt.go
+++ b/pkg/helpers/xcode_clt.go
@@ -32,8 +32,7 @@ func ensureXcodeCommandLineTools(ctx *context.Context, osIdent *osidentity.Ident
 	}
 
 	ctx.UI.Warningf(xcodeCLTInstallMessage)
-	ctx.UI.TaskCommand("xcode-select", "--install")
-	result = ctx.Executor.Run(executor.New("xcode-select", "--install"))
+	result = ctx.RunTaskCommand(executor.New("xcode-select", "--install"))
 	if result.Error != nil {
 		return fmt.Errorf("failed to start Xcode Command Line Tools installer: %w", result.Error)
 	}
@@ -52,8 +51,7 @@ func ensureXcodeFirstLaunch(ctx *context.Context, interactive bool) error {
 	}
 
 	ctx.UI.Warningf("Xcode first-launch setup is required. DevBuddy will run `sudo xcodebuild -runFirstLaunch`; this installs required Xcode components and accepts the Xcode/SDK license.")
-	ctx.UI.TaskCommand("sudo", "xcodebuild", "-runFirstLaunch")
-	result = ctx.Executor.Run(executor.New("sudo", "xcodebuild", "-runFirstLaunch"))
+	result = ctx.RunTaskCommand(executor.New("sudo", "xcodebuild", "-runFirstLaunch"))
 	if result.Error != nil {
 		return fmt.Errorf("failed to run Xcode first-launch setup: %w", result.Error)
 	}

--- a/pkg/tasks/apt.go
+++ b/pkg/tasks/apt.go
@@ -61,15 +61,13 @@ func (a *aptInstall) Needed(ctx *context.Context) *api.ActionResult {
 }
 
 func (a *aptInstall) Run(ctx *context.Context) error {
-	ctx.UI.TaskCommand("sudo", "apt-get", "update")
-	result := ctx.Executor.Run(executor.New("sudo", "apt-get", "update"))
+	result := ctx.RunTaskCommand(executor.New("sudo", "apt-get", "update"))
 	if result.Error != nil {
 		return fmt.Errorf("failed to run apt-get update: %w", result.Error)
 	}
 
 	args := append([]string{"install", "--no-install-recommends", "-y"}, a.missingPackageNames...)
-	ctx.UI.TaskCommand("sudo", append([]string{"apt-get"}, args...)...)
-	result = ctx.Executor.Run(executor.New("sudo", append([]string{"apt-get"}, args...)...))
+	result = ctx.RunTaskCommand(executor.New("sudo", append([]string{"apt-get"}, args...)...))
 	if result.Error != nil {
 		return fmt.Errorf("failed to run apt-get install: %w", result.Error)
 	}

--- a/pkg/tasks/golang_dep.go
+++ b/pkg/tasks/golang_dep.go
@@ -37,8 +37,7 @@ func (p *golangDepInstall) Needed(ctx *context.Context) *api.ActionResult {
 }
 
 func (p *golangDepInstall) Run(ctx *context.Context) error {
-	ctx.UI.TaskCommand("go", "get", "-u", "github.com/golang/dep/cmd/dep")
-	result := ctx.Executor.Run(executor.New("go", "get", "-u", "github.com/golang/dep/cmd/dep"))
+	result := ctx.RunTaskCommand(executor.New("go", "get", "-u", "github.com/golang/dep/cmd/dep"))
 	if result.Error != nil {
 		return fmt.Errorf("failed to install Go GolangDep: %w", result.Error)
 	}
@@ -82,8 +81,7 @@ func (p *golangDepEnsure) Needed(ctx *context.Context) *api.ActionResult {
 }
 
 func (p *golangDepEnsure) Run(ctx *context.Context) error {
-	ctx.UI.TaskCommand("dep", "ensure")
-	result := ctx.Executor.Run(executor.New("dep", "ensure"))
+	result := ctx.RunTaskCommand(executor.New("dep", "ensure"))
 	if result.Error != nil {
 		return fmt.Errorf("failed to run dep ensure: %w", result.Error)
 	}

--- a/pkg/tasks/homebrew.go
+++ b/pkg/tasks/homebrew.go
@@ -50,8 +50,7 @@ func (b *brewInstall) Needed(ctx *context.Context) *api.ActionResult {
 }
 
 func (b *brewInstall) Run(ctx *context.Context) error {
-	ctx.UI.TaskCommand("brew", "install", b.formula)
-	result := ctx.Executor.Run(executor.New("brew", "install", b.formula).AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
+	result := ctx.RunTaskCommand(executor.New("brew", "install", b.formula).AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
 	if result.Error != nil {
 		return fmt.Errorf("failed to run brew install: %w", result.Error)
 	}

--- a/pkg/tasks/node.go
+++ b/pkg/tasks/node.go
@@ -38,8 +38,7 @@ func parseNode(config *api.TaskConfig, task *api.Task) error {
 			ctx.UI.TaskWarning("No package.json found.")
 			return nil
 		}
-		ctx.UI.TaskCommand("npm", "install", "--no-progress")
-		return ctx.Executor.Run(executor.New("npm", "install", "--no-progress")).Error
+		return ctx.RunTaskCommand(executor.New("npm", "install", "--no-progress")).Error
 	}
 	task.AddActionBuilder("install dependencies with NPM", npmInstall).
 		On(api.FileCondition("package.json"))

--- a/pkg/tasks/pip.go
+++ b/pkg/tasks/pip.go
@@ -27,8 +27,7 @@ func parserPip(config *api.TaskConfig, task *api.Task) error {
 	for _, file := range files {
 		pipInstall := func(ctx *context.Context) error {
 			pipArgs := []string{"install", "--require-virtualenv", "-r", file}
-			ctx.UI.TaskCommand("pip", pipArgs...)
-			result := ctx.Executor.Run(executor.New("pip", pipArgs...).AddOutputFilter("already satisfied"))
+			result := ctx.RunTaskCommand(executor.New("pip", pipArgs...).AddOutputFilter("already satisfied"))
 			if result.Error != nil {
 				return fmt.Errorf("Pip failed: %w", result.Error)
 			}

--- a/pkg/tasks/pipfile.go
+++ b/pkg/tasks/pipfile.go
@@ -16,8 +16,7 @@ func init() {
 
 func parserPipfile(config *api.TaskConfig, task *api.Task) error {
 	installPipfile := func(ctx *context.Context) error {
-		ctx.UI.TaskCommand("pip", "install", "--require-virtualenv", "pipenv")
-		result := ctx.Executor.Run(executor.New("pip", "install", "--require-virtualenv", "pipenv"))
+		result := ctx.RunTaskCommand(executor.New("pip", "install", "--require-virtualenv", "pipenv"))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install pipenv: %w", result.Error)
 		}
@@ -40,8 +39,7 @@ func parserPipfile(config *api.TaskConfig, task *api.Task) error {
 		On(api.FuncCondition(installPipfileNeeded))
 
 	runPipfileInstall := func(ctx *context.Context) error {
-		ctx.UI.TaskCommand("pipenv", "install", "--system", "--dev")
-		result := ctx.Executor.Run(executor.New("pipenv", "install", "--system", "--dev").AddEnvVar("PIPENV_QUIET", "1"))
+		result := ctx.RunTaskCommand(executor.New("pipenv", "install", "--system", "--dev").AddEnvVar("PIPENV_QUIET", "1"))
 		if result.Error != nil {
 			return fmt.Errorf("pipenv failed: %w", result.Error)
 		}

--- a/pkg/tasks/python.go
+++ b/pkg/tasks/python.go
@@ -41,8 +41,7 @@ func parserPythonInstallPyenv(task *api.Task, version string) {
 		return api.NotNeeded()
 	}
 	run := func(ctx *context.Context) error {
-		ctx.UI.TaskCommand("brew", "install", "pyenv")
-		result := ctx.Executor.Run(executor.New("brew", "install", "pyenv").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
+		result := ctx.RunTaskCommand(executor.New("brew", "install", "pyenv").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install pyenv: %w", result.Error)
 		}
@@ -70,8 +69,7 @@ func parserPythonInstallPythonVersion(task *api.Task, version string) {
 		if err := helpers.EnsureXcodeCommandLineTools(ctx); err != nil {
 			return err
 		}
-		ctx.UI.TaskCommand("pyenv", "install", version)
-		result := ctx.Executor.Run(executor.New("pyenv", "install", version))
+		result := ctx.RunTaskCommand(executor.New("pyenv", "install", version))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install the required python version: %w", result.Error)
 		}
@@ -97,8 +95,7 @@ func parserPythonInstallVirtualenv(task *api.Task, version string) {
 		if err != nil {
 			return err
 		}
-		ctx.UI.TaskCommand(pyEnv.Which(version, "python"), "-m", "pip", "install", "virtualenv")
-		result := ctx.Executor.Run(executor.New(pyEnv.Which(version, "python"), "-m", "pip", "install", "virtualenv"))
+		result := ctx.RunTaskCommand(executor.New(pyEnv.Which(version, "python"), "-m", "pip", "install", "virtualenv"))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install virtualenv: %w", result.Error)
 		}
@@ -127,8 +124,7 @@ func parserPythonCreateVirtualenv(task *api.Task, version string) {
 		if err != nil {
 			return err
 		}
-		ctx.UI.TaskCommand(pyEnv.Which(version, "virtualenv"), venv.Path())
-		result := ctx.Executor.Run(executor.New(pyEnv.Which(version, "virtualenv"), venv.Path()))
+		result := ctx.RunTaskCommand(executor.New(pyEnv.Which(version, "virtualenv"), venv.Path()))
 		if result.Error != nil {
 			return fmt.Errorf("failed to create the virtualenv: %w", result.Error)
 		}

--- a/pkg/tasks/python_develop.go
+++ b/pkg/tasks/python_develop.go
@@ -26,8 +26,7 @@ func parserPythonDevelop(config *api.TaskConfig, task *api.Task) error {
 	pipArgs := []string{"install", "--require-virtualenv", "-e", pipTarget}
 
 	pipInstall := func(ctx *context.Context) error {
-		ctx.UI.TaskCommand("pip", pipArgs...)
-		result := ctx.Executor.Run(executor.New("pip", pipArgs...).AddOutputFilter("already satisfied"))
+		result := ctx.RunTaskCommand(executor.New("pip", pipArgs...).AddOutputFilter("already satisfied"))
 		if result.Error != nil {
 			return fmt.Errorf("Pip failed: %w", result.Error)
 		}

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -60,8 +60,7 @@ func parserRubyInstallRbenv(task *api.Task) {
 		return api.NotNeeded()
 	}
 	run := func(ctx *context.Context) error {
-		ctx.UI.TaskCommand("brew", "install", "rbenv")
-		result := ctx.Executor.Run(executor.New("brew", "install", "rbenv").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
+		result := ctx.RunTaskCommand(executor.New("brew", "install", "rbenv").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install rbenv: %w", result.Error)
 		}
@@ -89,8 +88,7 @@ func parserRubyInstallRubyVersion(task *api.Task, version string) {
 		if err := helpers.EnsureXcodeCommandLineTools(ctx); err != nil {
 			return err
 		}
-		ctx.UI.TaskCommand("rbenv", "install", version)
-		result := ctx.Executor.Run(executor.New("rbenv", "install", version))
+		result := ctx.RunTaskCommand(executor.New("rbenv", "install", version))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install the required ruby version: %w", result.Error)
 		}


### PR DESCRIPTION
## Summary

- Add `Context.RunTaskCommand` to display a task command and run the same `executor.Command` object.
- Convert task actions and Xcode prerequisite helpers that had matching display/run command pairs to use the shared helper.
- Keep the Ruby bundle path display unchanged because it intentionally shows `bundle install` while executing the rbenv-resolved binary.

## Validation

- `go test ./pkg/context`
- `go test ./pkg/context ./pkg/tasks/... ./pkg/helpers/...`
- `script/test`

Closes #573

