### PR TITLE
Support Linux rbenv installation

### DIFF
--- a/pkg/helpers/osidentity/osidentity.go
+++ b/pkg/helpers/osidentity/osidentity.go
@@ -16,6 +16,11 @@ func NewDebianForTest() *Identity {
 	return &Identity{"linux", "debian"}
 }
 
+// NewLinuxForTest returns new linux identity with the given release variant.
+func NewLinuxForTest(release string) *Identity {
+	return &Identity{"linux", release}
+}
+
 // IsDebianLike returns true if current platform behave like debian (including ubuntu)
 func (i *Identity) IsDebianLike() bool {
 	return i.platform == "linux" && i.release == "debian"

--- a/pkg/helpers/rbenv.go
+++ b/pkg/helpers/rbenv.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
 // ReadRubyVersionFile reads a `.ruby-version` file and returns the version
@@ -29,8 +30,9 @@ func ReadRubyVersionFile(projectPath string) (string, error) {
 }
 
 type RbEnv struct {
-	ctx  *context.Context
-	root string
+	ctx     *context.Context
+	command string
+	root    string
 }
 
 // RbEnvRoot returns the rbenv root directory using the same resolution as
@@ -44,11 +46,24 @@ func RbEnvRoot() string {
 }
 
 func NewRbEnv(ctx *context.Context) (*RbEnv, error) {
-	result := ctx.Executor.CaptureAndTrim(executor.New("rbenv", "root"))
-	if result.Error != nil {
-		return nil, fmt.Errorf("Command 'rbenv root' failed: %w", result.Error)
+	command := "rbenv"
+	result := ctx.Executor.CaptureAndTrim(executor.New(command, "root"))
+	if result.Error != nil && utils.PathExists(sourceRbEnvCommand()) {
+		command = sourceRbEnvCommand()
+		result = ctx.Executor.CaptureAndTrim(executor.New(command, "root"))
 	}
-	return &RbEnv{ctx: ctx, root: result.Output}, nil
+	if result.Error != nil {
+		return nil, fmt.Errorf("Command '%s root' failed: %w", command, result.Error)
+	}
+	return &RbEnv{ctx: ctx, command: command, root: result.Output}, nil
+}
+
+func sourceRbEnvCommand() string {
+	return path.Join(RbEnvRoot(), "bin", "rbenv")
+}
+
+func (r *RbEnv) Command() string {
+	return r.command
 }
 
 func (r *RbEnv) VersionInstalled(version string) (bool, error) {
@@ -60,7 +75,7 @@ func (r *RbEnv) VersionInstalled(version string) (bool, error) {
 }
 
 func (r *RbEnv) listVersions() ([]string, error) {
-	result := r.ctx.Executor.Capture(executor.New("rbenv", "versions", "--bare", "--skip-aliases"))
+	result := r.ctx.Executor.Capture(executor.New(r.command, "versions", "--bare", "--skip-aliases"))
 	if result.Error != nil {
 		return nil, fmt.Errorf("failed to run rbenv versions: %w", result.Error)
 	}

--- a/pkg/tasks/ruby.go
+++ b/pkg/tasks/ruby.go
@@ -4,11 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/executor"
 	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/devbuddy/devbuddy/pkg/helpers/osidentity"
 	"github.com/devbuddy/devbuddy/pkg/tasks/api"
+	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
 const rubyTaskName = "ruby"
@@ -53,20 +57,87 @@ func resolveRubyVersion(config *api.TaskConfig) (string, error) {
 
 func parserRubyInstallRbenv(task *api.Task) {
 	needed := func(ctx *context.Context) *api.ActionResult {
-		_, err := helpers.NewRbEnv(ctx)
+		rbEnv, err := helpers.NewRbEnv(ctx)
 		if err != nil {
 			return api.Needed("rbenv is not installed: %s", err)
+		}
+		hasRubyBuild, err := rbenvHasInstallCommand(ctx, rbEnv)
+		if err != nil {
+			return api.Failed("failed to inspect rbenv commands: %s", err)
+		}
+		if !hasRubyBuild {
+			return api.Needed("ruby-build is not installed")
 		}
 		return api.NotNeeded()
 	}
 	run := func(ctx *context.Context) error {
-		result := ctx.RunTaskCommand(executor.New("brew", "install", "rbenv").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
-		if result.Error != nil {
-			return fmt.Errorf("failed to install rbenv: %w", result.Error)
-		}
-		return nil
+		return installRbenv(ctx, osidentity.Detect())
 	}
 	task.AddActionBuilder("install rbenv", run).On(api.FuncCondition(needed))
+}
+
+func rbenvHasInstallCommand(ctx *context.Context, rbEnv *helpers.RbEnv) (bool, error) {
+	result := ctx.Executor.Capture(executor.New(rbEnv.Command(), "commands"))
+	if result.Error != nil {
+		return false, result.Error
+	}
+	for _, command := range strings.Split(result.Output, "\n") {
+		if strings.TrimSpace(command) == "install" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func installRbenv(ctx *context.Context, osIdent *osidentity.Identity) error {
+	switch {
+	case osIdent.IsMacOS():
+		return installRbenvWithHomebrew(ctx)
+	case osIdent.IsDebianLike():
+		return installRbenvWithApt(ctx)
+	default:
+		return installRbenvFromGit(ctx)
+	}
+}
+
+func installRbenvWithHomebrew(ctx *context.Context) error {
+	result := ctx.RunTaskCommand(executor.New("brew", "install", "rbenv", "ruby-build").AddEnvVar("HOMEBREW_NO_AUTO_UPDATE", "1"))
+	if result.Error != nil {
+		return fmt.Errorf("failed to install rbenv: %w", result.Error)
+	}
+	return nil
+}
+
+func installRbenvWithApt(ctx *context.Context) error {
+	result := ctx.RunTaskCommand(executor.New("sudo", "apt-get", "update"))
+	if result.Error != nil {
+		return fmt.Errorf("failed to run apt-get update: %w", result.Error)
+	}
+
+	result = ctx.RunTaskCommand(executor.New("sudo", "apt-get", "install", "--no-install-recommends", "-y", "rbenv", "ruby-build"))
+	if result.Error != nil {
+		return fmt.Errorf("failed to install rbenv: %w", result.Error)
+	}
+	return nil
+}
+
+func installRbenvFromGit(ctx *context.Context) error {
+	root := helpers.RbEnvRoot()
+	if !utils.PathExists(root) {
+		result := ctx.RunTaskCommand(executor.New("git", "clone", "https://github.com/rbenv/rbenv.git", root))
+		if result.Error != nil {
+			return fmt.Errorf("failed to clone rbenv: %w", result.Error)
+		}
+	}
+
+	rubyBuildPath := filepath.Join(root, "plugins", "ruby-build")
+	if !utils.PathExists(rubyBuildPath) {
+		result := ctx.RunTaskCommand(executor.New("git", "clone", "https://github.com/rbenv/ruby-build.git", rubyBuildPath))
+		if result.Error != nil {
+			return fmt.Errorf("failed to clone ruby-build: %w", result.Error)
+		}
+	}
+	return nil
 }
 
 func parserRubyInstallRubyVersion(task *api.Task, version string) {
@@ -88,7 +159,11 @@ func parserRubyInstallRubyVersion(task *api.Task, version string) {
 		if err := helpers.EnsureXcodeCommandLineTools(ctx); err != nil {
 			return err
 		}
-		result := ctx.RunTaskCommand(executor.New("rbenv", "install", version))
+		rbEnv, err := helpers.NewRbEnv(ctx)
+		if err != nil {
+			return fmt.Errorf("cannot use rbenv: %w", err)
+		}
+		result := ctx.RunTaskCommand(executor.New(rbEnv.Command(), "install", version))
 		if result.Error != nil {
 			return fmt.Errorf("failed to install the required ruby version: %w", result.Error)
 		}
@@ -106,13 +181,11 @@ func parserRubyBundleInstall(task *api.Task, version string) {
 			return err
 		}
 		bundle := rbEnv.Which(version, "bundle")
-		ctx.UI.TaskCommand("bundle", "config", "set", "--local", "path", "vendor/bundle")
-		result := ctx.Executor.Run(executor.New(bundle, "config", "set", "--local", "path", "vendor/bundle"))
+		result := ctx.RunTaskCommand(executor.New(bundle, "config", "set", "--local", "path", "vendor/bundle"))
 		if result.Error != nil {
 			return fmt.Errorf("bundle config failed: %w", result.Error)
 		}
-		ctx.UI.TaskCommand("bundle", "install")
-		result = ctx.Executor.Run(executor.New(bundle, "install"))
+		result = ctx.RunTaskCommand(executor.New(bundle, "install"))
 		if result.Error != nil {
 			return fmt.Errorf("bundle install failed: %w", result.Error)
 		}

--- a/pkg/tasks/ruby_test.go
+++ b/pkg/tasks/ruby_test.go
@@ -3,12 +3,15 @@ package tasks
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/devbuddy/devbuddy/pkg/config"
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/env"
 	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/devbuddy/devbuddy/pkg/helpers/osidentity"
 	"github.com/devbuddy/devbuddy/pkg/project"
 	"github.com/devbuddy/devbuddy/pkg/tasks/api"
 	"github.com/devbuddy/devbuddy/pkg/ui"
@@ -126,4 +129,127 @@ func rubyCommandString(cmd *executor.Command) string {
 		result += " " + arg
 	}
 	return result
+}
+
+func TestRubyInstallRbenvHomebrewInstallsRubyBuildExplicitly(t *testing.T) {
+	ctx, runner := newRubyInstallTestContext(t)
+
+	err := installRbenv(ctx, osidentity.NewMacOSForTest())
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"run brew install rbenv ruby-build"}, runner.commands)
+	require.Contains(t, runner.runCmds[0].Env, "HOMEBREW_NO_AUTO_UPDATE=1")
+}
+
+func TestRubyInstallRbenvDebianUsesAptPackages(t *testing.T) {
+	ctx, runner := newRubyInstallTestContext(t)
+
+	err := installRbenv(ctx, osidentity.NewDebianForTest())
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"run sudo apt-get update",
+		"run sudo apt-get install --no-install-recommends -y rbenv ruby-build",
+	}, runner.commands)
+}
+
+func TestRubyInstallRbenvLinuxFallbackClonesRbenvAndRubyBuild(t *testing.T) {
+	ctx, runner := newRubyInstallTestContext(t)
+
+	err := installRbenv(ctx, osidentity.NewLinuxForTest("unknown"))
+
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"run git clone https://github.com/rbenv/rbenv.git " + helpers.RbEnvRoot(),
+		"run git clone https://github.com/rbenv/ruby-build.git " + filepath.Join(helpers.RbEnvRoot(), "plugins", "ruby-build"),
+	}, runner.commands)
+}
+
+func TestRubyInstallRbenvLinuxFallbackSkipsExistingCheckouts(t *testing.T) {
+	ctx, runner := newRubyInstallTestContext(t)
+	require.NoError(t, os.MkdirAll(filepath.Join(helpers.RbEnvRoot(), "plugins", "ruby-build"), 0o755))
+
+	err := installRbenv(ctx, osidentity.NewLinuxForTest("unknown"))
+
+	require.NoError(t, err)
+	require.Empty(t, runner.commands)
+}
+
+func TestRbenvHasInstallCommand(t *testing.T) {
+	ctx, runner := newRubyInstallTestContext(t)
+	runner.captureOutputs = []string{helpers.RbEnvRoot(), "global\ninstall\nrehash\n"}
+
+	rbEnv, err := helpers.NewRbEnv(ctx)
+	require.NoError(t, err)
+	hasRubyBuild, err := rbenvHasInstallCommand(ctx, rbEnv)
+
+	require.NoError(t, err)
+	require.True(t, hasRubyBuild)
+	require.Equal(t, []string{"capture rbenv root", "capture rbenv commands"}, runner.commands)
+}
+
+func TestRbenvHasInstallCommandMissing(t *testing.T) {
+	ctx, runner := newRubyInstallTestContext(t)
+	runner.captureOutputs = []string{helpers.RbEnvRoot(), "global\nrehash\n"}
+
+	rbEnv, err := helpers.NewRbEnv(ctx)
+	require.NoError(t, err)
+	hasRubyBuild, err := rbenvHasInstallCommand(ctx, rbEnv)
+
+	require.NoError(t, err)
+	require.False(t, hasRubyBuild)
+}
+
+func newRubyInstallTestContext(t *testing.T) (*context.Context, *rubyInstallRunner) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("RBENV_ROOT", filepath.Join(os.Getenv("HOME"), ".rbenv"))
+
+	_, testingUI := ui.NewBufferedTesting(false)
+	runner := &rubyInstallRunner{}
+	ctx := &context.Context{
+		Project:  project.NewFromPath("/src/myproject"),
+		UI:       testingUI,
+		Cfg:      config.NewTestConfig(),
+		Env:      env.New([]string{}),
+		Executor: &executor.Executor{Runner: runner},
+	}
+	return ctx, runner
+}
+
+type rubyInstallRunner struct {
+	commands       []string
+	runCmds        []*executor.Command
+	captureOutputs []string
+	runErr         error
+	captureErr     error
+}
+
+func (r *rubyInstallRunner) Run(cmd *executor.Command) *executor.Result {
+	r.commands = append(r.commands, "run "+formatRubyTestCommand(cmd))
+	r.runCmds = append(r.runCmds, cmd)
+	if r.runErr != nil {
+		return &executor.Result{Error: r.runErr}
+	}
+	return &executor.Result{}
+}
+
+func (r *rubyInstallRunner) Capture(cmd *executor.Command) *executor.Result {
+	r.commands = append(r.commands, "capture "+formatRubyTestCommand(cmd))
+	if r.captureErr != nil {
+		return &executor.Result{Error: r.captureErr}
+	}
+	output := helpers.RbEnvRoot()
+	if len(r.captureOutputs) > 0 {
+		output = r.captureOutputs[0]
+		r.captureOutputs = r.captureOutputs[1:]
+	}
+	return &executor.Result{Output: output}
+}
+
+func formatRubyTestCommand(cmd *executor.Command) string {
+	if cmd.Shell {
+		return cmd.Program
+	}
+	return strings.Join(append([]string{cmd.Program}, cmd.Args...), " ")
 }


### PR DESCRIPTION
## Summary

- route Ruby rbenv installation by OS: Homebrew on macOS, apt on Debian-like Linux, git clone fallback elsewhere
- make ruby-build an explicit dependency and detect when the rbenv install command is missing
- allow source-installed rbenv to be used via `~/.rbenv/bin/rbenv` during the same run

## Validation

- `go test ./pkg/tasks ./pkg/helpers ./pkg/helpers/osidentity`
- `script/test`
- `git diff --check`

Closes #551
