### PR TITLE
Add Go install bin paths to activation

### DIFF
--- a/pkg/autoenv/features/golang.go
+++ b/pkg/autoenv/features/golang.go
@@ -1,6 +1,9 @@
 package features
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/devbuddy/devbuddy/pkg/context"
 	"github.com/devbuddy/devbuddy/pkg/helpers"
 )
@@ -22,6 +25,9 @@ func (golang) Activate(ctx *context.Context, param string) (bool, error) {
 		return true, nil
 	}
 
+	for _, binPath := range goInstallBinPaths(ctx) {
+		ctx.Env.PrependToPath(binPath)
+	}
 	ctx.Env.PrependToPath(golang.BinPath())
 
 	ctx.Env.Set("GOROOT", golang.Path())
@@ -30,3 +36,26 @@ func (golang) Activate(ctx *context.Context, param string) (bool, error) {
 }
 
 func (golang) Deactivate(ctx *context.Context, param string) {}
+
+func goInstallBinPaths(ctx *context.Context) []string {
+	if gobin := ctx.Env.Get("GOBIN"); gobin != "" {
+		return []string{gobin}
+	}
+
+	if gopath := ctx.Env.Get("GOPATH"); gopath != "" {
+		paths := []string{}
+		for _, dir := range filepath.SplitList(gopath) {
+			if dir == "" {
+				continue
+			}
+			paths = append(paths, filepath.Join(dir, "bin"))
+		}
+		return paths
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+	return []string{filepath.Join(home, "go", "bin")}
+}

--- a/pkg/autoenv/features/golang_test.go
+++ b/pkg/autoenv/features/golang_test.go
@@ -1,0 +1,66 @@
+package features
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devbuddy/devbuddy/pkg/config"
+	"github.com/devbuddy/devbuddy/pkg/context"
+	environ "github.com/devbuddy/devbuddy/pkg/env"
+	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGolangActivate_AddsGoInstallBinFromGOBIN(t *testing.T) {
+	ctx := goFeatureTestContext(t, []string{"PATH=/usr/bin", "GOBIN=/opt/go-tools/bin"})
+
+	again, err := golang{}.Activate(ctx, "1.23.6")
+
+	require.NoError(t, err)
+	require.False(t, again)
+	require.Equal(t, filepath.Join(goFeaturePath(t, ctx, "1.23.6"), "bin")+":/opt/go-tools/bin:/usr/bin", ctx.Env.Get("PATH"))
+}
+
+func TestGolangActivate_AddsGoInstallBinsFromGOPATH(t *testing.T) {
+	ctx := goFeatureTestContext(t, []string{"PATH=/usr/bin", "GOPATH=/opt/go:/workspace/go"})
+
+	again, err := golang{}.Activate(ctx, "1.23.6")
+
+	require.NoError(t, err)
+	require.False(t, again)
+	require.Equal(t, filepath.Join(goFeaturePath(t, ctx, "1.23.6"), "bin")+":/workspace/go/bin:/opt/go/bin:/usr/bin", ctx.Env.Get("PATH"))
+}
+
+func TestGolangActivate_AddsDefaultGoInstallBin(t *testing.T) {
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+	ctx := goFeatureTestContext(t, []string{"PATH=/usr/bin"})
+
+	again, err := golang{}.Activate(ctx, "1.23.6")
+
+	require.NoError(t, err)
+	require.False(t, again)
+	require.Equal(t, filepath.Join(goFeaturePath(t, ctx, "1.23.6"), "bin")+":"+filepath.Join(home, "go", "bin")+":/usr/bin", ctx.Env.Get("PATH"))
+}
+
+func goFeatureTestContext(t *testing.T, envVars []string) *context.Context {
+	t.Helper()
+
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	cfg, err := config.Load()
+	require.NoError(t, err)
+	ctx := &context.Context{
+		Cfg: cfg,
+		Env: environ.New(envVars),
+	}
+	goPath := goFeaturePath(t, ctx, "1.23.6")
+	require.NoError(t, os.MkdirAll(filepath.Join(goPath, "bin"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(goPath, "bin", "go"), []byte(""), 0o755))
+	return ctx
+}
+
+func goFeaturePath(t *testing.T, ctx *context.Context, version string) string {
+	t.Helper()
+	return helpers.NewGolang(ctx, version).Path()
+}


### PR DESCRIPTION
## Summary

- Add Go command install directories to Go feature activation PATH.
- Prefer `GOBIN` when it is configured, otherwise add every explicit `GOPATH/bin` entry.
- Fall back to Go's default `$HOME/go/bin` when neither `GOBIN` nor `GOPATH` is configured.

## Notes

Go installs command binaries into `GOBIN` when set; otherwise it uses `GOPATH/bin`, with modern Go defaulting GOPATH to `$HOME/go`. This keeps project commands working for both explicit older GOPATH setups and newer default-GOPATH setups when the user's shell PATH does not already include those directories.

## Validation

- `go test ./pkg/autoenv/features`
- `script/test`

Closes #202

