### PR TITLE
Use stdlib venv for Python environments

### DIFF
--- a/pkg/tasks/python.go
+++ b/pkg/tasks/python.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devbuddy/devbuddy/pkg/executor"
 	"github.com/devbuddy/devbuddy/pkg/helpers"
 	"github.com/devbuddy/devbuddy/pkg/tasks/api"
-	"github.com/devbuddy/devbuddy/pkg/utils"
 )
 
 const pythonTaskName = "python"
@@ -27,7 +26,6 @@ func parserPython(config *api.TaskConfig, task *api.Task) error {
 
 	parserPythonInstallPyenv(task, version)
 	parserPythonInstallPythonVersion(task, version)
-	parserPythonInstallVirtualenv(task, version)
 	parserPythonCreateVirtualenv(task, version)
 	return nil
 }
@@ -78,32 +76,6 @@ func parserPythonInstallPythonVersion(task *api.Task, version string) {
 	task.AddActionBuilder("install Python version with PyEnv", run).On(api.FuncCondition(needed))
 }
 
-func parserPythonInstallVirtualenv(task *api.Task, version string) {
-	needed := func(ctx *context.Context) *api.ActionResult {
-		pyEnv, err := helpers.NewPyEnv(ctx)
-		if err != nil {
-			return api.Failed("cannot use pyenv: %s", err)
-		}
-		installed := utils.PathExists(pyEnv.Which(version, "virtualenv"))
-		if !installed {
-			return api.Needed("virtualenv is not installed")
-		}
-		return api.NotNeeded()
-	}
-	run := func(ctx *context.Context) error {
-		pyEnv, err := helpers.NewPyEnv(ctx)
-		if err != nil {
-			return err
-		}
-		result := ctx.RunTaskCommand(executor.New(pyEnv.Which(version, "python"), "-m", "pip", "install", "virtualenv"))
-		if result.Error != nil {
-			return fmt.Errorf("failed to install virtualenv: %w", result.Error)
-		}
-		return nil
-	}
-	task.AddActionBuilder("install virtualenv", run).On(api.FuncCondition(needed))
-}
-
 func parserPythonCreateVirtualenv(task *api.Task, version string) {
 	needed := func(ctx *context.Context) *api.ActionResult {
 		name := helpers.VirtualenvName(ctx.Project, version)
@@ -124,7 +96,8 @@ func parserPythonCreateVirtualenv(task *api.Task, version string) {
 		if err != nil {
 			return err
 		}
-		result := ctx.RunTaskCommand(executor.New(pyEnv.Which(version, "virtualenv"), venv.Path()))
+		pythonCmd := pyEnv.Which(version, "python")
+		result := ctx.RunTaskCommand(executor.New(pythonCmd, "-m", "venv", venv.Path()))
 		if result.Error != nil {
 			return fmt.Errorf("failed to create the virtualenv: %w", result.Error)
 		}

--- a/pkg/tasks/python_test.go
+++ b/pkg/tasks/python_test.go
@@ -9,9 +9,12 @@ import (
 func TestPythonOk(t *testing.T) {
 	task := ensureLoadTestTask(t, `python: 3.6.3`)
 
-	require.Equal(t, "Task Python (3.6.3) feature=python:3.6.3 actions=4", task.Describe())
+	require.Equal(t, "Task Python (3.6.3) feature=python:3.6.3 actions=3", task.Describe())
 	require.Equal(t, "3.6.3", task.Info)
-	require.Equal(t, 4, len(task.Actions))
+	require.Equal(t, 3, len(task.Actions))
+	require.Equal(t, "install PyEnv", task.Actions[0].Description())
+	require.Equal(t, "install Python version with PyEnv", task.Actions[1].Description())
+	require.Equal(t, "create virtualenv", task.Actions[2].Description())
 	requireFeature(t, task, "python", "3.6.3")
 }
 


### PR DESCRIPTION
## Summary

Switch the Python task from installing and invoking the third-party `virtualenv` package to using the standard-library `venv` module from the selected pyenv Python.

## Why

Modern Python includes `venv`, so DevBuddy no longer needs an extra setup step just to create the project environment. This keeps the existing pyenv-managed interpreter and DevBuddy activation behavior, while reducing setup time and one dependency surface.

## Validation

- `go test ./pkg/tasks -run TestPythonOk -count=1`
- `go test ./pkg/tasks ./pkg/helpers ./pkg/autoenv -count=1`
- `script/test`
- `script/lint`
