### PR TITLE
Add uv sync task

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -145,6 +145,37 @@ up:
   - pipfile
 ```
 
+### `uv`
+
+This task installs `uv` in the selected Python virtualenv if needed, then runs
+`uv sync --active --inexact` so `uv` syncs the project into the DevBuddy-managed
+virtualenv instead of creating a separate `.venv`.
+
+A Python environment must be selected first. The project must have a
+`pyproject.toml`; `uv.lock` is tracked when present.
+
+```yaml
+up:
+  - python: 3.13.7
+  - uv
+```
+
+Dependency groups, extras, and lockfile-only installs can be requested:
+
+```yaml
+up:
+  - python: 3.13.7
+  - uv:
+      groups:
+        - dev
+      extras:
+        - postgres
+      frozen: true
+```
+
+Set `exact: true` to omit `--inexact` and let `uv sync` remove packages that are
+not declared by the project.
+
 ### `go`
 
 This task will download the Go distribution from `dl.google.com/go` and activate it

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ up:
   - python: 3.12.0
   - pip:
     - requirements.txt
+  # For pyproject.toml / uv.lock projects, use:
+  # - uv
   - homebrew:
     - curl
   - custom:

--- a/pkg/manifest/templates/default.yml
+++ b/pkg/manifest/templates/default.yml
@@ -26,6 +26,8 @@ up:
   #   - requirements.txt
   #   - tests/requirements.txt
   # - python_develop
+  # For pyproject.toml / uv.lock projects:
+  # - uv
 
   # Custom task:
   # - custom:

--- a/pkg/manifest/templates/python.yml
+++ b/pkg/manifest/templates/python.yml
@@ -19,6 +19,8 @@ up:
     - requirements.txt
     - tests/requirements.txt
   - python_develop
+  # For pyproject.toml / uv.lock projects, replace pip/python_develop with:
+  # - uv
 
   # - custom:
   #     name: Create the local tmp directory

--- a/pkg/tasks/uv.go
+++ b/pkg/tasks/uv.go
@@ -1,0 +1,148 @@
+package tasks
+
+import (
+	"fmt"
+
+	"github.com/devbuddy/devbuddy/pkg/context"
+	"github.com/devbuddy/devbuddy/pkg/executor"
+	"github.com/devbuddy/devbuddy/pkg/helpers"
+	"github.com/devbuddy/devbuddy/pkg/tasks/api"
+	"github.com/devbuddy/devbuddy/pkg/utils"
+)
+
+func init() {
+	api.Register("uv", "uv", parserUV).SetRequiredTask(pythonTaskName)
+}
+
+type uvConfig struct {
+	Groups    []string
+	Extras    []string
+	AllGroups bool
+	AllExtras bool
+	Exact     bool
+	Frozen    bool
+}
+
+func parserUV(config *api.TaskConfig, task *api.Task) error {
+	uvCfg, err := parseUVConfig(config)
+	if err != nil {
+		return err
+	}
+
+	task.Info = "sync"
+	parserUVInstall(task)
+	parserUVSync(task, uvCfg)
+	return nil
+}
+
+func parseUVConfig(config *api.TaskConfig) (uvConfig, error) {
+	groups, err := config.GetListOfStringsPropertyDefault("groups", []string{})
+	if err != nil {
+		return uvConfig{}, err
+	}
+	extras, err := config.GetListOfStringsPropertyDefault("extras", []string{})
+	if err != nil {
+		return uvConfig{}, err
+	}
+
+	allGroups, err := getOptionalBool(config, "all_groups")
+	if err != nil {
+		return uvConfig{}, err
+	}
+	allExtras, err := getOptionalBool(config, "all_extras")
+	if err != nil {
+		return uvConfig{}, err
+	}
+	exact, err := getOptionalBool(config, "exact")
+	if err != nil {
+		return uvConfig{}, err
+	}
+	frozen, err := getOptionalBool(config, "frozen")
+	if err != nil {
+		return uvConfig{}, err
+	}
+
+	return uvConfig{
+		Groups:    groups,
+		Extras:    extras,
+		AllGroups: allGroups,
+		AllExtras: allExtras,
+		Exact:     exact,
+		Frozen:    frozen,
+	}, nil
+}
+
+func getOptionalBool(config *api.TaskConfig, name string) (bool, error) {
+	value, _, err := config.GetBooleanProperty(name)
+	return value, err
+}
+
+func parserUVInstall(task *api.Task) {
+	needed := func(ctx *context.Context) *api.ActionResult {
+		version, err := findAutoEnvFeatureParam(ctx, pythonTaskName)
+		if err != nil {
+			return api.Failed("missing python feature: %s", err)
+		}
+		venv := helpers.NewVirtualenv(ctx.Cfg, helpers.VirtualenvName(ctx.Project, version))
+		if !utils.PathExists(venv.Which("uv")) {
+			return api.Needed("uv is not installed in the virtualenv")
+		}
+		return api.NotNeeded()
+	}
+	run := func(ctx *context.Context) error {
+		pipArgs := []string{"install", "--require-virtualenv", "uv"}
+		ctx.UI.TaskCommand("pip", pipArgs...)
+		result := ctx.Executor.Run(executor.New("pip", pipArgs...))
+		if result.Error != nil {
+			return fmt.Errorf("failed to install uv: %w", result.Error)
+		}
+		return nil
+	}
+	task.AddActionBuilder("install uv", run).On(api.FuncCondition(needed))
+}
+
+func parserUVSync(task *api.Task, uvCfg uvConfig) {
+	args := buildUVSyncArgs(uvCfg)
+	run := func(ctx *context.Context) error {
+		ctx.UI.TaskCommand("uv", args...)
+		result := ctx.Executor.Run(executor.New("uv", args...))
+		if result.Error != nil {
+			return fmt.Errorf("uv sync failed: %w", result.Error)
+		}
+		return nil
+	}
+	task.AddActionBuilder("sync uv project", run).
+		On(api.FuncCondition(uvProjectExists)).
+		On(api.FileCondition("pyproject.toml")).
+		On(api.FileCondition("uv.lock"))
+}
+
+func uvProjectExists(ctx *context.Context) *api.ActionResult {
+	if fileExists(ctx, "pyproject.toml") {
+		return api.NotNeeded()
+	}
+	return api.Failed("uv task requires pyproject.toml")
+}
+
+func buildUVSyncArgs(config uvConfig) []string {
+	args := []string{"sync", "--active"}
+	if !config.Exact {
+		args = append(args, "--inexact")
+	}
+	for _, group := range config.Groups {
+		args = append(args, "--group", group)
+	}
+	for _, extra := range config.Extras {
+		args = append(args, "--extra", extra)
+	}
+	if config.AllGroups {
+		args = append(args, "--all-groups")
+	}
+	if config.AllExtras {
+		args = append(args, "--all-extras")
+	}
+	if config.Frozen {
+		args = append(args, "--frozen")
+	}
+	return args
+}

--- a/pkg/tasks/uv_test.go
+++ b/pkg/tasks/uv_test.go
@@ -1,0 +1,46 @@
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUV(t *testing.T) {
+	task := ensureLoadTestTask(t, `uv`)
+
+	require.Equal(t, "Task uv (sync) required_task=python actions=2", task.Describe())
+	require.Equal(t, "sync", task.Info)
+	require.Equal(t, "python", task.RequiredTask)
+	require.Equal(t, 2, len(task.Actions))
+	require.Equal(t, "install uv", task.Actions[0].Description())
+	require.Equal(t, "sync uv project", task.Actions[1].Description())
+}
+
+func TestUVSyncArgsDefaultToActiveInexactEnvironment(t *testing.T) {
+	args := buildUVSyncArgs(uvConfig{})
+
+	require.Equal(t, []string{"sync", "--active", "--inexact"}, args)
+}
+
+func TestUVSyncArgs(t *testing.T) {
+	args := buildUVSyncArgs(uvConfig{
+		Groups:    []string{"dev", "docs"},
+		Extras:    []string{"postgres"},
+		AllGroups: true,
+		AllExtras: true,
+		Exact:     true,
+		Frozen:    true,
+	})
+
+	require.Equal(t, []string{
+		"sync",
+		"--active",
+		"--group", "dev",
+		"--group", "docs",
+		"--extra", "postgres",
+		"--all-groups",
+		"--all-extras",
+		"--frozen",
+	}, args)
+}


### PR DESCRIPTION
## Summary

Add a first-class `uv` task for Python projects that use `pyproject.toml` and `uv.lock`.

The task:
- requires the existing DevBuddy `python` task
- installs `uv` into the selected DevBuddy virtualenv when needed
- runs `uv sync --active --inexact` by default so the project syncs into the activated DevBuddy environment
- supports dependency groups, extras, all-groups/all-extras, `frozen`, and explicit `exact` syncs
- documents the task and adds template hints for modern Python projects

## Why

Current Python project tooling has moved toward `pyproject.toml`, lockfiles, dependency groups, and `uv` workflows. This adds support for that path without removing the existing `pip`, `pipfile`, or editable-install tasks.

## Validation

- `go test ./pkg/tasks -run 'TestUV' -count=1`
- `go test ./pkg/tasks ./pkg/manifest -count=1`
- `script/test`
- `script/lint`

## Stack

Stacked on #583.
